### PR TITLE
Cope with \r\n line endings produced by Function.prototype.toString

### DIFF
--- a/test/lines.js
+++ b/test/lines.js
@@ -81,8 +81,10 @@ function testEachPosHelper(lines, code) {
 }
 
 exports.testEachPos = function(t) {
-    var code = arguments.callee + "",
-        lines = fromString(code);
+    // Function.prototype.toString uses \r\n line endings on non-*NIX
+    // systems, so normalize those to \n characters.
+    var code = (arguments.callee + "").replace(/\r\n/g, "\n");
+    var lines = fromString(code);
 
     testEachPosHelper(lines, code);
 
@@ -99,8 +101,10 @@ exports.testEachPos = function(t) {
 };
 
 exports.testCharAt = function(t) {
-    var code = arguments.callee + "",
-        lines = fromString(code);
+    // Function.prototype.toString uses \r\n line endings on non-*NIX
+    // systems, so normalize those to \n characters.
+    var code = (arguments.callee + "").replace(/\r\n/g, "\n");
+    var lines = fromString(code);
 
     function compare(pos) {
         assert.strictEqual(


### PR DESCRIPTION
This should fix some tests on non-*NIX systems (#56). It would still be worthwhile to make line endings generated by the Printer configurable, but that's a more ambitious undertaking.

@RReverser do those tests pass for you with this commit?

Closes #56.
