### PR TITLE
fix printing of TryStatement

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -686,9 +686,10 @@ function genericPrintNoParens(path, options, print) {
             print(path.get("block"))
         ];
 
-        n.handlers.forEach(function(handler) {
-            parts.push(" ", print(handler));
-        });
+        parts.push(print(path.get("handler")))
+        // n.handlers.forEach(function(handler) {
+        //     parts.push(" ", print(handler));
+        // });
 
         if (n.finalizer)
             parts.push(" finally ", print(path.get("finalizer")));


### PR DESCRIPTION
I'm opening this PR to show what I had to do to fix this, but I'm not recommending it be merged. I don't know how to handle the `handlers` array, but this makes it work with a single handler.

With the previous code, I get this error:

```
assert.js:92
  throw new assert.AssertionError({
        ^
AssertionError: false == true
    at printWithComments (/Users/james/projects/regenerator/node_modules/recast/lib/prin
ter.js:65:14)                                                                          
    at /Users/james/projects/regenerator/node_modules/recast/lib/printer.js:681:29
    at Array.forEach (native)
    at genericPrintNoParens (/Users/james/projects/regenerator/node_modules/recast/lib/p
rinter.js:679:20)                                                                      
```

with this AST:

```
    b.tryStatement(
      b.blockStatement(machine.ast),
      b.catchClause(b.identifier('e'), null, b.blockStatement([
        b.expressionStatement(
          b.assignmentExpression(
            '=',
            b.memberExpression(b.identifier('$ctx'), b.identifier('errored'), false),
            b.literal(true)
          )
        )
      ]))
    )
```
