### PR TITLE
Add a test to ensure that "a = (1, 2)" is parsed and printed correctly.

### DIFF
--- a/test/parens.js
+++ b/test/parens.js
@@ -86,6 +86,7 @@ exports.testSequence = function(t) {
     check("[a, (b, c), d]");
     check("({ a: (1, 2) }).a");
     check("(a, b) ? (a = 1, b = 2) : (c = 3)");
+    check("a = (1, 2)");
 
     t.finish();
 };


### PR DESCRIPTION
Due to a bug in ast-types, this expression is re-printed as `a = 1, 2`.

https://github.com/benjamn/ast-types/pull/32
