### PR TITLE
Add a failing test to illustrate a problem with semicolon insertion.

### DIFF
--- a/test/printer.js
+++ b/test/printer.js
@@ -50,6 +50,22 @@ exports.testEmptyStatements = function(t, assert) {
     t.finish();
 };
 
+var importantSemicolons = [
+    "var a = {};", // <--- this trailing semi-colon is very important
+    "(function() {})();"
+].join("\n");
+
+exports.testIffeAfterVariableDeclarationEndingInObjectLiteral = function(t, assert) {
+    var ast = parse(importantSemicolons);
+    var printer = new Printer({ tabWidth: 2 });
+
+    var reprinted = printer.printGenerically(ast).code;
+    assert.strictEqual(typeof reprinted, "string");
+    assert.strictEqual(reprinted, importantSemicolons);
+
+    t.finish();
+};
+
 var switchCase = [
     "switch (test) {",
     "  default:",


### PR DESCRIPTION
Currently recast is not inserting a semicolon at the end of lines ending in `}`, which usually happens because of a function/class declaration or a block statement. However, it can also happen when the last declarator of a variable declaration is an object expression. In this case it is very important that there be a semicolon as the next line may begin with a parenthesis. Without the semicolon the JS engine will interpret `{}(` as a function call with the object expression as the callee, resulting in a runtime exception.

This PR does not fix the problem, but provides a failing test. If you don't have time to fix it but have time to give me a hint I can try to do it myself.
