### PR TITLE
Ensure printing try/catch generically works correctly.

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -695,7 +695,7 @@ function genericPrintNoParens(path, options, print) {
             print(path.get("block"))
         ];
 
-        n.handlers.forEach(function(handler) {
+        path.get("handlers").each(function(handler) {
             parts.push(" ", print(handler));
         });
 

--- a/test/printer.js
+++ b/test/printer.js
@@ -140,10 +140,8 @@ describe("printer", function() {
         var tryStmt = body[0];
         n.TryStatement.assert(tryStmt);
 
-        // Force reprinting of the catch.
-        tryStmt.handlers[0].guard = null;
-
-        assert.strictEqual(printer.print(ast).code, tryCatch);
+        // Force reprinting.
+        assert.strictEqual(printer.printGenerically(ast).code, tryCatch);
     });
 
     var classBody = [


### PR DESCRIPTION
Previously the `print` function was being called with `handler`, which was just a Node and not a NodePath, therefore the assertion in `print` was failing. This was only triggered when printing generically or printing a generated TryStatement.
