### PR TITLE
updated to es6 esprima, and added a failing test for method shorthand

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -7,7 +7,7 @@ var defaults = {
     sourceMapName: null,
     sourceRoot: null,
     inputSourceMap: null,
-    esprima: require("esprima"),
+    esprima: require("esprima-fb"),
     range: false,
     tolerant: true
 }, hasOwn = defaults.hasOwnProperty;

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
   },
   "main": "main.js",
   "scripts": {
-    "test": "node ./node_modules/mocha/bin/mocha --reporter spec"
+    "test": "node ./node_modules/mocha/bin/mocha --reporter spec",
+    "debug": "node ./node_modules/mocha/bin/mocha --debug-brk --reporter spec"
   },
   "dependencies": {
-    "esprima": "~1.1.1",
+    "esprima-fb": "^3001.1.0-dev-harmony-fb",
     "source-map": "0.1.32",
     "private": "~0.1.3",
     "cls": "~0.1.3",

--- a/test/es6tests.js
+++ b/test/es6tests.js
@@ -1,0 +1,50 @@
+var assert = require("assert");
+var parse = require("../lib/parser").parse;
+var Printer = require("../lib/printer").Printer;
+var n = require("../lib/types").namedTypes;
+var b = require("../lib/types").builders;
+
+describe("ES6 Compatability", function() {
+    it(
+        "correctly converts from a shorthand method to ES5 function",
+        function convertShorthandMethod() {
+            var printer = new Printer({ tabWidth: 2 });
+            var code = [
+                "var name='test-name';",
+                "var shorthandObj = {",
+                "  name,",
+                "  func() { return 'value'; }",
+                "};"
+            ].join("\n");
+            var ast = parse(code);
+            n.VariableDeclaration.assert(ast.program.body[1]);
+            var shorthandObjDec = ast.program.body[1].declarations[0].init;
+            var methodDecProperty = shorthandObjDec.properties[1];
+            var newES5MethodProperty = b.property(
+                methodDecProperty.kind,
+                methodDecProperty.key,
+                methodDecProperty.value,
+                false,
+                false
+            );
+            var correctMethodProperty = b.property(
+                methodDecProperty.kind,
+                methodDecProperty.key,
+                b.functionExpression(
+                    methodDecProperty.value.id,
+                    methodDecProperty.value.params,
+                    methodDecProperty.value.body,
+                    methodDecProperty.value.generator,
+                    methodDecProperty.value.expression
+                ),
+                false,
+                false
+            );
+            debugger;
+            assert.strictEqual(
+                printer.print(newES5MethodProperty).code,
+                printer.print(correctMethodProperty).code
+            );
+        }
+    );
+});

--- a/test/parens.js
+++ b/test/parens.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var esprima = require("esprima");
+var esprima = require("esprima-fb");
 var parse = require("../lib/parser").parse;
 var Printer = require("../lib/printer").Printer;
 var NodePath = require("ast-types").NodePath;


### PR DESCRIPTION
This change replaces the esprima npm module in-use with the fb equivalent one with support for harmony syntax. In addition to that, I've added a test that's currently failing because recast is having an issue converting a shorthand method decleration into a valid ES5 method declaration property.
