### PR TITLE
Add a failing test showing a regression in printing statement sequences.

### DIFF
--- a/test/printer.js
+++ b/test/printer.js
@@ -406,6 +406,19 @@ describe("printer", function() {
         );
     });
 
+    it("generically prints parsed code and generated code the same way", function() {
+        var printer = new Printer();
+        var ast = b.program([
+            b.expressionStatement(b.literal(1)),
+            b.expressionStatement(b.literal(2))
+        ]);
+
+        assert.strictEqual(
+            printer.printGenerically(parse("1; 2;")).code,
+            printer.printGenerically(ast).code
+        );
+    });
+
     it("ExportDeclaration semicolons", function() {
         var printer = new Printer();
         var code = "export var foo = 42;";


### PR DESCRIPTION
This regression was introduced by 554c01dc2c448e5a2b3b330c13a04356ad198321 which was intended to fix #39. My guess is that the new implementation is trying to use the original location of a node when it is not appropriate. Recast should be passing a flag or implementation function that will cause the printer to ignore original locations when printing generically.
