### PR TITLE
Force reprint on `null`ing the original

### DIFF
--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -123,6 +123,12 @@ function findReprints(newPath, reprints) {
 }
 
 function findAnyReprints(newPath, oldPath, reprints) {
+    // If `original` node was reset to `null`, reprint
+    // the node entirely.
+    if (newPath.node.original === null) {
+        return false;
+    }
+
     var newNode = newPath.value;
     var oldNode = oldPath.value;
 

--- a/test/printer.js
+++ b/test/printer.js
@@ -64,6 +64,89 @@ describe("printer", function() {
         assert.strictEqual(reprinted, importantSemicolons);
     });
 
+    var arrayExprWithTrailingComma = '[1, 2,];';
+    var arrayExprWithoutTrailingComma = '[1, 2];';
+
+    it("ArrayExpressionWithTrailingComma", function() {
+        var ast = parse(arrayExprWithTrailingComma);
+        var printer = new Printer({ tabWidth: 2 });
+
+        var body = ast.program.body;
+        var arrayExpr = body[0].expression;
+        n.ArrayExpression.assert(arrayExpr);
+
+        // This causes the array expression to be reprinted.
+        var arrayExprOrig = arrayExpr.original;
+        arrayExpr.original = null;
+
+        assert.strictEqual(
+            printer.print(ast).code,
+            arrayExprWithoutTrailingComma
+        );
+
+        arrayExpr.original = arrayExprOrig;
+
+        assert.strictEqual(
+            printer.print(ast).code,
+            arrayExprWithTrailingComma
+        );
+    });
+
+    var arrayExprWithHoles = '[,,];';
+
+    it("ArrayExpressionWithHoles", function() {
+        var ast = parse(arrayExprWithHoles);
+        var printer = new Printer({ tabWidth: 2 });
+
+        var body = ast.program.body;
+        var arrayExpr = body[0].expression;
+        n.ArrayExpression.assert(arrayExpr);
+
+        // This causes the array expression to be reprinted.
+        var arrayExprOrig = arrayExpr.original;
+        arrayExpr.original = null;
+
+        assert.strictEqual(
+            printer.print(ast).code,
+            arrayExprWithHoles
+        );
+
+        arrayExpr.original = arrayExprOrig;
+
+        assert.strictEqual(
+            printer.print(ast).code,
+            arrayExprWithHoles
+        );
+    });
+
+    var objectExprWithTrailingComma = '({x: 1, y: 2,});';
+    var objectExprWithoutTrailingComma = '({\n  x: 1,\n  y: 2\n});';
+
+    it("ArrayExpressionWithTrailingComma", function() {
+        var ast = parse(objectExprWithTrailingComma);
+        var printer = new Printer({ tabWidth: 2 });
+
+        var body = ast.program.body;
+        var objectExpr = body[0].expression;
+        n.ObjectExpression.assert(objectExpr);
+
+        // This causes the array expression to be reprinted.
+        var objectExprOrig = objectExpr.original;
+        objectExpr.original = null;
+
+        assert.strictEqual(
+            printer.print(ast).code,
+            objectExprWithoutTrailingComma
+        );
+
+        objectExpr.original = objectExprOrig;
+
+        assert.strictEqual(
+            printer.print(ast).code,
+            objectExprWithTrailingComma
+        );
+    });
+
     var switchCase = [
         "switch (test) {",
         "  default:",


### PR DESCRIPTION
This one adds the ability to force a reprint of a node, when the `original` is set to `null`.

One of such use cases is a trailing comma in objects and array initializers. The information about it is not written on AST (rather, it belongs to CST), so we need just to rewrite the node and the trailing comma will gone.

```
[1, 2,]; -> [1, 2];
({x, y,}); -> ({x, y});
```
