### PR TITLE
Do not expand shorthand properties.

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -476,11 +476,15 @@ function genericPrintNoParens(path, options, print) {
             );
         }
 
-        return concat([
-            print(path.get("key")),
-            ": ",
-            print(path.get("value"))
-        ]);
+        if (path.node.shorthand) {
+            return print(path.get("key"));
+        } else {
+            return concat([
+                print(path.get("key")),
+                ": ",
+                print(path.get("value"))
+            ]);
+        }
 
     case "ArrayExpression":
     case "ArrayPattern":

--- a/test/es6tests.js
+++ b/test/es6tests.js
@@ -46,4 +46,15 @@ describe("ES6 Compatability", function() {
             );
         }
     );
+
+  it(
+      "respects destructuring assignments",
+      function respectDestructuringAssignment() {
+          var printer = new Printer({ tabWidth: 2 });
+          var code = 'var {a} = {};';
+          var ast = parse(code);
+          n.VariableDeclaration.assert(ast.program.body[0]);
+          assert.strictEqual(printer.print(ast).code, code);
+      }
+  );
 });


### PR DESCRIPTION
`ObjectPattern` is used not only in object expressions but with destructuring assignment. Expanding them in this case is not appropriate, as it will end up with `var {a: a} = {};`
