### PR TITLE
Better logging for tab encountered error.

### DIFF
--- a/lib/comments.js
+++ b/lib/comments.js
@@ -184,7 +184,10 @@ PTp.visit = function(node) {
     }
 };
 
-function printLeadingComment(comment) {
+/**
+ * @param {Object} options - Options object that configures printing.
+ */
+function printLeadingComment(comment, options) {
     var orig = comment.original;
     var loc = orig && orig.loc;
     var lines = loc && loc.lines;
@@ -221,10 +224,13 @@ function printLeadingComment(comment) {
         parts.push("\n");
     }
 
-    return concat(parts).stripMargin(loc ? loc.start.column : 0);
+    return concat(parts, options).stripMargin(loc ? loc.start.column : 0);
 }
 
-function printTrailingComment(comment) {
+/**
+ * @param {Object} options - Options object that configures printing.
+ */
+function printTrailingComment(comment, options) {
     var orig = comment.original;
     var loc = orig && orig.loc;
     var lines = loc && loc.lines;
@@ -251,13 +257,16 @@ function printTrailingComment(comment) {
         parts.push("//", comment.value, "\n");
     } else assert.fail(comment.type);
 
-    return concat(parts).stripMargin(
+    return concat(parts, options).stripMargin(
         loc ? loc.start.column : 0,
         true // Skip the first line, in case there were leading spaces.
     );
 }
 
-exports.printComments = function(comments, innerLines) {
+/**
+ * @param {Object} options - Options object that configures printing.
+ */
+exports.printComments = function(comments, innerLines, options) {
     if (innerLines) {
         assert.ok(innerLines instanceof Lines);
     } else {
@@ -284,14 +293,14 @@ exports.printComments = function(comments, innerLines) {
     });
 
     leading.forEach(function(comment) {
-        parts.push(printLeadingComment(comment));
+        parts.push(printLeadingComment(comment, options));
     });
 
     parts.push(innerLines);
 
     trailing.forEach(function(comment) {
-        parts.push(printTrailingComment(comment));
+        parts.push(printTrailingComment(comment, options));
     });
 
-    return concat(parts);
+    return concat(parts, options);
 };

--- a/lib/lines.js
+++ b/lib/lines.js
@@ -115,6 +115,9 @@ exports.countSpaces = countSpaces;
 
 var leadingSpaceExp = /^\s*/;
 
+/**
+ * @param {Object} options - Options object that configures printing.
+ */
 function fromString(string, options) {
     if (string instanceof Lines)
         return string;
@@ -566,14 +569,17 @@ Lp.eachPos = function(callback, startPos, skipSpaces) {
     while (this.nextPos(pos, skipSpaces));
 };
 
-Lp.bootstrapSlice = function(start, end) {
+/**
+ * @param {Object} options - Options object that configures printing.
+ */
+Lp.bootstrapSlice = function(start, end, options) {
     var strings = this.toString().split("\n").slice(
             start.line - 1, end.line);
 
     strings.push(strings.pop().slice(0, end.column));
     strings[0] = strings[0].slice(start.column);
 
-    return fromString(strings.join("\n"));
+    return fromString(strings.join("\n"), options);
 };
 
 Lp.slice = function(start, end) {
@@ -743,7 +749,10 @@ Lp.isEmpty = function() {
     return this.length < 2 && this.getLineLength(1) < 1;
 };
 
-Lp.join = function(elements) {
+/**
+ * @param {Object} options - Options object that configures printing.
+ */
+Lp.join = function(elements, options) {
     var separator = this;
     var separatorSecret = getSecret(separator);
     var infos = [];
@@ -792,7 +801,7 @@ Lp.join = function(elements) {
     }
 
     elements.map(function(elem) {
-        var lines = fromString(elem);
+        var lines = fromString(elem, options);
         if (lines.isEmpty())
             return null;
         return getSecret(lines);
@@ -810,8 +819,11 @@ Lp.join = function(elements) {
     return lines;
 };
 
-exports.concat = function(elements) {
-    return emptyLines.join(elements);
+/**
+ * @param {Object} options - Options object that configures printing.
+ */
+exports.concat = function(elements, options) {
+    return emptyLines.join(elements, options);
 };
 
 Lp.concat = function(other) {

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -58,7 +58,7 @@ function Printer(originalOptions) {
 
     function printWithComments(path) {
         assert.ok(path instanceof NodePath);
-        return printComments(path.node.comments, print(path));
+        return printComments(path.node.comments, print(path), options);
     }
 
     function print(path, includeComments) {


### PR DESCRIPTION
I came across this error while transforming some of our comments. This tweaks the error to print the string that is causing the error, so you can more quickly identify it.

I would like to provide an even better error message explaining why and how the user should configure the printer with `tabWidth` but I wasn't sure why this comment node was being processed.

``` javascript
/***********
 *          CALLBACKS.
 **********/
```

Above is the actual comment, can you explain why I need to configure `tabWidth` now when I haven't had to before? Is it as simple as tabs in comments cause problems?

Due to `wrapColumn` I have had to configure the printer.

``` javascript
print(fileMetadata.ast, {wrapColumn: 200}).code
```

I guess the configuration triggers processing every node?
