### PR TITLE
improving source map composition

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -35,10 +35,7 @@ exports.composeSourceMaps = function(formerMap, latterMap) {
 
     var smcFormer = new SourceMapConsumer(formerMap);
     var smcLatter = new SourceMapConsumer(latterMap);
-    var smg = new SourceMapGenerator({
-        file: latterMap.file,
-        sourceRoot: latterMap.sourceRoot
-    });
+    var smg = SourceMapGenerator.fromSourceMap(smcFormer);
 
     var sourcesToContents = {};
 
@@ -49,6 +46,9 @@ exports.composeSourceMaps = function(formerMap, latterMap) {
         });
 
         var sourceName = origPos.source;
+        if (sourceName === null) {
+            return;
+        }
 
         smg.addMapping({
             source: sourceName,


### PR DESCRIPTION
- relies on `SourceMapGenerator.fromSourceMap` instead of creating a brand new generator (more info here: https://github.com/mozilla/source-map#sourcemapgeneratorfromsourcemapsourcemapconsumer).
- skips weird maps without source (learned from uglify-js)

note: this PR is suppose to fix the composition when using es6-module-transpiler + esnext + uglify in the broccoli infrastructure that we are working on.

note2: `fromSourceMap` helps with the path to the source files in the map. the current implementation in recast relies on creating a new map based on the path to the source, as a result, the path to files in the inspector is not preserved, and the temporary path is used for the final map, while `fromSourceMap` preserve those too.

/cc @eventualbuddha 
