### PR TITLE
Add tests and implementation for a "quotemark" printer option

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -49,7 +49,12 @@ var defaults = {
 
     // If you want esprima not to throw exceptions when it encounters
     // non-fatal errors, keep this option true.
-    tolerant: true
+    tolerant: true,
+    
+    // If you want to override the quotemarks used in string literals, specify
+    // either "single" or "double" here
+    // Otherwise, the input marks will be preserved
+    quotemark: null,
 }, hasOwn = defaults.hasOwnProperty;
 
 // Copy options and fill in default values.
@@ -73,6 +78,7 @@ exports.normalize = function(options) {
         inputSourceMap: get("inputSourceMap"),
         esprima: get("esprima"),
         range: get("range"),
-        tolerant: get("tolerant")
+        tolerant: get("tolerant"),
+        quotemark: get("quotemark"),
     };
 };

--- a/lib/options.js
+++ b/lib/options.js
@@ -51,10 +51,11 @@ var defaults = {
     // non-fatal errors, keep this option true.
     tolerant: true,
     
-    // If you want to override the quotemarks used in string literals, specify
-    // either "single" or "double" here
+    // If you want to override the quotes used in string literals, specify
+    // either "single", "double", or "auto" here ("auto" will select the one 
+    // which results in the shorter literal)
     // Otherwise, the input marks will be preserved
-    quotemark: null,
+    quote: null,
 }, hasOwn = defaults.hasOwnProperty;
 
 // Copy options and fill in default values.
@@ -79,6 +80,6 @@ exports.normalize = function(options) {
         esprima: get("esprima"),
         range: get("range"),
         tolerant: get("tolerant"),
-        quotemark: get("quotemark"),
+        quote: get("quote"),
     };
 };

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -126,13 +126,6 @@ function findReprints(newPath, reprints, options) {
 function findAnyReprints(newPath, oldPath, reprints, options) {
     var newNode = newPath.value;
     var oldNode = oldPath.value;
-        
-    if (options && options.quotemark &&
-          newPath.parentPath && 
-          newPath.parentPath.value &&
-          newPath.parentPath.value.type === "Literal" && 
-          isString.check(newPath.parentPath.value.value))
-        return false; //mark literal for reprint
             
     if (newNode === oldNode)
         return true;

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -65,7 +65,7 @@ function Patcher(lines) {
 }
 exports.Patcher = Patcher;
 
-exports.getReprinter = function(path) {
+exports.getReprinter = function(path, options) {
     assert.ok(path instanceof NodePath);
 
     // Make sure that this path refers specifically to a Node, rather than
@@ -79,7 +79,7 @@ exports.getReprinter = function(path) {
     var lines = origLoc && origLoc.lines;
     var reprints = [];
 
-    if (!lines || !findReprints(path, reprints))
+    if (!lines || !findReprints(path, reprints, options))
         return;
 
     return function(print) {
@@ -98,7 +98,7 @@ exports.getReprinter = function(path) {
     };
 };
 
-function findReprints(newPath, reprints) {
+function findReprints(newPath, reprints, options) {
     var newNode = newPath.value;
     Node.assert(newNode);
 
@@ -112,7 +112,7 @@ function findReprints(newPath, reprints) {
     }
 
     var oldPath = new NodePath(oldNode);
-    var canReprint = findChildReprints(newPath, oldPath, reprints);
+    var canReprint = findChildReprints(newPath, oldPath, reprints, options);
 
     if (!canReprint) {
         // Make absolutely sure the calling code does not attempt to reprint
@@ -123,23 +123,30 @@ function findReprints(newPath, reprints) {
     return canReprint;
 }
 
-function findAnyReprints(newPath, oldPath, reprints) {
+function findAnyReprints(newPath, oldPath, reprints, options) {
     var newNode = newPath.value;
     var oldNode = oldPath.value;
-
+        
+    if (options && options.quotemark &&
+          newPath.parentPath && 
+          newPath.parentPath.value &&
+          newPath.parentPath.value.type === "Literal" && 
+          isString.check(newPath.parentPath.value.value))
+        return false; //mark literal for reprint
+            
     if (newNode === oldNode)
         return true;
 
     if (isArray.check(newNode))
-        return findArrayReprints(newPath, oldPath, reprints);
+        return findArrayReprints(newPath, oldPath, reprints, options);
 
     if (isObject.check(newNode))
-        return findObjectReprints(newPath, oldPath, reprints);
+        return findObjectReprints(newPath, oldPath, reprints, options);
 
     return false;
 }
 
-function findArrayReprints(newPath, oldPath, reprints) {
+function findArrayReprints(newPath, oldPath, reprints, options) {
     var newNode = newPath.value;
     var oldNode = oldPath.value;
     isArray.assert(newNode);
@@ -150,13 +157,13 @@ function findArrayReprints(newPath, oldPath, reprints) {
         return false;
 
     for (var i = 0; i < len; ++i)
-        if (!findAnyReprints(newPath.get(i), oldPath.get(i), reprints))
+        if (!findAnyReprints(newPath.get(i), oldPath.get(i), reprints, options))
             return false;
 
     return true;
 }
 
-function findObjectReprints(newPath, oldPath, reprints) {
+function findObjectReprints(newPath, oldPath, reprints, options) {
     var newNode = newPath.value;
     isObject.assert(newNode);
 
@@ -186,7 +193,7 @@ function findObjectReprints(newPath, oldPath, reprints) {
         if (newNode.type === oldNode.type) {
             var childReprints = [];
 
-            if (findChildReprints(newPath, oldPath, childReprints)) {
+            if (findChildReprints(newPath, oldPath, childReprints, options)) {
                 reprints.push.apply(reprints, childReprints);
             } else {
                 reprints.push({
@@ -218,7 +225,7 @@ function findObjectReprints(newPath, oldPath, reprints) {
         return false;
     }
 
-    return findChildReprints(newPath, oldPath, reprints);
+    return findChildReprints(newPath, oldPath, reprints, options);
 }
 
 // This object is reused in hasOpeningParen and hasClosingParen to avoid
@@ -300,7 +307,7 @@ function hasParens(oldPath) {
     return hasOpeningParen(oldPath) && hasClosingParen(oldPath);
 }
 
-function findChildReprints(newPath, oldPath, reprints) {
+function findChildReprints(newPath, oldPath, reprints, options) {
     var newNode = newPath.value;
     var oldNode = oldPath.value;
 
@@ -340,7 +347,7 @@ function findChildReprints(newPath, oldPath, reprints) {
         if (k === "loc")
             continue;
 
-        if (!findAnyReprints(newPath.get(k), oldPath.get(k), reprints))
+        if (!findAnyReprints(newPath.get(k), oldPath.get(k), reprints, options))
             return false;
     }
 

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -65,7 +65,7 @@ function Patcher(lines) {
 }
 exports.Patcher = Patcher;
 
-exports.getReprinter = function(path, options) {
+exports.getReprinter = function(path) {
     assert.ok(path instanceof NodePath);
 
     // Make sure that this path refers specifically to a Node, rather than
@@ -79,7 +79,7 @@ exports.getReprinter = function(path, options) {
     var lines = origLoc && origLoc.lines;
     var reprints = [];
 
-    if (!lines || !findReprints(path, reprints, options))
+    if (!lines || !findReprints(path, reprints))
         return;
 
     return function(print) {
@@ -98,7 +98,7 @@ exports.getReprinter = function(path, options) {
     };
 };
 
-function findReprints(newPath, reprints, options) {
+function findReprints(newPath, reprints) {
     var newNode = newPath.value;
     Node.assert(newNode);
 
@@ -112,7 +112,7 @@ function findReprints(newPath, reprints, options) {
     }
 
     var oldPath = new NodePath(oldNode);
-    var canReprint = findChildReprints(newPath, oldPath, reprints, options);
+    var canReprint = findChildReprints(newPath, oldPath, reprints);
 
     if (!canReprint) {
         // Make absolutely sure the calling code does not attempt to reprint
@@ -123,23 +123,23 @@ function findReprints(newPath, reprints, options) {
     return canReprint;
 }
 
-function findAnyReprints(newPath, oldPath, reprints, options) {
+function findAnyReprints(newPath, oldPath, reprints) {
     var newNode = newPath.value;
     var oldNode = oldPath.value;
-            
+
     if (newNode === oldNode)
         return true;
 
     if (isArray.check(newNode))
-        return findArrayReprints(newPath, oldPath, reprints, options);
+        return findArrayReprints(newPath, oldPath, reprints);
 
     if (isObject.check(newNode))
-        return findObjectReprints(newPath, oldPath, reprints, options);
+        return findObjectReprints(newPath, oldPath, reprints);
 
     return false;
 }
 
-function findArrayReprints(newPath, oldPath, reprints, options) {
+function findArrayReprints(newPath, oldPath, reprints) {
     var newNode = newPath.value;
     var oldNode = oldPath.value;
     isArray.assert(newNode);
@@ -150,13 +150,13 @@ function findArrayReprints(newPath, oldPath, reprints, options) {
         return false;
 
     for (var i = 0; i < len; ++i)
-        if (!findAnyReprints(newPath.get(i), oldPath.get(i), reprints, options))
+        if (!findAnyReprints(newPath.get(i), oldPath.get(i), reprints))
             return false;
 
     return true;
 }
 
-function findObjectReprints(newPath, oldPath, reprints, options) {
+function findObjectReprints(newPath, oldPath, reprints) {
     var newNode = newPath.value;
     isObject.assert(newNode);
 
@@ -186,7 +186,7 @@ function findObjectReprints(newPath, oldPath, reprints, options) {
         if (newNode.type === oldNode.type) {
             var childReprints = [];
 
-            if (findChildReprints(newPath, oldPath, childReprints, options)) {
+            if (findChildReprints(newPath, oldPath, childReprints)) {
                 reprints.push.apply(reprints, childReprints);
             } else {
                 reprints.push({
@@ -218,7 +218,7 @@ function findObjectReprints(newPath, oldPath, reprints, options) {
         return false;
     }
 
-    return findChildReprints(newPath, oldPath, reprints, options);
+    return findChildReprints(newPath, oldPath, reprints);
 }
 
 // This object is reused in hasOpeningParen and hasClosingParen to avoid
@@ -300,7 +300,7 @@ function hasParens(oldPath) {
     return hasOpeningParen(oldPath) && hasClosingParen(oldPath);
 }
 
-function findChildReprints(newPath, oldPath, reprints, options) {
+function findChildReprints(newPath, oldPath, reprints) {
     var newNode = newPath.value;
     var oldNode = oldPath.value;
 
@@ -340,7 +340,7 @@ function findChildReprints(newPath, oldPath, reprints, options) {
         if (k === "loc")
             continue;
 
-        if (!findAnyReprints(newPath.get(k), oldPath.get(k), reprints, options))
+        if (!findAnyReprints(newPath.get(k), oldPath.get(k), reprints))
             return false;
     }
 

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -82,7 +82,7 @@ function Printer(originalOptions) {
     }
 
     function maybeReprint(path) {
-        var reprinter = getReprinter(path, options);
+        var reprinter = getReprinter(path);
         if (reprinter)
             return maybeAddParens(path, reprinter(maybeReprint));
         return printRootGenerically(path);

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -82,7 +82,7 @@ function Printer(originalOptions) {
     }
 
     function maybeReprint(path) {
-        var reprinter = getReprinter(path);
+        var reprinter = getReprinter(path, options);
         if (reprinter)
             return maybeAddParens(path, reprinter(maybeReprint));
         return printRootGenerically(path);
@@ -543,7 +543,7 @@ function genericPrintNoParens(path, options, print) {
 
     case "ModuleSpecifier":
         // A ModuleSpecifier is a string-valued Literal.
-        return fromString(nodeStr(n), options);
+        return fromString(nodeStr(n, options), options);
 
     case "UnaryExpression":
         var parts = [n.operator];
@@ -1283,10 +1283,22 @@ function endsWithBrace(lines) {
     return lastNonSpaceCharacter(lines) === "}";
 }
 
-function nodeStr(n) {
+function swapQuotes(str) {
+    return str.replace(/['"]/g, function(m) {
+        return m === '"' ? '\'' : '"';
+    });
+}
+
+function nodeStr(n, options) {
     namedTypes.Literal.assert(n);
     isString.assert(n.value);
-    return JSON.stringify(n.value);
+    switch (options.quotemark) {
+        case "single":
+            return swapQuotes(JSON.stringify(swapQuotes(n.value)));
+        case "double":
+        default:
+            return JSON.stringify(n.value);
+    }
 }
 
 function maybeAddSemicolon(lines) {

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1293,15 +1293,15 @@ function nodeStr(n, options) {
     namedTypes.Literal.assert(n);
     isString.assert(n.value);
     switch (options.quote) {
-        case "auto":
-            var double = JSON.stringify(n.value);
-            var single = swapQuotes(JSON.stringify(swapQuotes(n.value)));
-            return double.length > single.length ? single : double;
-        case "single":
-            return swapQuotes(JSON.stringify(swapQuotes(n.value)));
-        case "double":
-        default:
-            return JSON.stringify(n.value);
+    case "auto":
+        var double = JSON.stringify(n.value);
+        var single = swapQuotes(JSON.stringify(swapQuotes(n.value)));
+        return double.length > single.length ? single : double;
+    case "single":
+        return swapQuotes(JSON.stringify(swapQuotes(n.value)));
+    case "double":
+    default:
+        return JSON.stringify(n.value);
     }
 }
 

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1292,7 +1292,11 @@ function swapQuotes(str) {
 function nodeStr(n, options) {
     namedTypes.Literal.assert(n);
     isString.assert(n.value);
-    switch (options.quotemark) {
+    switch (options.quote) {
+        case "auto":
+            var double = JSON.stringify(n.value);
+            var single = swapQuotes(JSON.stringify(swapQuotes(n.value)));
+            return double.length > single.length ? single : double;
         case "single":
             return swapQuotes(JSON.stringify(swapQuotes(n.value)));
         case "double":

--- a/test/printer.js
+++ b/test/printer.js
@@ -622,4 +622,35 @@ describe("printer", function() {
             "}"
         ].join("\n"));
     });
+    
+    it("should print string literals with the specified delimiter", function() {
+        var ast = parse([
+            "var obj = {",
+            "    \"foo's\": 'bar',",
+            "    //This is pretty messy",
+            "    '\"bar\\'s\"': /regex/m",
+            "}"
+        ].join("\n"));
+
+        var variableDeclaration = ast.program.body[0];
+        n.VariableDeclaration.assert(variableDeclaration);
+
+        var printer = new Printer({ quotemark: "single" });
+        assert.strictEqual(printer.print(ast).code, [
+            "var obj = {",
+            "    'foo\\'s': 'bar',",
+            "    //This is pretty messy",
+            "    '\"bar\\'s\"': /regex/m",
+            "}"
+        ].join("\n"));
+
+        var printer2 = new Printer({ quotemark: "double" });
+        assert.strictEqual(printer2.print(ast).code, [
+            "var obj = {",
+            "    \"foo's\": \"bar\",",
+            "    //This is pretty messy",
+            '    "\\"bar\'s\\"": /regex/m',
+            "}"
+        ].join("\n"));
+    });
 });

--- a/test/printer.js
+++ b/test/printer.js
@@ -634,7 +634,7 @@ describe("printer", function() {
         var variableDeclaration = ast.program.body[0];
         n.VariableDeclaration.assert(variableDeclaration);
 
-        var printer = new Printer({ quotemark: "single" });
+        var printer = new Printer({ quote: "single" });
         assert.strictEqual(printer.printGenerically(ast).code, [
             "var obj = {",
             "    'foo\\'s': 'bar',",
@@ -642,12 +642,20 @@ describe("printer", function() {
             "};"
         ].join("\n"));
 
-        var printer2 = new Printer({ quotemark: "double" });
+        var printer2 = new Printer({ quote: "double" });
         assert.strictEqual(printer2.printGenerically(ast).code, [
             "var obj = {",
             "    \"foo's\": \"bar\",",
             '    "\\"bar\'s\\"": /regex/m',
             "};"
         ].join("\n"));
+        
+        var printer3 = new Printer({ quote: "auto" });
+        assert.strictEqual(printer3.printGenerically(ast).code, [
+            "var obj = {",
+            '    "foo\'s": "bar",',
+            '    \'"bar\\\'s"\': /regex/m',
+            "};"
+        ].join("\n"));        
     });
 });

--- a/test/printer.js
+++ b/test/printer.js
@@ -627,30 +627,27 @@ describe("printer", function() {
         var ast = parse([
             "var obj = {",
             "    \"foo's\": 'bar',",
-            "    //This is pretty messy",
             "    '\"bar\\'s\"': /regex/m",
-            "}"
+            "};"
         ].join("\n"));
 
         var variableDeclaration = ast.program.body[0];
         n.VariableDeclaration.assert(variableDeclaration);
 
         var printer = new Printer({ quotemark: "single" });
-        assert.strictEqual(printer.print(ast).code, [
+        assert.strictEqual(printer.printGenerically(ast).code, [
             "var obj = {",
             "    'foo\\'s': 'bar',",
-            "    //This is pretty messy",
             "    '\"bar\\'s\"': /regex/m",
-            "}"
+            "};"
         ].join("\n"));
 
         var printer2 = new Printer({ quotemark: "double" });
-        assert.strictEqual(printer2.print(ast).code, [
+        assert.strictEqual(printer2.printGenerically(ast).code, [
             "var obj = {",
             "    \"foo's\": \"bar\",",
-            "    //This is pretty messy",
             '    "\\"bar\'s\\"": /regex/m',
-            "}"
+            "};"
         ].join("\n"));
     });
 });


### PR DESCRIPTION
@sebmarkbage on the React repo mentioned needing Recast to support a feature like this for them to support configurable quotemarks when compiling JSX transformations in the future. ([mentioned originally on pull request 1709](https://github.com/facebook/react/pull/1709))