### PR TITLE
Update to esprima-fb@9001.1.0-dev-harmony-fb

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "debug": "node ./node_modules/mocha/bin/mocha --debug-brk --reporter spec"
   },
   "dependencies": {
-    "esprima-fb": "~8001.2001.0-dev-harmony-fb",
+    "esprima-fb": "~9001.1.0-dev-harmony-fb",
     "source-map": "~0.1.40",
     "private": "~0.1.5",
     "ast-types": "~0.6.1"


### PR DESCRIPTION
This unblocks some projects mentioned here: https://github.com/facebook/esprima/issues/78

Please publish a new version of recast to npm with this change. Thanks!