### PR TITLE
fix arrow function print logic to better account for rest params

### DIFF
--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -313,6 +313,9 @@ FPp.needsParens = function(assumeExpressionContext) {
             return false;
         }
 
+    case "ArrowFunctionExpression":
+        return isBinary(parent);
+
     default:
         if (parent.type === "NewExpression" &&
             name === "callee" &&

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -247,7 +247,7 @@ function genericPrintNoParens(path, options, print) {
         if (n.async)
             parts.push("async ");
 
-        if (n.params.length === 1) {
+        if (n.params.length === 1 && !n.rest) {
             parts.push(path.call(print, "params", 0));
         } else {
             parts.push(

--- a/test/printer.js
+++ b/test/printer.js
@@ -487,6 +487,22 @@ describe("printer", function() {
             printer.print(funExpr).code,
             "function a(b, c=1, ...d) {}"
         );
+
+        var arrowFunExpr = b.arrowFunctionExpression(
+            [b.identifier('b'), b.identifier('c')],
+            b.blockStatement([]),
+            false,
+            false,
+            false,
+            undefined);
+
+        arrowFunExpr.defaults = [undefined, b.literal(1)];
+        arrowFunExpr.rest = b.identifier('d');
+
+        assert.strictEqual(
+            printer.print(arrowFunExpr).code,
+            "(b, c=1, ...d) => {}"
+        );
     });
 
     it("generically prints parsed code and generated code the same way", function() {


### PR DESCRIPTION
If an arrow function has one normal parameter and one rest parameter, recast will leave out the rest param when printing the arrow function. I've fixed the logic in printer.js and modified an existing unit test to exercise this code path.

**Note** this fix depends on this fix in ast-types: https://github.com/benjamn/ast-types/commit/39ac68d61b1a6c211245c87141c335ee7a2923a9
(apologies if there is a better way to express this dependency, or if I should be waiting to issue this pull request until the corresponding fix in ast-types is integrated)