### PR TITLE
Allow ExpressionStatement and BlockStatement to not add semicolons with the pretty printer

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -56,6 +56,11 @@ var defaults = {
     // which results in the shorter literal)
     // Otherwise, the input marks will be preserved
     quote: null,
+
+    // If you want the pretty-printer to not add semi-colons to certain types
+    // (it can only currently ignore semicolons for ExpressionStatement and
+    // BlockStatement).
+    noSemicolon: []
 }, hasOwn = defaults.hasOwnProperty;
 
 // Copy options and fill in default values.
@@ -81,5 +86,6 @@ exports.normalize = function(options) {
         range: get("range"),
         tolerant: get("tolerant"),
         quote: get("quote"),
+        noSemicolon: get("noSemicolon"),
     };
 };

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -168,13 +168,13 @@ function genericPrintNoParens(path, options, print) {
     case "Program":
         return maybeAddSemicolon(path.call(function(bodyPath) {
             return printStatementSequence(bodyPath, options, print);
-        }, "body"));
+        }, "body"), n.type, options);
 
     case "EmptyStatement":
         return fromString("");
 
     case "ExpressionStatement":
-        return concat([path.call(print, "expression"), ";"]);
+        return concat([path.call(print, "expression"), optionalSemicolon(n.type, options)]);
 
     case "BinaryExpression":
     case "LogicalExpression":
@@ -408,7 +408,7 @@ function genericPrintNoParens(path, options, print) {
 
     case "BlockStatement":
         var naked = path.call(function(bodyPath) {
-            return printStatementSequence(bodyPath, options, print);
+            return printStatementSequence(bodyPath, options, print, n.type);
         }, "body");
 
         if (naked.isEmpty()) {
@@ -1044,7 +1044,7 @@ function genericPrintNoParens(path, options, print) {
     return p;
 }
 
-function printStatementSequence(path, options, print) {
+function printStatementSequence(path, options, print, type) {
     var inClassBody =
         namedTypes.ClassBody &&
         namedTypes.ClassBody.check(path.getParentNode());
@@ -1104,7 +1104,7 @@ function printStatementSequence(path, options, print) {
         if (needSemicolon) {
             // Try to add a semicolon to anything that isn't a method in a
             // class body.
-            printed = maybeAddSemicolon(printed);
+            printed = maybeAddSemicolon(printed, type, options);
         }
 
         var trueLoc = options.reuseWhitespace && util.getTrueLoc(stmt);
@@ -1299,9 +1299,20 @@ function nodeStr(n, options) {
     }
 }
 
-function maybeAddSemicolon(lines) {
+function maybeAddSemicolon(lines, type, options) {
     var eoc = lastNonSpaceCharacter(lines);
     if (!eoc || "\n};".indexOf(eoc) < 0)
-        return concat([lines, ";"]);
+        return concat([lines, optionalSemicolon(type, options)]);
     return lines;
+}
+
+function optionalSemicolon(type, options) {
+    if (typeof type !== 'undefined') {
+        if (options.noSemicolon.indexOf(type) === -1) {
+            return ';'
+        }
+        return '';
+    }
+
+    return ';';
 }


### PR DESCRIPTION
I've only implemented this for ExpressionStatement and BlockStatement so far, but it'd be nice to have trailing semicolon addition as optional.
