### PR TITLE
handle parentheses around object literals in arrow functions correctly

### DIFF
--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -316,6 +316,12 @@ FPp.needsParens = function(assumeExpressionContext) {
     case "ArrowFunctionExpression":
         return isBinary(parent);
 
+    case "ObjectExpression":
+        if (parent.type === "ArrowFunctionExpression" &&
+            name === "body") {
+            return true;
+        }
+
     default:
         if (parent.type === "NewExpression" &&
             name === "callee" &&

--- a/test/parens.js
+++ b/test/parens.js
@@ -116,6 +116,9 @@ describe("parens", function() {
         check("(function(){}).apply(this, arguments)");
         check("function f() { (function(){}).call(this) }");
         check("while (true) { (function(){}).call(this) }");
+        check("() => ({a:1,b:2})");
+        check("(x, y={z:1}) => x + y.z");
+        check("a || ((x, y={z:1}) => x + y.z)");
     });
 
     it("ObjectLiteral", function() {


### PR DESCRIPTION
In es6 arrow functions like this `(x, y) => x + y` the return statement is implicit. However, if the thing you're returning is an object literal, you need to surround it with parentheses (since curly braces are otherwise used to denote a function body).

Recast should add parentheses correctly in this situation.

Note: I wasn't sure where to add a unit test for this, but would be happy to do so if pointed in the right direction.