### PR TITLE
Add ability to print Flow/TypeScript type annotations.

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -208,7 +208,10 @@ function genericPrintNoParens(path, options, print) {
         return fromString(".").join(n.body);
 
     case "Identifier":
-        return fromString(n.name, options);
+        return concat([
+            fromString(n.name, options),
+            path.call(print, "typeAnnotation")
+        ]);
 
     case "SpreadElement":
     case "SpreadElementPattern":
@@ -229,13 +232,20 @@ function genericPrintNoParens(path, options, print) {
         if (n.generator)
             parts.push("*");
 
-        if (n.id)
-            parts.push(" ", path.call(print, "id"));
+        if (n.id) {
+            parts.push(
+                " ",
+                path.call(print, "id"),
+                path.call(print, "typeParameters")
+            );
+        }
 
         parts.push(
             "(",
             printFunctionParams(path, options, print),
-            ") ",
+            ")",
+            path.call(print, "returnType"),
+            " ",
             path.call(print, "body")
         );
 
@@ -453,32 +463,53 @@ function genericPrintNoParens(path, options, print) {
 
     case "ObjectExpression":
     case "ObjectPattern":
+    case "ObjectTypeAnnotation":
         var allowBreak = false,
-            len = n.properties.length,
-            parts = [len > 0 ? "{\n" : "{"];
+            isTypeAnnotation = (n.type == "ObjectTypeAnnotation"),
+            separator = isTypeAnnotation ? ';' : ',';
 
-        path.map(function(childPath) {
-            var i = childPath.getName();
-            var prop = childPath.getValue();
-            var lines = print(childPath).indent(options.tabWidth);
+        var fields = ["properties"];
+        if (isTypeAnnotation) {
+            fields.unshift("indexers", "callProperties");
+        }
 
-            var multiLine = lines.length > 1;
-            if (multiLine && allowBreak) {
-                // Similar to the logic for BlockStatement.
-                parts.push("\n");
-            }
+        var len = fields.reduce(function(acc, field) {
+            return acc + n[field].length;
+        }, 0);
 
-            parts.push(lines);
+        var oneLine = ((isTypeAnnotation && len == 1) || len == 0);
+        var parts = [oneLine ? "{" : "{\n"];
 
-            if (i < len - 1) {
-                // Add an extra line break if the previous object property
-                // had a multi-line value.
-                parts.push(multiLine ? ",\n\n" : ",\n");
-                allowBreak = !multiLine;
-            }
-        }, "properties");
+        fields.forEach(function(field) {
+            path.map(function(childPath) {
+                var i = childPath.getName();
+                var prop = childPath.getValue();
+                var lines = print(childPath)
 
-        parts.push(len > 0 ? "\n}" : "}");
+                if (!oneLine) {
+                    lines = lines.indent(options.tabWidth);
+                }
+
+                var multiLine = !isTypeAnnotation && lines.length > 1;
+                if (multiLine && allowBreak) {
+                    // Similar to the logic for BlockStatement.
+                    parts.push("\n");
+                }
+
+                parts.push(lines);
+
+                if (i < len - 1) {
+                    // Add an extra line break if the previous object property
+                    // had a multi-line value.
+                    parts.push(separator + (multiLine ? "\n\n" : "\n"));
+                    allowBreak = !multiLine;
+                } else if (len != 1 && isTypeAnnotation) {
+                    parts.push(separator);
+                }
+            }, field);
+        });
+
+        parts.push(oneLine ? "}" : "\n}");
 
         return concat(parts);
 
@@ -923,17 +954,38 @@ function genericPrintNoParens(path, options, print) {
         return concat(parts);
 
     case "ClassProperty":
-        return concat([path.call(print, "id"), ";"]);
+        return concat([
+            path.call(print, "key"),
+            path.call(print, "typeAnnotation"),
+            ";"
+        ]);
 
     case "ClassDeclaration":
     case "ClassExpression":
         var parts = ["class"];
 
-        if (n.id)
-            parts.push(" ", path.call(print, "id"));
+        if (n.id) {
+            parts.push(
+                " ",
+                path.call(print, "id"),
+                path.call(print, "typeParameters")
+            );
+        }
 
-        if (n.superClass)
-            parts.push(" extends ", path.call(print, "superClass"));
+        if (n.superClass) {
+            parts.push(
+                " extends ",
+                path.call(print, "superClass"),
+                path.call(print, "superTypeParameters")
+            );
+        }
+
+        if (n["implements"]) {
+            parts.push(" implements ");
+            parts.push(
+                fromString(", ", options).join(path.map(print, "implements"))
+            );
+        }
 
         parts.push(" ", path.call(print, "body"));
 
@@ -953,6 +1005,9 @@ function genericPrintNoParens(path, options, print) {
     case "Specifier":
     case "NamedSpecifier":
     case "Comment": // Supertype of Block and Line.
+    case "MemberTypeAnnotation": // Flow
+    case "TupleTypeAnnotation": // Flow
+    case "Type": // Flow
         throw new Error("unprintable type: " + JSON.stringify(n.type));
 
     case "Block": // Block comment.
@@ -961,10 +1016,227 @@ function genericPrintNoParens(path, options, print) {
     case "Line": // Line comment.
         return concat(["//", fromString(n.value, options)]);
 
+    // Type Annotations for Facebook Flow, typically stripped out or
+    // transformed away before printing.
+    case "TypeAnnotation":
+        return concat([
+            n.typeAnnotation.type != "FunctionTypeAnnotation" ? ": " : "",
+            path.call(print, "typeAnnotation")
+        ]);
+
+    case "AnyTypeAnnotation":
+        return fromString("any", options);
+
+    case "ArrayTypeAnnotation":
+        return concat([
+            path.call(print, "elementType"),
+            "[]"
+        ]);
+
+    case "BooleanTypeAnnotation":
+        return fromString("boolean", options);
+
+    case "DeclareClass":
+        return concat([
+            fromString("declare class ", options),
+            path.call(print, "id"),
+            " ",
+            path.call(print, "body"),
+        ]);
+
+    case "DeclareFunction":
+        return concat([
+            fromString("declare function ", options),
+            path.call(print, "id")
+        ]);
+
+    case "DeclareModule":
+        return concat([
+            fromString("declare module ", options),
+            path.call(print, "id"),
+            " ",
+            path.call(print, "body"),
+        ]);
+
+    case "DeclareVariable":
+        return concat([
+            fromString("declare var ", options),
+            path.call(print, "id")
+        ]);
+
+    case "FunctionTypeAnnotation":
+        // yay magic. FunctionTypeAnnotation is ambigous:
+        // declare function(a: B): void; OR
+        // var A: (a: B) => void;
+        var parts = [];
+        var len = n.params.length;
+
+        var MAGIC_CONSTANT = path.stack.length - 7;
+        var isArrowFunctionTypeAnnotation = (
+            path.stack[MAGIC_CONSTANT].type != "DeclareFunction" &&
+            path.getParentNode().type != "ObjectTypeCallProperty"
+        );
+        var needsColon = (
+            isArrowFunctionTypeAnnotation &&
+            path.getParentNode().type != "FunctionTypeParam"
+        );
+
+        if (needsColon) {
+            parts.push(": ");
+        }
+
+        parts.push("(");
+        path.each(function(p) {
+            var i = p.getName();
+            parts.push(print(p));
+            if (i < len - 1) {
+                parts.push(", ");
+            }
+        }, "params");
+        parts.push(")");
+        // The returnType is not wrapped in a TypeAnnotation,
+        // the colon needs to be added separately.
+        if (n.returnType) {
+            parts.push(
+                isArrowFunctionTypeAnnotation ? " => " : ": ",
+                path.call(print, "returnType")
+            );
+        }
+        return concat(parts);
+
+    case "FunctionTypeParam":
+        return concat([
+            path.call(print, "name"),
+            ": ",
+            path.call(print, "typeAnnotation"),
+        ]);
+
+    case "GenericTypeAnnotation":
+        return concat([
+            path.call(print, "id"),
+            path.call(print, "typeParameters")
+        ]);
+
+    case "InterfaceDeclaration":
+        var parts = [
+            fromString("interface ", options),
+            path.call(print, "id"),
+            path.call(print, "typeParameters"),
+            " "
+        ];
+
+        if (n.extends) {
+            parts.push("extends ");
+            parts.push(fromString(", ").join(path.map(print, "extends")));
+        }
+
+        parts.push(path.call(print, "body"));
+
+        return concat(parts);
+
+    case "ClassImplements":
+    case "InterfaceExtends":
+        return concat([
+            path.call(print, "id"),
+            path.call(print, "typeParameters")
+        ]);
+
+    case "IntersectionTypeAnnotation":
+        var parts = [];
+        path.each(function(p) {
+            parts.push(print(p));
+        }, "types");
+        return fromString(" & ", options).join(parts);
+
+    case "NullableTypeAnnotation":
+        return concat([
+            "?",
+            path.call(print, "typeAnnotation")
+        ]);
+
+    case "NumberTypeAnnotation":
+        return fromString("number", options);
+
+    case "ObjectTypeCallProperty":
+        return path.call(print, "value");
+
+    case "ObjectTypeIndexer":
+        return concat([
+            "[",
+            path.call(print, "id"),
+            ": ",
+            path.call(print, "key"),
+            "]: ",
+            path.call(print, "value")
+        ]);
+
+    case "ObjectTypeProperty":
+        return fromString(": ", options).join([
+            path.call(print, "key"),
+            path.call(print, "value")
+        ]);
+
+    case "QualifiedTypeIdentifier":
+        return concat([
+            path.call(print, "qualification"),
+            ".",
+            path.call(print, "id")
+        ]);
+
+    case "StringLiteralTypeAnnotation":
+        return fromString(nodeStr(n, options), options);
+
+    case "StringTypeAnnotation":
+        return fromString("string", options);
+
+    case "TypeAlias":
+        return fromString(" = ").join([
+            concat(["type ", path.call(print, "id")]),
+            path.call(print, "right")
+        ]);
+
+    case "TypeCastExpression":
+        return concat([
+            "(",
+            path.call(print, "expression"),
+            path.call(print, "typeAnnotation"),
+            ")"
+        ]);
+
+    case "TypeParameterDeclaration":
+    case "TypeParameterInstantiation":
+        var parts = [],
+            len = n.params.length;
+        parts.push("<");
+        path.each(function(p) {
+            var i = p.getName();
+            parts.push(print(p));
+            if (i < len - 1) {
+                parts.push(", ");
+            }
+        }, "params");
+        parts.push(">");
+        return concat(parts);
+
+    case "TypeofTypeAnnotation":
+        return concat([
+            fromString("typeof ", options),
+            path.call(print, "argument")
+        ]);
+
+    case "UnionTypeAnnotation":
+        var parts = [];
+        path.each(function(p) {
+            parts.push(print(p));
+        }, "types");
+        return fromString(" | ", options).join(parts);
+
+    case "VoidTypeAnnotation":
+        return fromString("void", options);
+
     // Unhandled types below. If encountered, nodes of these types should
     // be either left alone or desugared into AST types that are fully
     // supported by the pretty-printer.
-
     case "ClassHeritage": // TODO
     case "ComprehensionBlock": // TODO
     case "ComprehensionExpression": // TODO
@@ -977,43 +1249,6 @@ function genericPrintNoParens(path, options, print) {
     case "LetExpression": // TODO
     case "GraphExpression": // TODO
     case "GraphIndexExpression": // TODO
-
-    // Type Annotations for Facebook Flow, typically stripped out or
-    // transformed away before printing.
-    case "AnyTypeAnnotation": // TODO
-    case "ArrayTypeAnnotation": // TODO
-    case "BooleanTypeAnnotation": // TODO
-    case "ClassImplements": // TODO
-    case "DeclareClass": // TODO
-    case "DeclareFunction": // TODO
-    case "DeclareModule": // TODO
-    case "DeclareVariable": // TODO
-    case "FunctionTypeAnnotation": // TODO
-    case "FunctionTypeParam": // TODO
-    case "GenericTypeAnnotation": // TODO
-    case "InterfaceDeclaration": // TODO
-    case "InterfaceExtends": // TODO
-    case "IntersectionTypeAnnotation": // TODO
-    case "MemberTypeAnnotation": // TODO
-    case "NullableTypeAnnotation": // TODO
-    case "NumberTypeAnnotation": // TODO
-    case "ObjectTypeAnnotation": // TODO
-    case "ObjectTypeCallProperty": // TODO
-    case "ObjectTypeIndexer": // TODO
-    case "ObjectTypeProperty": // TODO
-    case "QualifiedTypeIdentifier": // TODO
-    case "StringLiteralTypeAnnotation": // TODO
-    case "StringTypeAnnotation": // TODO
-    case "TupleTypeAnnotation": // TODO
-    case "Type": // TODO
-    case "TypeAlias": // TODO
-    case "TypeAnnotation": // TODO
-    case "TypeCastExpression": // TODO
-    case "TypeParameterDeclaration": // TODO
-    case "TypeParameterInstantiation": // TODO
-    case "TypeofTypeAnnotation": // TODO
-    case "UnionTypeAnnotation": // TODO
-    case "VoidTypeAnnotation": // TODO
 
     // XML types that nobody cares about or needs to print.
     case "XMLDefaultDeclaration":
@@ -1200,11 +1435,14 @@ function printMethod(path, options, print) {
 
     parts.push(
         key,
+        path.call(print, "value", "typeParameters"),
         "(",
         path.call(function(valuePath) {
             return printFunctionParams(valuePath, options, print);
         }, "value"),
-        ") ",
+        ")",
+        path.call(print, "value", "returnType"),
+        " ",
         path.call(print, "value", "body")
     );
 

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1065,7 +1065,7 @@ function genericPrintNoParens(path, options, print) {
         ]);
 
     case "FunctionTypeAnnotation":
-        // yay magic. FunctionTypeAnnotation is ambigous:
+        // yay magic. FunctionTypeAnnotation is ambiguous:
         // declare function(a: B): void; OR
         // var A: (a: B) => void;
         var parts = [];
@@ -1184,7 +1184,7 @@ function genericPrintNoParens(path, options, print) {
         ]);
 
     case "StringLiteralTypeAnnotation":
-        return fromString(nodeStr(n, options), options);
+        return fromString(nodeStr(n.value, options), options);
 
     case "StringTypeAnnotation":
         return fromString("string", options);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "debug": "node ./node_modules/mocha/bin/mocha --debug-brk --reporter spec"
   },
   "dependencies": {
-    "esprima-fb": "~13001.1.0-dev-harmony-fb",
+    "esprima-fb": "~13001.1001.0-dev-harmony-fb",
     "source-map": "~0.4.1",
     "private": "~0.1.5",
     "ast-types": "~0.7.0"

--- a/test/type-syntax.js
+++ b/test/type-syntax.js
@@ -1,0 +1,92 @@
+var assert = require("assert");
+var parse = require("../lib/parser").parse;
+var Printer = require("../lib/printer").Printer;
+var types = require("../lib/types");
+var n = types.namedTypes;
+var b = types.builders;
+
+describe("type syntax", function() {
+    var printer = new Printer({ tabWidth: 2 });
+
+    function check(source) {
+        var ast1 = parse(source);
+        var ast2 = parse(printer.printGenerically(ast1).code);
+        types.astNodesAreEquivalent.assert(ast1, ast2);
+    }
+
+    it("should parse and print type annotations correctly", function() {
+        // Import type annotations
+        check("import type foo from 'foo'");
+
+        // Scalar type annotations
+        check("var a: number;");
+        check("var a: number = 5;");
+
+        check("var a: any;");
+        check("var a: boolean;");
+        check("var a: string;");
+        check("var a: \"foo\";");
+        check("var a: void;");
+
+        // Nullable
+        check("var a: ?number;");
+
+        // Unions & Intersections
+        check("var a: number | string | boolean = 26");
+        check("var a: number & string & boolean = 26");
+
+        // Types
+        check("var a: A = 5;");
+        // TODO!?
+        check("var a: typeof A;");
+
+        // Type aliases
+        check("type A = B;");
+        check("type A = B.C;");
+
+        // Generic
+        check("var a: Array<Foo>;");
+        check("var a: number[];");
+
+        // Return types
+        check("function a(): number {}");
+        check("var a: () => X = fn");
+
+        // Object
+        check("var a: {b: number; x: {y: A}};");
+        check("var b: {[key: string]: number};")
+        check("var c: {(): number};")
+        check("var d: {[key: string]: A; [key: number]: B; (): C; a: D};")
+
+        // Casts
+        check("(1 + 1: number)");
+
+        // Declare
+        check("declare var A: string;");
+
+        check("declare function foo(c: C): void;");
+        check("declare function foo(c: C, b: B): void;");
+        check("declare function foo(c: (e: Event) => void, b: B): void;");
+        check("declare class C {x: string}");
+        check("declare module M {declare function foo(c: C): void;}");
+
+        // Classes
+        check("class A { a: number; }");
+        check("class A { foo(a: number): string {} }");
+        check("class A { static foo(a: number): string {} }");
+
+        // Type parameters
+        check("class A<T> {}");
+        check("class A<X, Y> {}");
+        check("class A<X> extends B<Y> {}");
+        check("function a<T>(y: Y<T>): T {}");
+        check("class A { foo<T>(a: number): string {} }");
+
+        // Interfaces
+        check("interface A<X> extends B<A>, C { a: number; }");
+        check("class A extends B implements C<T>, Y {}");
+
+        // Bounded polymorphism
+        check("class A<T: number> {}");
+    });
+});


### PR DESCRIPTION
This adds printing for all flow/typescript syntax. I'll outline a few things in the comments. Note that this breaks 3 tests. It might be related to the `needsParens` code, but I'm unsure what to do to make the printing work. It seems that it prints `(function()() {})` now. @benjamn do you have an idea about this?

cc @jeffmo @gabelevi