### PR TITLE
Add parenthesis to arrow function params when using SpreadElementPattern

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -257,7 +257,11 @@ function genericPrintNoParens(path, options, print) {
         if (n.async)
             parts.push("async ");
 
-        if (n.params.length === 1 && !n.rest) {
+        if (
+            n.params.length === 1 &&
+            !n.rest &&
+            n.params[0].type !== 'SpreadElementPattern'
+        ) {
             parts.push(path.call(print, "params", 0));
         } else {
             parts.push(

--- a/test/printer.js
+++ b/test/printer.js
@@ -638,7 +638,7 @@ describe("printer", function() {
             "}"
         ].join("\n"));
     });
-    
+
     it("should print string literals with the specified delimiter", function() {
         var ast = parse([
             "var obj = {",
@@ -665,14 +665,14 @@ describe("printer", function() {
             '    "\\"bar\'s\\"": /regex/m',
             "};"
         ].join("\n"));
-        
+
         var printer3 = new Printer({ quote: "auto" });
         assert.strictEqual(printer3.printGenerically(ast).code, [
             "var obj = {",
             '    "foo\'s": "bar",',
             '    \'"bar\\\'s"\': /regex/m',
             "};"
-        ].join("\n"));        
+        ].join("\n"));
     });
 
     it("should print block comments at head of class once", function() {
@@ -810,6 +810,39 @@ describe("printer", function() {
         });
 
         var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+    });
+
+    it("should add parenthesis around SpreadElementPattern", function() {
+        var code = "(...rest) => rest;";
+
+        var ast = b.program([
+            b.expressionStatement(b.arrowFunctionExpression(
+                [b.spreadElementPattern(b.identifier('rest'))],
+                b.identifier('rest'),
+                false
+            ))
+        ]);
+
+        var printer = new Printer({
+            tabWidth: 2
+        });
+
+        var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+
+        // Do the same for the `rest` field.
+        var arrowFunction = b.arrowFunctionExpression(
+            [],
+            b.identifier('rest'),
+            false
+        );
+        arrowFunction.rest = b.identifier('rest');
+        ast = b.program([
+            b.expressionStatement(arrowFunction)
+        ]);
+
+        pretty = printer.printGenerically(ast).code;
         assert.strictEqual(pretty, code);
     });
 });


### PR DESCRIPTION
Before: `...rest => rest`
After: `(...rest) => rest`

I circumvented this by doing

```js
b.arrowFunctionExpression(…);
b.rest = j.identifier('rest');
```

but I prefer to use the SpreadElementPattern here because it means I can just append it to the params list:

```js
j.arrowFunctionExpression(
  (fn.params || []).concat(
    j.spreadElementPattern(j.identifier('rest'))
  ),
  fn.body,
  fn.generator
);
```