### PR TITLE
Print trailing commas when the `trailingComma` option is specified.

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -50,12 +50,17 @@ var defaults = {
     // If you want esprima not to throw exceptions when it encounters
     // non-fatal errors, keep this option true.
     tolerant: true,
-    
+
     // If you want to override the quotes used in string literals, specify
-    // either "single", "double", or "auto" here ("auto" will select the one 
+    // either "single", "double", or "auto" here ("auto" will select the one
     // which results in the shorter literal)
     // Otherwise, the input marks will be preserved
     quote: null,
+
+    // If you want to print trailing commas in object literals,
+    // array expressions, functions calls and function definitions pass true
+    // for this option.
+    trailingComma: false,
 }, hasOwn = defaults.hasOwnProperty;
 
 // Copy options and fill in default values.
@@ -81,5 +86,6 @@ exports.normalize = function(options) {
         range: get("range"),
         tolerant: get("tolerant"),
         quote: get("quote"),
+        trailingComma: get("trailingComma"),
     };
 };

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -486,7 +486,6 @@ function genericPrintNoParens(path, options, print) {
         fields.forEach(function(field) {
             path.map(function(childPath) {
                 var i = childPath.getName();
-                var prop = childPath.getValue();
                 var lines = print(childPath);
 
                 if (!oneLine) {
@@ -507,6 +506,8 @@ function genericPrintNoParens(path, options, print) {
                     parts.push(separator + (multiLine ? "\n\n" : "\n"));
                     allowBreak = !multiLine;
                 } else if (len !== 1 && isTypeAnnotation) {
+                    parts.push(separator);
+                } else if (options.trailingComma) {
                     parts.push(separator);
                 }
             }, field);
@@ -542,8 +543,12 @@ function genericPrintNoParens(path, options, print) {
     case "ArrayExpression":
     case "ArrayPattern":
         var elems = n.elements,
-            len = elems.length,
-            parts = ["["];
+            len = elems.length;
+
+        var printed = path.map(print, "elements");
+        var joined = fromString(", ").join(printed);
+        var oneLine = joined.getLineLength(1) <= options.wrapColumn;
+        var parts = [oneLine ? "[" : "[\n"];
 
         path.each(function(elemPath) {
             var i = elemPath.getName();
@@ -556,11 +561,18 @@ function genericPrintNoParens(path, options, print) {
                 // both (all) of the holes.
                 parts.push(",");
             } else {
-                if (i > 0)
-                    parts.push(" ");
-                parts.push(print(elemPath));
-                if (i < len - 1)
+                var lines = printed[i];
+                if (oneLine) {
+                    if (i > 0)
+                        parts.push(" ");
+                } else {
+                    lines = lines.indent(options.tabWidth);
+                }
+                parts.push(lines);
+                if (i < len - 1 || (!oneLine && options.trailingComma))
                     parts.push(",");
+                if (!oneLine)
+                    parts.push("\n");
             }
         }, "elements");
 
@@ -1456,7 +1468,11 @@ function printArgumentsList(path, options, print) {
     var joined = fromString(", ").join(printed);
     if (joined.getLineLength(1) > options.wrapColumn) {
         joined = fromString(",\n").join(printed);
-        return concat(["(\n", joined.indent(options.tabWidth), "\n)"]);
+        return concat([
+            "(\n",
+            joined.indent(options.tabWidth),
+            options.trailingComma ? ",\n)" : "\n)"
+        ]);
     }
 
     return concat(["(", joined, ")"]);
@@ -1486,6 +1502,9 @@ function printFunctionParams(path, options, print) {
     if (joined.length > 1 ||
         joined.getLineLength(1) > options.wrapColumn) {
         joined = fromString(",\n").join(printed);
+        if (options.trailingComma && !fun.rest) {
+            joined = concat([joined, ",\n"]);
+        }
         return concat(["\n", joined.indent(options.tabWidth)]);
     }
 

--- a/test/printer.js
+++ b/test/printer.js
@@ -638,7 +638,7 @@ describe("printer", function() {
             "}"
         ].join("\n"));
     });
-    
+
     it("should print string literals with the specified delimiter", function() {
         var ast = parse([
             "var obj = {",
@@ -665,14 +665,14 @@ describe("printer", function() {
             '    "\\"bar\'s\\"": /regex/m',
             "};"
         ].join("\n"));
-        
+
         var printer3 = new Printer({ quote: "auto" });
         assert.strictEqual(printer3.printGenerically(ast).code, [
             "var obj = {",
             '    "foo\'s": "bar",',
             '    \'"bar\\\'s"\': /regex/m',
             "};"
-        ].join("\n"));        
+        ].join("\n"));
     });
 
     it("should print block comments at head of class once", function() {
@@ -795,6 +795,85 @@ describe("printer", function() {
             "  get [foo]() { return bar }",
             "};"
         ].join("\n"));
+    });
+
+    it("prints trailing commas in object literals", function() {
+        var code = [
+            "({",
+            "  foo: bar,",
+            "  bar: foo,",
+            "});"
+        ].join("\n");
+
+        var ast = parse(code);
+
+        var printer = new Printer({
+            tabWidth: 2,
+            trailingComma: true,
+        });
+
+        var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+    });
+
+    it("prints trailing commas in function calls", function() {
+        var code = [
+            "call(",
+            "  1,",
+            "  2,",
+            ");"
+        ].join("\n");
+
+        var ast = parse(code);
+
+        var printer = new Printer({
+            tabWidth: 2,
+            wrapColumn: 1,
+            trailingComma: true,
+        });
+
+        var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+    });
+
+    it("prints trailing commas in array expressions", function() {
+        var code = [
+            "[",
+            "  1,",
+            "  2,",
+            "];"
+        ].join("\n");
+
+        var ast = parse(code);
+
+        var printer = new Printer({
+            tabWidth: 2,
+            wrapColumn: 1,
+            trailingComma: true,
+        });
+
+        var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+    });
+
+    it("prints trailing commas in function definitions", function() {
+        var code = [
+            "function foo(",
+            "  a,",
+            "  b,",
+            ") {}"
+        ].join("\n");
+
+        var ast = parse(code);
+
+        var printer = new Printer({
+            tabWidth: 2,
+            wrapColumn: 1,
+            trailingComma: true,
+        });
+
+        var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
     });
 
     it("should support AssignmentPattern and RestElement", function() {


### PR DESCRIPTION
This adds support to print trailing commas, which is useful for code bases that adopted this style. They are only added if the corresponding list is split over multiple lines.

I had to add printing logic similar from function arguments to array expressions which, when `wrapColumn` is specified, tries to fit everything within the limit.

Are there any places that I missed where we should add trailing commas?