### PR TITLE
Attempt to guess whether or not to use tabs

### DIFF
--- a/lib/lines.js
+++ b/lib/lines.js
@@ -483,7 +483,7 @@ Lp.guessUseTabs = function() {
 
     var result = tabIndentCount > noTabIndentCount;
 
-    return secret.cachedUseTabs = result
+    return secret.cachedUseTabs = result;
 };
 
 Lp.isOnlyWhitespace = function() {

--- a/lib/lines.js
+++ b/lib/lines.js
@@ -476,7 +476,7 @@ Lp.guessUseTabs = function() {
         // Intentionally not counting mixed spaces/tabs
         if (hasTab && !hasSpace) {
             ++tabIndentCount;
-        } else if (hasSpace && !hasTab) {
+        } else {
             ++noTabIndentCount;
         }
     }

--- a/lib/lines.js
+++ b/lib/lines.js
@@ -426,6 +426,66 @@ Lp.guessTabWidth = function() {
     return secret.cachedTabWidth = result;
 };
 
+Lp.guessUseTabs = function() {
+    var secret = getSecret(this);
+    if (hasOwn.call(secret, "cachedUseTabs")) {
+        return secret.cachedUseTabs;
+    }
+
+    var lastPrefixWhitespace = "";
+    var indentDiffs = [];
+
+    for (var line = 1, last = this.length; line <= last; ++line) {
+        var info = secret.infos[line - 1];
+        var sliced = info.line.slice(info.sliceStart, info.sliceEnd);
+
+        // Whitespace-only lines don't tell us much about the likely tab
+        // use of this code.
+        if (isOnlyWhitespace(sliced)) {
+            continue;
+        }
+
+        var before = info.line.slice(0, info.sliceStart);
+
+        if (before.indexOf(lastPrefixWhitespace) === 0 && before.length) {
+            // Increased or same indent
+            // This line has as much as, or more, whitespace than previous line
+            indentDiffs.push({
+                diff: before.slice(lastPrefixWhitespace.length),
+                deindent: false
+            });
+        } else if (lastPrefixWhitespace.indexOf(before) === 0 && lastPrefixWhitespace.length) {
+            // De-indent
+            indentDiffs.push({
+                diff: lastPrefixWhitespace.slice(before.length),
+                deindent: true
+            });
+        }
+    }
+
+    var tabIndentCount = 0;
+    var noTabIndentCount = 0;
+
+    // Now iterate through indentDiffs and determine frequencies of all-tab
+    // and all-space indents
+    for (var i = 0; i < indentDiffs.length; ++i) {
+        var diff = indentDiffs[i].diff;
+        var hasTab = diff.indexOf('\t') !== -1;
+        var hasSpace = diff.indexOf(' ') !== -1;
+
+        // Intentionally not counting mixed spaces/tabs
+        if (hasTab && !hasSpace) {
+            ++tabIndentCount;
+        } else if (hasSpace && !hasTab) {
+            ++noTabIndentCount;
+        }
+    }
+
+    var result = tabIndentCount > noTabIndentCount;
+
+    return secret.cachedUseTabs = result
+};
+
 Lp.isOnlyWhitespace = function() {
     return isOnlyWhitespace(this.toString());
 };

--- a/lib/lines.js
+++ b/lib/lines.js
@@ -454,12 +454,16 @@ Lp.guessUseTabs = function() {
                 diff: before.slice(lastPrefixWhitespace.length),
                 deindent: false
             });
+
+            lastPrefixWhitespace = before;
         } else if (lastPrefixWhitespace.indexOf(before) === 0 && lastPrefixWhitespace.length) {
             // De-indent
             indentDiffs.push({
                 diff: lastPrefixWhitespace.slice(before.length),
                 deindent: true
             });
+
+            lastPrefixWhitespace = before;
         }
     }
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -10,8 +10,11 @@ var defaults = {
     tabWidth: 4,
 
     // If you really want the pretty-printer to use tabs instead of
-    // spaces, make this option true.
-    useTabs: false,
+    // spaces, make this option true. If you want the pretty-printer to
+    // uses spaces instead of tabs, make this option false. If you want
+    // the parser to guess between tabs and spaces, leave this option
+    // unspecified.
+    useTabs: void 0,
 
     // The reprinting code leaves leading whitespace untouched unless it
     // has to reindent a line, or you pass false for this option.
@@ -70,7 +73,7 @@ exports.normalize = function(options) {
 
     return {
         tabWidth: +get("tabWidth"),
-        useTabs: !!get("useTabs"),
+        useTabs: get("useTabs"),
         reuseWhitespace: !!get("reuseWhitespace"),
         wrapColumn: Math.max(get("wrapColumn"), 0),
         sourceFileName: get("sourceFileName"),

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -48,6 +48,7 @@ function Printer(originalOptions) {
     assert.ok(this instanceof Printer);
 
     var explicitTabWidth = originalOptions && originalOptions.tabWidth;
+    var explicitUseTabs = originalOptions && originalOptions.useTabs != null;
     var options = normalizeOptions(originalOptions);
     assert.notStrictEqual(options, originalOptions);
 
@@ -67,18 +68,29 @@ function Printer(originalOptions) {
 
         assert.ok(path instanceof FastPath);
 
-        if (!explicitTabWidth) {
-            var oldTabWidth = options.tabWidth;
+        var oldTabWidth = options.tabWidth;
+        var oldUseTabs = options.useTabs;
+
+        if (!explicitTabWidth || !explicitUseTabs) {
             var loc = path.getNode().loc;
-            if (loc && loc.lines && loc.lines.guessTabWidth) {
-                options.tabWidth = loc.lines.guessTabWidth();
-                var lines = maybeReprint(path);
-                options.tabWidth = oldTabWidth;
-                return lines;
+            if (loc && loc.lines) {
+                if (!explicitTabWidth && loc.lines.guessTabWidth) {
+                    options.tabWidth = loc.lines.guessTabWidth();
+                }
+
+                if (!explicitUseTabs && loc.lines.guessUseTabs) {
+                    options.useTabs = loc.lines.guessUseTabs();
+                }
             }
         }
 
-        return maybeReprint(path);
+        var lines = maybeReprint(path);
+
+        // Restore old options
+        options.tabWidth = oldTabWidth;
+        options.useTabs = oldUseTabs;
+
+        return lines;
     }
 
     function maybeReprint(path) {

--- a/test/data/fileWithTabs.js
+++ b/test/data/fileWithTabs.js
@@ -1,0 +1,3 @@
+function someFunction(foo, bar) {
+	console.log("file with tabs");
+}

--- a/test/lines.js
+++ b/test/lines.js
@@ -500,6 +500,39 @@ describe("lines", function() {
         });
     });
 
+    it("GuessUseTabs", function(done) {
+        var lines = fromString(arguments.callee + "");
+        assert.strictEqual(lines.guessUseTabs(), false);
+
+        lines = fromString([
+            "function identity(x) {",
+            "\treturn x;",
+            "}"
+        ].join("\n"), { tabWidth: 4 });
+        debugger;
+        assert.strictEqual(lines.guessUseTabs(), true);
+        assert.strictEqual(lines.indent(5).guessUseTabs(), true);
+        assert.strictEqual(lines.indent(-4).guessUseTabs(), true);
+
+        fs.readFile(__filename, "utf-8", function(err, source) {
+            assert.equal(err, null);
+            assert.strictEqual(fromString(source).guessUseTabs(), false);
+
+            fs.readFile(path.join(
+                __dirname,
+                "data",
+                "fileWithTabs.js"
+            ), "utf-8", function(err, source) {
+                assert.equal(err, null);
+
+                var tabOpts = { tabWidth: 4 };
+                assert.strictEqual(fromString(source, tabOpts).guessUseTabs(), true);
+
+                done();
+            });
+        });
+    });
+
     it("ExoticWhitespace", function() {
         var source = "";
         var spacePattern = /^\s+$/;

--- a/test/lines.js
+++ b/test/lines.js
@@ -509,7 +509,6 @@ describe("lines", function() {
             "\treturn x;",
             "}"
         ].join("\n"), { tabWidth: 4 });
-        debugger;
         assert.strictEqual(lines.guessUseTabs(), true);
         assert.strictEqual(lines.indent(5).guessUseTabs(), true);
         assert.strictEqual(lines.indent(-4).guessUseTabs(), true);

--- a/test/printer.js
+++ b/test/printer.js
@@ -468,6 +468,57 @@ describe("printer", function() {
         );
     });
 
+    it("GuessUseTabs", function() {
+        var code = [
+            "function identity(x) {",
+            "\treturn x;",
+            "}"
+        ].join("\n");
+
+        var guessedTabs = [
+            "function identity(x) {",
+            "\tlog(x);",
+            "\treturn x;",
+            "}"
+        ].join("\n");
+
+        var explicitSpaces = [
+            "function identity(x) {",
+            "    log(x);",
+            "    return x;",
+            "}"
+        ].join("\n");
+
+        var ast = parse(code);
+
+        var funDecl = ast.program.body[0];
+        n.FunctionDeclaration.assert(funDecl);
+
+        var funBody = funDecl.body.body;
+
+        funBody.unshift(
+            b.expressionStatement(
+                b.callExpression(
+                    b.identifier("log"),
+                    funDecl.params
+                )
+            )
+        );
+
+        assert.strictEqual(
+            new Printer().print(ast).code,
+            guessedTabs
+        );
+
+        assert.strictEqual(
+            new Printer({
+                tabWidth: 4,
+                useTabs: false
+            }).print(ast).code,
+            explicitSpaces
+        );
+    });
+
     it("FunctionDefaultsAndRest", function() {
         var printer = new Printer();
         var funExpr = b.functionExpression(


### PR DESCRIPTION
Attempting to fix #185. Unfortunately that's not happening just yet. New statements start with no indentation, then get spaces added despite the file having been guessed as `{ useTabs: true }`.

Could use some help debugging this, to be honest. I definitely feel like I'm on the right track, but I'm just missing something in the recursive (and hard to trace) print flow. But if anyone has a better approach, I'm open to suggestions.
