### PR TITLE
Printing support for property initializers.

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1105,11 +1105,19 @@ function genericPrintNoParens(path, options, print) {
         return concat(parts);
 
     case "ClassProperty":
-        return concat([
-            path.call(print, "key"),
-            path.call(print, "typeAnnotation"),
-            ";"
-        ]);
+        var parts = [];
+        if (n.static)
+            parts.push("static ");
+
+        parts.push(path.call(print, "key"));
+        if (n.typeAnnotation)
+            parts.push(path.call(print, "typeAnnotation"));
+
+        if (n.value)
+            parts.push(" = ", path.call(print, "value"));
+
+        parts.push(";");
+        return concat(parts);
 
     case "ClassDeclaration":
     case "ClassExpression":

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -279,7 +279,11 @@ function genericPrintNoParens(path, options, print) {
         if (n.async)
             parts.push("async ");
 
-        if (n.params.length === 1 && !n.rest) {
+        if (
+            n.params.length === 1 &&
+            !n.rest &&
+            n.params[0].type !== 'SpreadElementPattern'
+        ) {
             parts.push(path.call(print, "params", 0));
         } else {
             parts.push(

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "esprima-fb": "~14001.1.0-dev-harmony-fb",
     "source-map": "~0.4.1",
     "private": "~0.1.5",
-    "ast-types": "0.8.2"
+    "ast-types": "0.8.3"
   },
   "devDependencies": {
     "mocha": "~2.2.5"

--- a/test/printer.js
+++ b/test/printer.js
@@ -891,4 +891,37 @@ describe("printer", function() {
         var pretty = printer.printGenerically(ast).code;
         assert.strictEqual(pretty, code);
     });
+
+    it("should add parenthesis around SpreadElementPattern", function() {
+        var code = "(...rest) => rest;";
+
+        var ast = b.program([
+            b.expressionStatement(b.arrowFunctionExpression(
+                [b.spreadElementPattern(b.identifier('rest'))],
+                b.identifier('rest'),
+                false
+            ))
+        ]);
+
+        var printer = new Printer({
+            tabWidth: 2
+        });
+
+        var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+
+        // Do the same for the `rest` field.
+        var arrowFunction = b.arrowFunctionExpression(
+            [],
+            b.identifier('rest'),
+            false
+        );
+        arrowFunction.rest = b.identifier('rest');
+        ast = b.program([
+            b.expressionStatement(arrowFunction)
+        ]);
+
+        pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+    });
 });

--- a/test/printer.js
+++ b/test/printer.js
@@ -924,4 +924,63 @@ describe("printer", function() {
         pretty = printer.printGenerically(ast).code;
         assert.strictEqual(pretty, code);
     });
+
+    it("should print ClassProperty correctly", function() {
+        var code = [
+            "class A {",
+            "  foo: Type = Bar;",
+            "}",
+        ].join("\n");
+
+        var ast = b.program([
+            b.classDeclaration(
+                b.identifier('A'),
+                b.classBody([
+                    b.classProperty(
+                        b.identifier('foo'),
+                        b.identifier('Bar'),
+                        b.typeAnnotation(
+                            b.genericTypeAnnotation(b.identifier('Type'), null)
+                        )
+                    )
+                ])
+            )
+        ]);
+
+        var printer = new Printer({
+            tabWidth: 2
+        });
+
+        var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+    });
+
+    it("should print static ClassProperty correctly", function() {
+        var code = [
+            "class A {",
+            "  static foo = Bar;",
+            "}",
+        ].join("\n");
+
+        var ast = b.program([
+            b.classDeclaration(
+                b.identifier('A'),
+                b.classBody([
+                    b.classProperty(
+                        b.identifier('foo'),
+                        b.identifier('Bar'),
+                        null,
+                        true
+                    )
+                ])
+            )
+        ]);
+
+        var printer = new Printer({
+            tabWidth: 2
+        });
+
+        var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+    });
 });


### PR DESCRIPTION
This adds printing support for property initializers in "ES7".

Depends on https://github.com/benjamn/ast-types/pull/117 and https://github.com/benjamn/recast/pull/179 – I can remove the other recast diff though, just accidentally stacked it on top.
Fixes #188