### PR TITLE
Fix import type/typeof and fix minor type printing issues.

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -474,6 +474,10 @@ function genericPrintNoParens(path, options, print) {
     case "ImportDeclaration":
         var parts = ["import "];
 
+        if (n.importKind && n.importKind !== "value") {
+            parts.push(n.importKind + " ");
+        }
+
         if (n.specifiers &&
             n.specifiers.length > 0) {
 
@@ -579,9 +583,9 @@ function genericPrintNoParens(path, options, print) {
         var oneLine = (isTypeAnnotation && len === 1) || len === 0;
         var parts = [oneLine ? "{" : "{\n"];
 
+        var i = 0;
         fields.forEach(function(field) {
             path.map(function(childPath) {
-                var i = childPath.getName();
                 var lines = print(childPath);
 
                 if (!oneLine) {
@@ -606,6 +610,7 @@ function genericPrintNoParens(path, options, print) {
                 } else if (options.trailingComma) {
                     parts.push(separator);
                 }
+                i++;
             }, field);
         });
 
@@ -1220,7 +1225,8 @@ function genericPrintNoParens(path, options, print) {
     case "DeclareFunction":
         return concat([
             fromString("declare function ", options),
-            path.call(print, "id")
+            path.call(print, "id"),
+            ";"
         ]);
 
     case "DeclareModule":
@@ -1234,7 +1240,8 @@ function genericPrintNoParens(path, options, print) {
     case "DeclareVariable":
         return concat([
             fromString("declare var ", options),
-            path.call(print, "id")
+            path.call(print, "id"),
+            ";"
         ]);
 
     case "FunctionTypeAnnotation":
@@ -1301,7 +1308,7 @@ function genericPrintNoParens(path, options, print) {
             );
         }
 
-        parts.push(path.call(print, "body"));
+        parts.push(" ", path.call(print, "body"));
 
         return concat(parts);
 
@@ -1366,7 +1373,8 @@ function genericPrintNoParens(path, options, print) {
             "type ",
             path.call(print, "id"),
             " = ",
-            path.call(print, "right")
+            path.call(print, "right"),
+            ";"
         ]);
 
     case "TypeCastExpression":

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "debug": "node ./node_modules/mocha/bin/mocha --debug-brk --reporter spec"
   },
   "dependencies": {
-    "esprima-fb": "~14001.1.0-dev-harmony-fb",
+    "esprima-fb": "~15001.1.0-dev-harmony-fb",
     "source-map": "~0.4.1",
     "private": "~0.1.5",
     "ast-types": "0.8.3"

--- a/test/type-syntax.js
+++ b/test/type-syntax.js
@@ -6,17 +6,20 @@ var n = types.namedTypes;
 var b = types.builders;
 
 describe("type syntax", function() {
-    var printer = new Printer({ tabWidth: 2 });
+    var printer = new Printer({ tabWidth: 2, quote: 'single' });
 
     function check(source) {
         var ast1 = parse(source);
-        var ast2 = parse(printer.printGenerically(ast1).code);
+        var code = printer.printGenerically(ast1).code;
+        var ast2 = parse(code);
         types.astNodesAreEquivalent.assert(ast1, ast2);
+        assert.strictEqual(source, code);
     }
 
     it("should parse and print type annotations correctly", function() {
         // Import type annotations
-        check("import type foo from 'foo'");
+        check("import type foo from 'foo';");
+        check("import typeof foo from 'foo';");
 
         // Scalar type annotations
         check("var a: number;");
@@ -25,15 +28,15 @@ describe("type syntax", function() {
         check("var a: any;");
         check("var a: boolean;");
         check("var a: string;");
-        check("var a: \"foo\";");
+        check("var a: 'foo';");
         check("var a: void;");
 
         // Nullable
         check("var a: ?number;");
 
         // Unions & Intersections
-        check("var a: number | string | boolean = 26");
-        check("var a: number & string & boolean = 26");
+        check("var a: number | string | boolean = 26;");
+        check("var a: number & string & boolean = 26;");
 
         // Types
         check("var a: A = 5;");
@@ -50,16 +53,16 @@ describe("type syntax", function() {
 
         // Return types
         check("function a(): number {}");
-        check("var a: () => X = fn");
+        check("var a: () => X = fn;");
 
         // Object
-        check("var a: {b: number; x: {y: A}};");
+        check("var a: {\n  b: number;\n  x: {y: A};\n};");
         check("var b: {[key: string]: number};")
         check("var c: {(): number};")
-        check("var d: {[key: string]: A; [key: number]: B; (): C; a: D};")
+        check("var d: {\n  [key: string]: A;\n  [key: number]: B;\n  (): C;\n  a: D;\n};")
 
         // Casts
-        check("(1 + 1: number)");
+        check("(1 + 1: number);");
 
         // Declare
         check("declare var A: string;");
@@ -68,22 +71,22 @@ describe("type syntax", function() {
         check("declare function foo(c: C, b: B): void;");
         check("declare function foo(c: (e: Event) => void, b: B): void;");
         check("declare class C {x: string}");
-        check("declare module M {declare function foo(c: C): void;}");
+        check("declare module M {\n  declare function foo(c: C): void;\n}");
 
         // Classes
-        check("class A { a: number; }");
-        check("class A { foo(a: number): string {} }");
-        check("class A { static foo(a: number): string {} }");
+        check("class A {\n  a: number;\n}");
+        check("class A {\n  foo(a: number): string {}\n}");
+        check("class A {\n  static foo(a: number): string {}\n}");
 
         // Type parameters
         check("class A<T> {}");
         check("class A<X, Y> {}");
         check("class A<X> extends B<Y> {}");
         check("function a<T>(y: Y<T>): T {}");
-        check("class A { foo<T>(a: number): string {} }");
+        check("class A {\n  foo<T>(a: number): string {}\n}");
 
         // Interfaces
-        check("interface A<X> extends B<A>, C { a: number; }");
+        check("interface A<X> extends B<A>, C {a: number}");
         check("class A extends B implements C<T>, Y {}");
 
         // Bounded polymorphism


### PR DESCRIPTION
In https://github.com/facebook/esprima/commit/01e5f03ae650a228507504236ceb4ed06372e841 we updated how we use `import type` and added support for `import typeof`. We removed `isKind` and are instead relying on `importKind` which can be any of `value`, `type` or `typeof`. I made it so that it prints  `importKind` directly when it is not `value`.

I noticed also that there were minor bugs in the support for type printing. I discovered this because the ast in both cases was correct but the printed source was not. I changed the test to also directly compare the printed source, which required me to add newlines/spaces to the input source. That seemed better to me compared to using regex to remove newlines and spaces from the output. I will highlight some other fixes inline.