### PR TITLE
Add support for printing template expressions.

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -585,7 +585,7 @@ function genericPrintNoParens(path, options, print) {
 
         var i = 0;
         fields.forEach(function(field) {
-            path.map(function(childPath) {
+            path.each(function(childPath) {
                 var lines = print(childPath);
 
                 if (!oneLine) {
@@ -1155,6 +1155,29 @@ function genericPrintNoParens(path, options, print) {
 
         return concat(parts);
 
+    case "TemplateElement":
+        return fromString(n.value.raw, options);
+
+    case "TemplateLiteral":
+        var expressions = path.map(print, "expressions");
+        var parts = [];
+        path.each(function(childPath) {
+            var i = childPath.getName();
+            parts.push(print(childPath));
+            if (i < expressions.length) {
+                parts.push("${", expressions[i], "}");
+            }
+        }, "quasis");
+
+        return concat(parts);
+    case "TaggedTemplateExpression":
+        return concat([
+            path.call(print, "tag"),
+            "`",
+            path.call(print, "quasi"),
+            "`",
+        ]);
+
     // These types are unprintable because they serve as abstract
     // supertypes for other (printable) types.
     case "Node":
@@ -1412,9 +1435,6 @@ function genericPrintNoParens(path, options, print) {
     case "ComprehensionBlock": // TODO
     case "ComprehensionExpression": // TODO
     case "Glob": // TODO
-    case "TaggedTemplateExpression": // TODO
-    case "TemplateElement": // TODO
-    case "TemplateLiteral": // TODO
     case "GeneratorExpression": // TODO
     case "LetStatement": // TODO
     case "LetExpression": // TODO

--- a/test/printer.js
+++ b/test/printer.js
@@ -893,7 +893,7 @@ describe("printer", function() {
         assert.strictEqual(pretty, code);
     });
 
-    it("should add parenthesis around SpreadElementPattern", function() {
+    it("adds parenthesis around SpreadElementPattern", function() {
         var code = "(...rest) => rest;";
 
         var ast = b.program([
@@ -926,7 +926,7 @@ describe("printer", function() {
         assert.strictEqual(pretty, code);
     });
 
-    it("should print ClassProperty correctly", function() {
+    it("prints ClassProperty correctly", function() {
         var code = [
             "class A {",
             "  foo: Type = Bar;",
@@ -956,7 +956,7 @@ describe("printer", function() {
         assert.strictEqual(pretty, code);
     });
 
-    it("should print static ClassProperty correctly", function() {
+    it("prints static ClassProperty correctly", function() {
         var code = [
             "class A {",
             "  static foo = Bar;",
@@ -985,7 +985,84 @@ describe("printer", function() {
         assert.strictEqual(pretty, code);
     });
 
-    it("should preserve newlines at the beginning/end of files", function() {
+    it("prints template expressions correctly", function() {
+        var code = [
+            "graphql`query`;",
+        ].join("\n");
+
+        var ast = b.program([
+            b.taggedTemplateStatement(
+                b.identifier('graphql'),
+                b.templateLiteral(
+                    [b.templateElement({cooked: 'query', raw: 'query'}, false)],
+                    []
+                )
+            )
+        ]);
+
+        var printer = new Printer({
+            tabWidth: 2
+        });
+
+        var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+
+        code = [
+            "graphql`query${foo.getQuery()}field${bar}`;",
+        ].join("\n");
+
+        ast = b.program([
+            b.taggedTemplateStatement(
+                b.identifier('graphql'),
+                b.templateLiteral(
+                    [
+                        b.templateElement(
+                            {cooked: 'query', raw: 'query'},
+                            false
+                        ),
+                        b.templateElement(
+                            {cooked: 'field', raw: 'field'},
+                            false
+                        ),
+                        b.templateElement(
+                            {cooked: '', raw: ''},
+                            true
+                        ),
+                    ],
+                    [
+                        b.callExpression(
+                            b.memberExpression(
+                                b.identifier('foo'),
+                                b.identifier('getQuery'),
+                                false
+                            ),
+                            []
+                        ),
+                        b.identifier('bar')
+                    ]
+                )
+            )
+        ]);
+
+        pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+
+        code = [
+            "graphql`",
+            "  query {",
+            "    ${foo.getQuery()},",
+            "    field,",
+            "    ${bar},",
+            "  }",
+            "`;",
+        ].join("\n");
+
+        ast = parse(code);
+        pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+    });
+
+    it("preserves newlines at the beginning/end of files", function() {
         var code = [
             "",
             "f();",


### PR DESCRIPTION
This adds support for printing template literals.

I did this pretty fast so let me know if I missed anything obvious. 

(Also sneaked in a small code update for printing ObjectExpressions and removed `should` from some tests).