### PR TITLE
Fix printing class methods

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1619,7 +1619,7 @@ function printMethod(path, options, print) {
         parts.push("async ");
     }
 
-    if (!kind || kind === "init") {
+    if (!kind || kind === "init" || kind === "method") {
         if (node.value.generator) {
             parts.push("*");
         }


### PR DESCRIPTION
The kind of MethodDefinition changed from init to method in ast-types. This fixes the printer.