### PR TITLE
[rfc] Respect all line terminators when splitting lines

### DIFF
--- a/lib/lines.js
+++ b/lib/lines.js
@@ -118,6 +118,9 @@ function countSpaces(spaces, tabWidth) {
 exports.countSpaces = countSpaces;
 
 var leadingSpaceExp = /^\s*/;
+var lineTerminatorSeqExp =
+    /\u000D\u000A|\u000D(?!\u000A)|\u000A|\u2028|\u2029/;
+
 
 /**
  * @param {Object} options - Options object that configures printing.
@@ -137,7 +140,7 @@ function fromString(string, options) {
     if (cacheable && hasOwn.call(fromStringCache, string))
         return fromStringCache[string];
 
-    var lines = new Lines(string.split("\n").map(function(line) {
+    var lines = new Lines(string.split(lineTerminatorSeqExp).map(function(line) {
         var spaces = leadingSpaceExp.exec(line)[0];
         return {
             line: line,

--- a/test/lines.js
+++ b/test/lines.js
@@ -10,6 +10,30 @@ function check(a, b) {
 }
 
 describe("lines", function() {
+
+    describe('line terminators', function() {
+        var source = [
+            'foo;',
+            'bar;',
+        ];
+
+        var terminators = [
+            '\u000A',
+            '\u000D',
+            '\u2028',
+            '\u2029',
+            '\u000D\u000A',
+        ];
+        terminators.forEach(function(t) {
+            it('can handle ' + escape(t) + ' as line terminator', function() {
+                var lines = fromString(source.join(t));
+                assert.strictEqual(lines.length, 2);
+                assert.strictEqual(lines.getLineLength(1), 4);
+            });
+        });
+    });
+
+
     it("FromString", function() {
         function checkIsCached(s) {
             assert.strictEqual(fromString(s), fromString(s));


### PR DESCRIPTION
I'm not sure if this is the right approach or if this is needed at all, but my investigation lead me to believe that there is an issue with the `fromString` implementation.

Context: There are problems with using react-docgen with files that use Windows line terminators (see reactjs/react-docgen/issues/11), specifically reading docblock comments.
I added a test which throws an error inside recast: https://gist.github.com/fkling/d31c7729c3c0f521ed39.

It seems that recast doesn't split on all of the line terminators that are defined in the [spec][]. So modified `fromString` and added corresponding tests. Unfortunately this makes it fail for two other tests: https://gist.github.com/fkling/cc043e2afe503d8cb5ba

That lead me to look at the `ExoticWhitespace` test which *looks* like it should actually cover my use case.

Any idea what's going on?

[spec]: http://www.ecma-international.org/ecma-262/5.1/#sec-7.3