### PR TITLE
Add option to print object patterns on one line

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -581,7 +581,7 @@ function genericPrintNoParens(path, options, print) {
             len += n[field].length;
         });
 
-        var oneLine = (isTypeAnnotation && len === 1) || len === 0;
+        var oneLine = n.oneLine || (isTypeAnnotation && len === 1) || len === 0;
         var parts = [oneLine ? "{" : "{\n"];
 
         var i = 0;
@@ -602,13 +602,17 @@ function genericPrintNoParens(path, options, print) {
                 parts.push(lines);
 
                 if (i < len - 1) {
-                    // Add an extra line break if the previous object property
-                    // had a multi-line value.
-                    parts.push(separator + (multiLine ? "\n\n" : "\n"));
-                    allowBreak = !multiLine;
+                    if (oneLine) {
+                        parts.push(separator + " ");
+                    } else {
+                        // Add an extra line break if the previous object
+                        // property had a multi-line value.
+                        parts.push(separator + (multiLine ? "\n\n" : "\n"));
+                        allowBreak = !multiLine;
+                    }
                 } else if (len !== 1 && isTypeAnnotation) {
                     parts.push(separator);
-                } else if (options.trailingComma) {
+                } else if (!oneLine && options.trailingComma) {
                     parts.push(separator);
                 }
                 i++;

--- a/test/printer.js
+++ b/test/printer.js
@@ -1110,4 +1110,25 @@ describe("printer", function() {
             ""
         ].join("\n"));
     });
+
+    it("prints object patterns on one line with `oneLine` option", function () {
+        var code = [
+            "var {",
+            "  foo,",
+            "  bar,",
+            "} = require('foobar');",
+        ].join("\n")
+
+        var ast = parse(code);
+        ast.program.body[0].declarations[0].id.oneLine = true;
+
+        var printer = new Printer({
+            tabWidth: 2,
+            trailingComma: true, // Make sure the trailing comma isn't printed
+        });
+
+        var expected = "var {foo, bar} = require(\"foobar\");";
+        var actual = printer.printGenerically(ast).code;
+        assert.strictEqual(actual, expected);
+    });
 });


### PR DESCRIPTION
This allows you to print object patterns on one line. The option is put on each node because you generally will not want to configure it globally for all object patterns.

This is important for us when using requires, right now

```
var apple = require('apple');
var {foo, bar} = require('foobar');
var banana = require('banana');
```

Always gets reprinted as

```
var apple = require('apple');
var {
  foo,
  bar
} = require('foobar');
var banana = require('banana');
```

Which isn't really acceptable when you have a long list of requires.