### PR TITLE
Fix printing import declarations

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -383,9 +383,18 @@ function genericPrintNoParens(path, options, print) {
         return fromString("*");
 
     case "ImportNamespaceSpecifier":
-        return concat(["* as ", path.call(print, "id")]);
+        var parts = ["* as "];
+        if (n.local) {
+            parts.push(path.call(print, "local"));
+        } else if (n.id) {
+            parts.push(path.call(print, "id"));
+        }
+        return concat(parts);
 
     case "ImportDefaultSpecifier":
+        if (n.local) {
+            return path.call(print, "local");
+        }
         return path.call(print, "id");
 
     case "ExportDeclaration":


### PR DESCRIPTION
ESTree (esprima and Babel) puts the identifier name in the "local" property, not the "id" property.

See http://felix-kling.de/esprima_ast_explorer/#/3lOF4MIKlj and facebook/jscodeshift/issues/33

Do you want me to provide tests?