### PR TITLE
Added parseOptions key, for arbitrary additional options.

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -4,6 +4,9 @@ var defaults = {
     // recast.parse as options.esprima.
     esprima: require("esprima-fb"),
 
+    // Additional options passed to the parse module (i.e. Acorn plugins)
+    parseOptions: null,
+
     // Number of spaces the pretty-printer should use per tab for
     // indentation. If you do not pass this option explicitly, it will be
     // (quite reliably!) inferred from the original code.
@@ -87,6 +90,7 @@ exports.normalize = function(options) {
         sourceRoot: get("sourceRoot"),
         inputSourceMap: get("inputSourceMap"),
         esprima: get("esprima"),
+        parseOptions: get("parseOptions") || {},
         range: get("range"),
         tolerant: get("tolerant"),
         quote: get("quote"),

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -23,7 +23,8 @@ exports.parse = function parse(source, options) {
     });
 
     var comments = [];
-    var program = options.esprima.parse(sourceWithoutTabs, {
+    
+    var parseOptions = {
         loc: true,
         locations: true,
         range: options.range,
@@ -32,7 +33,12 @@ exports.parse = function parse(source, options) {
         tolerant: options.tolerant,
         ecmaVersion: 6,
         sourceType: 'module'
-    });
+    }
+    for (var optionKey in options.parseOptions) {
+        parseOptions[optionKey] = options.parseOptions[optionKey];
+    }
+
+    var program = options.esprima.parse(sourceWithoutTabs, parseOptions);
 
     program.loc = program.loc || {
         start: lines.firstPos(),


### PR DESCRIPTION
Found myself wanting to use `acorn-jsx` as the underlying parser for `recast`, but to activate the JSX plugin, one must call

``` js
acorn.parse(code, { plugins: { jsx: true } })
```

This PR adds a `parseOptions` key which is merged into the normal Recast parse options.

Note: there is a potentially viable alternative in exporting the tab-stripping and tree `Program` modification separately from the `parse` function and allowing callers to call their own parser module directly, and pass the resulting AST into some `recast.format(ast)` function. 
