### PR TITLE
Upgrade source-map to ~0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "esprima-fb": "~15001.1001.0-dev-harmony-fb",
-    "source-map": "~0.4.4",
+    "source-map": "~0.5.0",
     "private": "~0.1.5",
     "ast-types": "0.8.11"
   },


### PR DESCRIPTION
The update is just leaner and faster. https://github.com/mozilla/source-map/pull/203, https://github.com/mozilla/source-map/pull/204, https://github.com/mozilla/source-map/pull/205 and https://github.com/mozilla/source-map/pull/206