### PR TITLE
Always wrap arrow functions in parenthesis if the only param isn’t an identifier.

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -282,8 +282,7 @@ function genericPrintNoParens(path, options, print) {
         if (
             n.params.length === 1 &&
             !n.rest &&
-            n.params[0].type !== 'SpreadElementPattern' &&
-            n.params[0].type !== 'RestElement'
+            n.params[0].type === 'Identifier'
         ) {
             parts.push(path.call(print, "params", 0));
         } else {

--- a/test/printer.js
+++ b/test/printer.js
@@ -938,6 +938,42 @@ describe("printer", function() {
         assert.strictEqual(pretty, code);
     });
 
+    it("adds parenthesis around async arrow functions with args", function() {
+        var code = "async () => {};";
+
+        var fn = b.arrowFunctionExpression(
+            [],
+            b.blockStatement([]),
+            false
+        );
+        fn.async = true;
+
+        var ast = b.program([
+            b.expressionStatement(fn)
+        ]);
+
+        var printer = new Printer({
+            tabWidth: 2
+        });
+
+        var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+
+        // No parenthesis for single params if they are identifiers
+        code = "async foo => {};";
+        fn.params = [b.identifier('foo')];
+
+        pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+
+        // Add parenthesis for destructuring
+        code = "async ([a, b]) => {};";
+        fn.params = [b.arrayPattern([b.identifier('a'), b.identifier('b')])];
+
+        pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+    });
+
     it("prints ClassProperty correctly", function() {
         var code = [
             "class A {",


### PR DESCRIPTION
Fixes #217