### PR TITLE
Print class decorators (not only class methods decorators)

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1135,7 +1135,15 @@ function genericPrintNoParens(path, options, print) {
 
     case "ClassDeclaration":
     case "ClassExpression":
-        var parts = ["class"];
+        var parts = [];
+
+        if (n.decorators) {
+            path.each(function(decoratorPath) {
+                parts.push(print(decoratorPath), "\n");
+            }, "decorators");
+        }
+
+        parts.push("class");
 
         if (n.id) {
             parts.push(


### PR DESCRIPTION
Now it can print by ast
```javascript
@decorator
class Some {
  method() {
  }
}
```

not only
```javascript
class Some {
  @decorator
  method() {
  }
}
```
as yesterday