### PR TITLE
Add lineBreaksInObjects option to control whether pretty-printed Objects have line breaks between multiline properties

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -64,6 +64,10 @@ var defaults = {
     // array expressions, functions calls and function definitions pass true
     // for this option.
     trailingComma: false,
+
+    // If you want line breaks before and after multiline properties in objects,
+    // pass true for this option.
+    lineBreaksInObjects: true,
 }, hasOwn = defaults.hasOwnProperty;
 
 // Copy options and fill in default values.

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -612,8 +612,8 @@ function genericPrintNoParens(path, options, print) {
                 if (i < len - 1) {
                     // Add an extra line break if the previous object property
                     // had a multi-line value.
-                    parts.push(separator + (multiLine ? "\n\n" : "\n"));
-                    allowBreak = !multiLine;
+                    parts.push(separator + (multiLine && options.lineBreaksInObjects? "\n\n" : "\n"));
+                    allowBreak = !multiLine && options.lineBreaksInObjects;
                 } else if (len !== 1 && isTypeAnnotation) {
                     parts.push(separator);
                 } else if (options.trailingComma) {


### PR DESCRIPTION
This is for issue #228 