### PR TITLE
Fix printing implements keyword

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1172,7 +1172,7 @@ function genericPrintNoParens(path, options, print) {
             );
         }
 
-        if (n["implements"]) {
+        if (n["implements"] && n['implements'].length > 0) {
             parts.push(
                 " implements ",
                 fromString(", ").join(path.map(print, "implements"))


### PR DESCRIPTION
Only print implements keyword if implements property has more than 0 items

Basically printing a `ClassExpression` adds an implements keyword. I'm guessing that this check here should really also check if the implements array is empty and that's why I get that result, because the default for `ClassExpression.implements` is `[]`.

Here's how this looks like:

http://astexplorer.net/#/mNvVofHYVs/1

cc @benjamn 