### PR TITLE
[package] Support webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "test": "node ./node_modules/mocha/bin/mocha --reporter spec --full-trace",
     "debug": "node ./node_modules/mocha/bin/mocha --debug-brk --reporter spec"
   },
+  "browser": {
+    "fs": false
+  },
   "dependencies": {
     "esprima-fb": "~15001.1001.0-dev-harmony-fb",
     "source-map": "~0.5.0",


### PR DESCRIPTION
I'm trying to use https://github.com/reactjs/react-docgen with webpack.
However I'm getting the following error:
```
ERROR in ./~/recast/main.js
Module not found: Error: Cannot resolve module 'fs' in /Users/oliviertassinari/material-ui/docs/node_modules/recast
 @ ./~/recast/main.js 18:4-17
```
This PR aim to fix it, following this PR https://github.com/jadejs/jade/pull/1644