### PR TITLE
Fix needsParens for `ArrowFunctionExpression`'s as callees

### DIFF
--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -326,12 +326,6 @@ FPp.needsParens = function(assumeExpressionContext) {
 
         return isBinary(parent);
 
-    case "FunctionExpression":
-        if(parent.type === 'CallExpression' && 
-           name === 'callee') {
-            return true;
-        };
-
     case "ObjectExpression":
         if (parent.type === "ArrowFunctionExpression" &&
             name === "body") {

--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -319,7 +319,18 @@ FPp.needsParens = function(assumeExpressionContext) {
         }
 
     case "ArrowFunctionExpression":
+        if(parent.type === 'CallExpression' && 
+           name === 'callee') {
+            return true;
+        };
+
         return isBinary(parent);
+
+    case "FunctionExpression":
+        if(parent.type === 'CallExpression' && 
+           name === 'callee') {
+            return true;
+        };
 
     case "ObjectExpression":
         if (parent.type === "ArrowFunctionExpression" &&

--- a/test/parens.js
+++ b/test/parens.js
@@ -271,4 +271,21 @@ describe("parens", function() {
             code
         );
     });
+
+    it.only("should be added to callee expressions of type ArrowFunctionExpression", function() {
+        var code = [
+            "(()=>{})()"
+        ].join(eol);
+
+        var ast = parse(code);
+        var printer = new Printer({
+            tabWidth: 2
+        });
+
+        assert.strictEqual(
+            printer.printGenerically(ast).code,
+            code
+        );
+
+    });
 });

--- a/test/parens.js
+++ b/test/parens.js
@@ -272,19 +272,8 @@ describe("parens", function() {
         );
     });
 
-    it("should be added to callee expressions of type ArrowFunctionExpression", function() {
-        var code = [
-            "(()=>{})()"
-        ].join(eol);
-
-        var ast = parse(code);
-        var printer = new Printer({
-            tabWidth: 2
-        });
-
-        assert.strictEqual(
-            printer.printGenerically(ast).code,
-            code
-        );
+    it("should be added to callees that are function expressions", function() {
+        check("(()=>{})()");
+        check("(function(){})()");
     });
 });

--- a/test/parens.js
+++ b/test/parens.js
@@ -272,7 +272,7 @@ describe("parens", function() {
         );
     });
 
-    it.only("should be added to callee expressions of type ArrowFunctionExpression", function() {
+    it("should be added to callee expressions of type ArrowFunctionExpression", function() {
         var code = [
             "(()=>{})()"
         ].join(eol);
@@ -286,6 +286,5 @@ describe("parens", function() {
             printer.printGenerically(ast).code,
             code
         );
-
     });
 });


### PR DESCRIPTION
Basically if the left hand expression of a callexpression is an arrow function we get this invalid output (when using `printGenerically`):

```js
()=>{}();
```

this output is invalid what it should be is:

```js
(()=>{})();
```

this pr fixes it and adds a spec for regressions.

cc @benjamn