### PR TITLE
Attempt to use babylon as the default parser.

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -1,8 +1,35 @@
+var babylon = require("babylon");
+var babylonOptions = {
+    sourceType: 'module',
+    allowImportExportEverywhere: false,
+    allowReturnOutsideFunction: false,
+    plugins: [
+        'asyncFunctions',
+        'asyncGenerators',
+        'classConstructorCall',
+        'classProperties',
+        'decorators',
+        'doExpressions',
+        'exponentiationOperator',
+        'exportExtensions',
+        'flow',
+        'functionSent',
+        'functionBind',
+        'jsx',
+        'objectRestSpread',
+        'trailingFunctionCommas'
+    ]
+};
+
 var defaults = {
     // If you want to use a different branch of esprima, or any other
     // module that supports a .parse function, pass that module object to
     // recast.parse as options.parser (legacy synonym: options.esprima).
-    parser: require("esprima"),
+    parser: {
+        parse: function (source) {
+            return babylon.parse(source, babylonOptions);
+        }
+    },
 
     // Number of spaces the pretty-printer should use per tab for
     // indentation. If you do not pass this option explicitly, it will be

--- a/package.json
+++ b/package.json
@@ -29,13 +29,11 @@
   },
   "dependencies": {
     "ast-types": "0.8.15",
-    "esprima": "~2.7.1",
+    "babylon": "~6.4.2",
     "private": "~0.1.5",
     "source-map": "~0.5.0"
   },
   "devDependencies": {
-    "babylon": "~6.4.2",
-    "esprima-fb": "^15001.1001.0-dev-harmony-fb",
     "mocha": "~2.2.5"
   },
   "engines": {

--- a/test/jsx.js
+++ b/test/jsx.js
@@ -4,13 +4,10 @@ var types = require("../lib/types");
 
 describe("JSX Compatability", function() {
   var printer = new Printer({ tabWidth: 2 });
-  var parseOptions = {
-    parser: require("esprima-fb")
-  };
 
   function check(source) {
-    var ast1 = parse(source, parseOptions);
-    var ast2 = parse(printer.printGenerically(ast1).code, parseOptions);
+    var ast1 = parse(source);
+    var ast2 = parse(printer.printGenerically(ast1).code);
     types.astNodesAreEquivalent.assert(ast1, ast2);
   }
 

--- a/test/parens.js
+++ b/test/parens.js
@@ -1,5 +1,4 @@
 var assert = require("assert");
-var esprima = require("esprima");
 var parse = require("../lib/parser").parse;
 var Printer = require("../lib/printer").Printer;
 var NodePath = require("ast-types").NodePath;
@@ -10,7 +9,7 @@ var printer = new Printer;
 var eol = require("os").EOL;
 
 function parseExpression(expr) {
-    var ast = esprima.parse(expr);
+    var ast = parse(expr);
     n.Program.assert(ast);
     ast = ast.body[0];
     if (n.ExpressionStatement.check(ast))

--- a/test/printer.js
+++ b/test/printer.js
@@ -807,10 +807,7 @@ describe("printer", function() {
             "});"
         ].join(eol);
 
-        var ast = parse(code, {
-            // Supports trailing commas whereas plain esprima does not.
-            parser: require("esprima-fb")
-        });
+        var ast = parse(code);
 
         var printer = new Printer({
             tabWidth: 2,
@@ -829,10 +826,7 @@ describe("printer", function() {
             ");"
         ].join(eol);
 
-        var ast = parse(code, {
-            // Supports trailing commas whereas plain esprima does not.
-            parser: require("esprima-fb")
-        });
+        var ast = parse(code);
 
         var printer = new Printer({
             tabWidth: 2,
@@ -852,10 +846,7 @@ describe("printer", function() {
             "];"
         ].join(eol);
 
-        var ast = parse(code, {
-            // Supports trailing commas whereas plain esprima does not.
-            parser: require("esprima-fb")
-        });
+        var ast = parse(code);
 
         var printer = new Printer({
             tabWidth: 2,
@@ -875,10 +866,7 @@ describe("printer", function() {
             ") {}"
         ].join(eol);
 
-        var ast = parse(code, {
-            // Supports trailing commas whereas plain esprima does not.
-            parser: require("esprima-fb")
-        });
+        var ast = parse(code);
 
         var printer = new Printer({
             tabWidth: 2,
@@ -897,11 +885,7 @@ describe("printer", function() {
             "}"
         ].join(eol);
 
-        var ast = parse(code, {
-            // Supports rest parameter destructuring whereas plain esprima
-            // does not.
-            parser: require("esprima-fb")
-        });
+        var ast = parse(code);
 
         var printer = new Printer({
             tabWidth: 2
@@ -1137,9 +1121,9 @@ describe("printer", function() {
 
         var lines = fromString(code);
         var ast = parse(code, {
-            esprima: {
+            parser: {
                 parse: function(source, options) {
-                    var program = require("esprima").parse(source, options);
+                    var program = parse(source, options);
                     n.Program.assert(program);
                     // Expand ast.program.loc to include any
                     // leading/trailing whitespace, to simulate the

--- a/test/type-syntax.js
+++ b/test/type-syntax.js
@@ -8,14 +8,11 @@ var eol = require("os").EOL;
 
 describe("type syntax", function() {
   var printer = new Printer({ tabWidth: 2, quote: 'single' });
-  var parseOptions = {
-    parser: require("esprima-fb")
-  };
 
   function check(source) {
-    var ast1 = parse(source, parseOptions);
+    var ast1 = parse(source);
     var code = printer.printGenerically(ast1).code;
-    var ast2 = parse(code, parseOptions);
+    var ast2 = parse(code);
     types.astNodesAreEquivalent.assert(ast1, ast2);
     assert.strictEqual(source, code);
   }


### PR DESCRIPTION
This pull request currently has a lot of test failures, but perhaps it's not as far from working as it seems.

Previous discussion of the default parser choice: #178

To be clear: `recast` works perfectly well with [`babylon` as a custom parser](https://github.com/benjamn/recast/blob/892a12e2b3ef5313ab6af135c309c2fad59b0ef7/test/babylon.js#L29-L35), there are just a lot of existing tests that implicitly depend on `esprima(-fb)` parsing quirks.
