### PR TITLE
Print rest params in FunctionTypeAnnotations

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1300,9 +1300,14 @@ function genericPrintNoParens(path, options, print) {
             parts.push(": ");
         }
 
+        var params = path.map(print, "params");
+        if (n.rest) {
+            params.push(concat(["...", path.call(print, "rest")]));
+        }
+
         parts.push(
             "(",
-            fromString(", ").join(path.map(print, "params")),
+            fromString(", ").join(params),
             ")"
         );
 

--- a/test/type-syntax.js
+++ b/test/type-syntax.js
@@ -74,6 +74,7 @@ describe("type syntax", function() {
     check("declare function foo(c: C): void;");
     check("declare function foo(c: C, b: B): void;");
     check("declare function foo(c: (e: Event) => void, b: B): void;");
+    check("declare function foo(c: C, ...d: Array<D>): void;");
     check("declare class C {x: string}");
     check("declare module M {" + eol + "  declare function foo(c: C): void;" + eol + "}");
 


### PR DESCRIPTION
Although the `FunctionTypeAnnotation` specifies a [`rest` field](https://github.com/benjamn/ast-types/blob/master/def/fb-harmony.js#L162), the printer does not account for the existence of this field and does not correctly print it. This pull request adds the ability to print the `rest` field as well as adds a brief test.
