### PR TITLE
Print trailing comments on statements as trailing

### DIFF
--- a/lib/comments.js
+++ b/lib/comments.js
@@ -337,7 +337,8 @@ exports.printComments = function(path, print) {
         var leading = types.getFieldValue(comment, "leading");
         var trailing = types.getFieldValue(comment, "trailing");
 
-        if (leading || (trailing && !(comment.type === "Block" ||
+        if (leading || (trailing && !(n.Statement.check(value) ||
+                                      comment.type === "Block" ||
                                       comment.type === "CommentBlock"))) {
             leadingParts.push(printLeadingComment(commentPath, print));
         } else if (trailing) {

--- a/test/comments.js
+++ b/test/comments.js
@@ -220,6 +220,43 @@ describe("comments", function() {
         assert.strictEqual(actual, expected);
     });
 
+    var statementTrailing = [
+        "if (true) {",
+        "  f();",
+        "  // trailing 1",
+        "  /* trailing 2 */",
+        "  // trailing 3",
+        "  /* trailing 4 */",
+        "}"
+    ];
+
+    var statementTrailingExpected = [
+        "if (true) {",
+        "  e();",
+        "  f();",
+        "  // trailing 1",
+        "  /* trailing 2 */",
+        "  // trailing 3",
+        "  /* trailing 4 */",
+        "}"
+    ];
+
+    it("StatementTrailingComments", function() {
+        var code = statementTrailing.join(eol);
+        var ast = recast.parse(code);
+
+        var block = ast.program.body[0].consequent;
+        n.BlockStatement.assert(block);
+
+        block.body.unshift(b.expressionStatement(
+            b.callExpression(b.identifier("e"), [])));
+
+        var actual = recast.print(ast, { tabWidth: 2 }).code;
+        var expected = statementTrailingExpected.join(eol);
+
+        assert.strictEqual(actual, expected);
+    });
+
     var protoAssign = [
         "A.prototype.foo = function() {",
         "  return this.bar();",


### PR DESCRIPTION
Doing so doesn't break any existing tests.

@benjamn: This fixes a test case I have in my downstream project, and the provided test case.  If it doesn't have any unforeseen consequences, it may be a fix for #191 for most purposes.