### PR TITLE
Preserve leading and trailing whitespace around string children of JSXElements

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1023,11 +1023,7 @@ function genericPrintNoParens(path, options, print) {
 
                 if (namedTypes.Literal.check(child) &&
                     typeof child.value === "string") {
-                    if (/\S/.test(child.value)) {
-                        return child.value.replace(/^\s+|\s+$/g, "");
-                    } else if (/\n/.test(child.value)) {
-                        return "\n";
-                    }
+                    return child.value;
                 }
 
                 return print(childPath);

--- a/test/jsx.js
+++ b/test/jsx.js
@@ -47,4 +47,8 @@ describe("JSX Compatability", function() {
   it("should parse and print namespaced elements", function() {
     check("<Foo.Bar />");
   });
+
+  it('should parse and print string literal children with leading and trailing whitespace', function () {
+    check("<div>Hello, {name} and {name2}.</div>");
+  });
 });


### PR DESCRIPTION
I'm not sure what the intention was behind the whitespace-stripping logic I removed. If there is a specific case that it was meant to handle, let me know and I can update this pull request with a test for it.

Fixes #246.