### PR TITLE
add failing test for decorators

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -261,6 +261,7 @@ function fixTemplateLiteral(node, lines) {
 util.isExportDeclaration = function (node) {
   if (node) switch (node.type) {
   case "ExportDeclaration":
+  case "ExportDefaultDeclaration":
   case "ExportDefaultSpecifier":
   case "DeclareExportDeclaration":
   case "ExportNamedDeclaration":


### PR DESCRIPTION
This basically just does what it says. I don't know enough about the internals of recast to actually fix the problem, but now there's a tested failure case! :)