### PR TITLE
Add support for ES7 exponentiation operator

### DIFF
--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -374,7 +374,7 @@ var PRECEDENCE = {};
  ["<", ">", "<=", ">=", "in", "instanceof"],
  [">>", "<<", ">>>"],
  ["+", "-"],
- ["*", "/", "%"]
+ ["*", "/", "%", "**"]
 ].forEach(function(tier, i) {
     tier.forEach(function(op) {
         PRECEDENCE[op] = i;

--- a/test/babylon.js
+++ b/test/babylon.js
@@ -188,4 +188,32 @@ describe("decorators", function () {
       "type X = {b: number};"
     );
   });
+
+  function parseExpression(code) {
+    return recast.parse(code, parseOptions).program.body[0].expression;
+  }
+
+  it("should parenthesize ** operator arguments when lower precedence", function () {
+    var ast = recast.parse('a ** b;', parseOptions);
+
+    ast.program.body[0].expression.left = parseExpression('x + y');
+    ast.program.body[0].expression.right = parseExpression('x || y');
+
+    assert.strictEqual(
+      recast.print(ast).code,
+      '(x + y) ** (x || y);'
+    );
+  });
+
+  it("should parenthesize ** operator arguments as needed when same precedence", function () {
+    var ast = recast.parse('a ** b;', parseOptions);
+
+    ast.program.body[0].expression.left = parseExpression('x * y');
+    ast.program.body[0].expression.right = parseExpression('x / y');
+
+    assert.strictEqual(
+      recast.print(ast).code,
+      'x * y ** (x / y);'
+    );
+  });
 });


### PR DESCRIPTION
The change itself is trivial - just adding `**` operator to PRECEDENCE table.

I'm not really sure about the proper way to test it. Added a test to Babylon test suite, which covers the problem that I was running into. Though it might seem more logical to include it to the general Parens test suite, but Esprima doesn't yet support this operator yet.

For reference: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Operator_Precedence