### PR TITLE
Add singleArgumentArrowParenthesis option

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -64,6 +64,10 @@ var defaults = {
     // array expressions, functions calls and function definitions pass true
     // for this option.
     trailingComma: false,
+
+    // If you want parenthesis to wrap single-argument arrow function parameter
+    // lists, pass true for this option.
+    singleArgumentArrowParenthesis: false,
 }, hasOwn = defaults.hasOwnProperty;
 
 // Copy options and fill in default values.
@@ -91,5 +95,6 @@ exports.normalize = function(options) {
         tolerant: get("tolerant"),
         quote: get("quote"),
         trailingComma: get("trailingComma"),
+        singleArgumentArrowParenthesis: get("singleArgumentArrowParenthesis"),
     };
 };

--- a/lib/options.js
+++ b/lib/options.js
@@ -67,7 +67,7 @@ var defaults = {
 
     // If you want parenthesis to wrap single-argument arrow function parameter
     // lists, pass true for this option.
-    singleArgumentArrowParenthesis: false,
+    arrowParensAlways: false,
 }, hasOwn = defaults.hasOwnProperty;
 
 // Copy options and fill in default values.
@@ -95,6 +95,6 @@ exports.normalize = function(options) {
         tolerant: get("tolerant"),
         quote: get("quote"),
         trailingComma: get("trailingComma"),
-        singleArgumentArrowParenthesis: get("singleArgumentArrowParenthesis"),
+        arrowParensAlways: get("arrowParensAlways"),
     };
 };

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -333,6 +333,7 @@ function genericPrintNoParens(path, options, print) {
             parts.push("async ");
 
         if (
+            !options.singleArgumentArrowParenthesis &&
             n.params.length === 1 &&
             !n.rest &&
             n.params[0].type === 'Identifier' &&

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -333,7 +333,7 @@ function genericPrintNoParens(path, options, print) {
             parts.push("async ");
 
         if (
-            !options.singleArgumentArrowParenthesis &&
+            !options.arrowParensAlways &&
             n.params.length === 1 &&
             !n.rest &&
             n.params[0].type === 'Identifier' &&

--- a/test/printer.js
+++ b/test/printer.js
@@ -956,7 +956,7 @@ describe("printer", function() {
         assert.strictEqual(pretty, code);
     });
 
-    it("adds parenthesis around single arrow function arg when options.singleArgumentArrowParenthesis is true", function() {
+    it("adds parenthesis around single arrow function arg when options.arrowParensAlways is true", function() {
       var code = "(a) => {};";
 
       var fn = b.arrowFunctionExpression(
@@ -970,7 +970,7 @@ describe("printer", function() {
       ]);
 
       var printer = new Printer({
-        singleArgumentArrowParenthesis: true
+        arrowParensAlways: true
       });
       var pretty = printer.printGenerically(ast).code;
       assert.strictEqual(pretty, code);

--- a/test/printer.js
+++ b/test/printer.js
@@ -956,6 +956,26 @@ describe("printer", function() {
         assert.strictEqual(pretty, code);
     });
 
+    it("adds parenthesis around single arrow function arg when options.singleArgumentArrowParenthesis is true", function() {
+      var code = "(a) => {};";
+
+      var fn = b.arrowFunctionExpression(
+          [b.identifier('a')],
+          b.blockStatement([]),
+          false
+      );
+
+      var ast = b.program([
+          b.expressionStatement(fn)
+      ]);
+
+      var printer = new Printer({
+        singleArgumentArrowParenthesis: true
+      });
+      var pretty = printer.printGenerically(ast).code;
+      assert.strictEqual(pretty, code);
+    });
+
     it("adds parenthesis around async arrow functions with args", function() {
         var code = "async () => {};";
 


### PR DESCRIPTION
For users with eslint configured with `arrow-parens: always`.