### PR TITLE
Add `flowObjectCommas` option

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -68,6 +68,11 @@ var defaults = {
     // If you want parenthesis to wrap single-argument arrow function parameter
     // lists, pass true for this option.
     arrowParensAlways: false,
+
+    // There are 2 supported syntaxes (`,` and `;`) in Flow Object Types;
+    // The use of commas is in line with the more popular style and matches
+    // how objects are defined in JS, making it a bit more natural to write.
+    flowUsesCommas: true,
 }, hasOwn = defaults.hasOwnProperty;
 
 // Copy options and fill in default values.
@@ -96,5 +101,6 @@ exports.normalize = function(options) {
         quote: get("quote"),
         trailingComma: get("trailingComma"),
         arrowParensAlways: get("arrowParensAlways"),
+        flowUsesCommas: get("flowUsesCommas"),
     };
 };

--- a/lib/options.js
+++ b/lib/options.js
@@ -72,7 +72,7 @@ var defaults = {
     // There are 2 supported syntaxes (`,` and `;`) in Flow Object Types;
     // The use of commas is in line with the more popular style and matches
     // how objects are defined in JS, making it a bit more natural to write.
-    flowUsesCommas: true,
+    flowObjectCommas: true,
 }, hasOwn = defaults.hasOwnProperty;
 
 // Copy options and fill in default values.
@@ -101,6 +101,6 @@ exports.normalize = function(options) {
         quote: get("quote"),
         trailingComma: get("trailingComma"),
         arrowParensAlways: get("arrowParensAlways"),
-        flowUsesCommas: get("flowUsesCommas"),
+        flowObjectCommas: get("flowObjectCommas"),
     };
 };

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -565,7 +565,7 @@ function genericPrintNoParens(path, options, print) {
     case "ObjectTypeAnnotation":
         var allowBreak = false;
         var isTypeAnnotation = n.type === "ObjectTypeAnnotation";
-        var separator = isTypeAnnotation ? ';' : ',';
+        var separator = options.flowUsesCommas ? "," : (isTypeAnnotation ? ";" : ",");
         var fields = [];
 
         if (isTypeAnnotation) {

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -565,7 +565,7 @@ function genericPrintNoParens(path, options, print) {
     case "ObjectTypeAnnotation":
         var allowBreak = false;
         var isTypeAnnotation = n.type === "ObjectTypeAnnotation";
-        var separator = options.flowUsesCommas ? "," : (isTypeAnnotation ? ";" : ",");
+        var separator = options.flowObjectCommas ? "," : (isTypeAnnotation ? ";" : ",");
         var fields = [];
 
         if (isTypeAnnotation) {

--- a/test/printer.js
+++ b/test/printer.js
@@ -1368,16 +1368,16 @@ describe("printer", function() {
         ].join(eol);
 
         var ast = b.typeAlias(
-            b.identifier('MyType'),
+            b.identifier("MyType"),
             null,
             b.objectTypeAnnotation([
                 b.objectTypeProperty(
-                    b.identifier('message'),
+                    b.identifier("message"),
                     b.stringTypeAnnotation(),
                     false
                 ),
                 b.objectTypeProperty(
-                    b.identifier('isAwesome'),
+                    b.identifier("isAwesome"),
                     b.booleanTypeAnnotation(),
                     false
                 )
@@ -1398,16 +1398,16 @@ describe("printer", function() {
         ].join(eol);
 
         var ast = b.typeAlias(
-            b.identifier('MyType'),
+            b.identifier("MyType"),
             null,
             b.objectTypeAnnotation([
                 b.objectTypeProperty(
-                    b.identifier('message'),
+                    b.identifier("message"),
                     b.stringTypeAnnotation(),
                     false
                 ),
                 b.objectTypeProperty(
-                    b.identifier('isAwesome'),
+                    b.identifier("isAwesome"),
                     b.booleanTypeAnnotation(),
                     false
                 )

--- a/test/printer.js
+++ b/test/printer.js
@@ -1389,7 +1389,7 @@ describe("printer", function() {
         assert.strictEqual(pretty, code);
     });
 
-    it("prints semicolons for flow object types when options.flowUsesCommas is falsy", function() {
+    it("prints semicolons for flow object types when options.flowObjectCommas is falsy", function() {
         var code = [
             "type MyType = {",
             "    message: string;",
@@ -1414,7 +1414,7 @@ describe("printer", function() {
             ])
         );
 
-        var printer = new Printer({ flowUsesCommas: false });
+        var printer = new Printer({ flowObjectCommas: false });
         var pretty = printer.printGenerically(ast).code;
         assert.strictEqual(pretty, code);
     });

--- a/test/printer.js
+++ b/test/printer.js
@@ -1358,4 +1358,64 @@ describe("printer", function() {
 
         assert.strictEqual(actual, expected);
     });
+
+    it("prints commas for flow object types by default", function() {
+        var code = [
+            "type MyType = {",
+            "    message: string,",
+            "    isAwesome: boolean,",
+            "};"
+        ].join(eol);
+
+        var ast = b.typeAlias(
+            b.identifier('MyType'),
+            null,
+            b.objectTypeAnnotation([
+                b.objectTypeProperty(
+                    b.identifier('message'),
+                    b.stringTypeAnnotation(),
+                    false
+                ),
+                b.objectTypeProperty(
+                    b.identifier('isAwesome'),
+                    b.booleanTypeAnnotation(),
+                    false
+                )
+            ])
+        );
+
+        var printer = new Printer();
+        var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+    });
+
+    it("prints semicolons for flow object types when options.flowUsesCommas is falsy", function() {
+        var code = [
+            "type MyType = {",
+            "    message: string;",
+            "    isAwesome: boolean;",
+            "};"
+        ].join(eol);
+
+        var ast = b.typeAlias(
+            b.identifier('MyType'),
+            null,
+            b.objectTypeAnnotation([
+                b.objectTypeProperty(
+                    b.identifier('message'),
+                    b.stringTypeAnnotation(),
+                    false
+                ),
+                b.objectTypeProperty(
+                    b.identifier('isAwesome'),
+                    b.booleanTypeAnnotation(),
+                    false
+                )
+            ])
+        );
+
+        var printer = new Printer({ flowUsesCommas: false });
+        var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+    });
 });

--- a/test/type-syntax.js
+++ b/test/type-syntax.js
@@ -7,7 +7,7 @@ var b = types.builders;
 var eol = require("os").EOL;
 
 describe("type syntax", function() {
-  var printer = new Printer({ tabWidth: 2, quote: 'single' });
+  var printer = new Printer({ tabWidth: 2, quote: 'single', flowUsesCommas: false });
   var parseOptions = {
     parser: require("esprima-fb")
   };

--- a/test/type-syntax.js
+++ b/test/type-syntax.js
@@ -7,7 +7,7 @@ var b = types.builders;
 var eol = require("os").EOL;
 
 describe("type syntax", function() {
-  var printer = new Printer({ tabWidth: 2, quote: 'single', flowUsesCommas: false });
+  var printer = new Printer({ tabWidth: 2, quote: 'single', flowObjectCommas: false });
   var parseOptions = {
     parser: require("esprima-fb")
   };


### PR DESCRIPTION
Currently there are 2 supported syntaxes (`,` and `;`) in Flow Object Types. The use of commas is in line with the more popular style and matches how objects are defined in JS, making it a bit more natural to write. Recently we added a lint rule that enforces the use of commas, so it would great to have this option in recast as well. Thanks! 😃 

cc @cpojer