### PR TITLE
Print parens for nullable union/intersection types

### DIFF
--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -192,8 +192,8 @@ FPp.needsParens = function(assumeExpressionContext) {
         return false;
     }
 
-    // Only expressions need parentheses.
-    if (!n.Expression.check(node)) {
+    // Only statements don't need parentheses.
+    if (n.Statement.check(node)) {
         return false;
     }
 
@@ -288,6 +288,10 @@ FPp.needsParens = function(assumeExpressionContext) {
         default:
             return false;
         }
+
+    case "IntersectionTypeAnnotation":
+    case "UnionTypeAnnotation":
+        return parent.type === "NullableTypeAnnotation";
 
     case "Literal":
         return parent.type === "MemberExpression"

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1345,17 +1345,6 @@ function genericPrintNoParens(path, options, print) {
         return fromString(" & ").join(path.map(print, "types"));
 
     case "NullableTypeAnnotation":
-        if (
-            n.typeAnnotation.type === "UnionTypeAnnotation" ||
-            n.typeAnnotation.type === "IntersectionTypeAnnotation"
-        ) {
-            return concat([
-                "?",
-                "(",
-                path.call(print, "typeAnnotation"),
-                ")"
-            ]);
-        }
         return concat([
             "?",
             path.call(print, "typeAnnotation")

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1345,6 +1345,17 @@ function genericPrintNoParens(path, options, print) {
         return fromString(" & ").join(path.map(print, "types"));
 
     case "NullableTypeAnnotation":
+        if (
+            n.typeAnnotation.type === "UnionTypeAnnotation" ||
+            n.typeAnnotation.type === "IntersectionTypeAnnotation"
+        ) {
+            return concat([
+                "?",
+                "(",
+                path.call(print, "typeAnnotation"),
+                ")"
+            ]);
+        }
         return concat([
             "?",
             path.call(print, "typeAnnotation")

--- a/test/printer.js
+++ b/test/printer.js
@@ -1454,4 +1454,22 @@ describe("printer", function() {
         var pretty = printer.printGenerically(ast).code;
         assert.strictEqual(pretty, code);
     });
+
+    it("prints parens for nullable union/intersection types", function() {
+        var code = "type MyType = ?(string | number);";
+
+        var ast = b.typeAlias(
+            b.identifier("MyType"),
+            null,
+            b.nullableTypeAnnotation(
+                b.unionTypeAnnotation(
+                    [b.stringTypeAnnotation(), b.numberTypeAnnotation()]
+                )
+            )
+        );
+
+        var printer = new Printer({});
+        var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+    });
 });


### PR DESCRIPTION
Add parens for types like `?(string | number)`. Thanks!