### PR TITLE
test(parser,printer): add failing test case

### DIFF
--- a/test/parser.js
+++ b/test/parser.js
@@ -169,4 +169,9 @@ describe("parser", function() {
     check({ esprima: parser });
     check({ parser: parser });
   });
+
+  it("Flow annotation parse", function() {
+    var code = '(props: Props) => {}';
+    assert.doesNotThrow(function() { parse(code) })
+  });
 });

--- a/test/printer.js
+++ b/test/printer.js
@@ -1454,4 +1454,19 @@ describe("printer", function() {
         var pretty = printer.printGenerically(ast).code;
         assert.strictEqual(pretty, code);
     });
+
+    it("print arrowFunctionExpression with single argument and typeAnnotation will added parens", function() {
+        var ast = parse(`props => {}`)
+        var propsParam = b.identifier('props')
+        propsParam.typeAnnotation = b.typeAnnotation(b.genericTypeAnnotation(b.identifier('Props'), null))
+        var arrowFunc = b.arrowFunctionExpression(
+            [propsParam],
+            b.blockStatement([])
+        )
+        ast.program.body[0].expression = arrowFunc
+
+        var printer = new Printer();
+        var pretty = printer.print(ast).code;
+        assert.strictEqual(pretty, '(props: Props) => {}');
+    });
 });


### PR DESCRIPTION
Add two possible failing case:
1) `print` dont add parenthesis for single argument with `typeAnnotation` https://github.com/typeetfunc/recast/blob/master/test/printer.js#L1458. `printGenerically` works properly, but `jscodeshift` use `print` and `printGenerically` doesnt print comments.
2)`parse` dont parse `(props: Props) => {}`. Probably I use it incorrectly.
