### PR TITLE
Fix assumption of declaration property on export

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -111,7 +111,7 @@ util.getTrueLoc = function(node, lines) {
   // If the node is an export declaration and its .declaration has any
   // decorators, their locations might contribute to the true start/end
   // positions of the export declaration node.
-  if (util.isExportDeclaration(node) &&
+  if (node.declaration && util.isExportDeclaration(node) &&
       node.declaration.decorators) {
     node.declaration.decorators.forEach(include);
   }


### PR DESCRIPTION
Not all export declaration nodes have a `declaration` property. e.g. `export { MyObject, MyOtherObject}` has no `declaration` but an array of `specifiers`

When printing it will crash with an `TypeError: Cannot read property 'decorators' of null` error.