### PR TITLE
Fix export trailing semicolon

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1740,7 +1740,12 @@ function printExportDeclaration(path, options, print) {
 
     var lines = concat(parts);
 
-    if (lastNonSpaceCharacter(lines) !== ";") {
+    if (lastNonSpaceCharacter(lines) !== ";" &&
+        (!decl.declaration || (
+          decl.declaration.type !== "FunctionDeclaration" &&
+          decl.declaration.type !== "ClassDeclaration"
+        ))
+    ) {
         lines = concat([lines, ";"]);
     }
 

--- a/test/es6tests.js
+++ b/test/es6tests.js
@@ -105,10 +105,10 @@ describe("import/export syntax", function() {
         check("export default {};");
         check("export default [];");
         check("export default foo;");
-        check("export default function () {};");
-        check("export default class {};");
-        check("export default function foo () {};");
-        check("export default class foo {};");
+        check("export default function () {}");
+        check("export default class {}");
+        check("export default function foo () {}");
+        check("export default class foo {}");
 
         // variables exports
         check("export var foo = 1;");
@@ -117,8 +117,8 @@ describe("import/export syntax", function() {
         check("export let foo = 2;");
         check("export let bar;"); // lazy initialization
         check("export const foo = 3;");
-        check("export function foo () {};");
-        check("export class foo {};");
+        check("export function foo () {}");
+        check("export class foo {}");
 
         // named exports
         check("export {foo};");

--- a/test/printer.js
+++ b/test/printer.js
@@ -538,12 +538,6 @@ describe("printer", function() {
         ast = parse(code);
 
         assert.strictEqual(printer.print(ast).code, code);
-        assert.strictEqual(printer.printGenerically(ast).code, code + ";");
-
-        code = "export function foo() {};";
-        ast = parse(code);
-
-        assert.strictEqual(printer.print(ast).code, code);
         assert.strictEqual(printer.printGenerically(ast).code, code);
     });
 


### PR DESCRIPTION
When printing exported class or function declarations, recast currently prints an unnecessary trailing semicolon. This PR provides a fix to omit them.

These are the only two scenarios I could think of that would not require a semicolon.