### PR TITLE
Update to ast-types 0.8.18

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1424,6 +1424,28 @@ function genericPrintNoParens(path, options, print) {
             fromString(", ").join(path.map(print, "params")),
             ">"
         ]);
+    case "TypeParameter":
+        switch (n.variance) {
+            case 'plus':
+                parts.push('+');
+                break;
+            case 'minus':
+                parts.push('-');
+                break;
+            default:
+        }
+
+        parts.push(path.call(print, 'name'));
+
+        if (n.bound) {
+            parts.push(path.call(print, 'bound'));
+        }
+
+        if (n['default']) {
+            parts.push('=', path.call(print, 'default'));
+        }
+
+        return concat(parts);
 
     case "TypeofTypeAnnotation":
         return concat([
@@ -1436,6 +1458,9 @@ function genericPrintNoParens(path, options, print) {
 
     case "VoidTypeAnnotation":
         return fromString("void", options);
+
+    case "NullTypeAnnotation":
+        return fromString("null", options);
 
     // Unhandled types below. If encountered, nodes of these types should
     // be either left alone or desugared into AST types that are fully

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "fs": false
   },
   "dependencies": {
-    "ast-types": "0.8.17",
+    "ast-types": "0.8.18",
     "esprima": "~2.7.1",
     "private": "~0.1.5",
     "source-map": "~0.5.0"


### PR DESCRIPTION
... to include `TypeParameter` information (https://github.com/benjamn/ast-types/commit/d5ce0400511bdf6b063c13728c4fa09edd9e122d). See also https://github.com/flowtype/flow-codemod/issues/6#issuecomment-233738594 .

This would also require a new (patch) release of recast.