### PR TITLE
Guess line terminators - fixes #269

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,3 @@
 [*.js]
 indent_style = space
+indent_size = 4

--- a/lib/lines.js
+++ b/lib/lines.js
@@ -122,7 +122,7 @@ var leadingSpaceExp = /^\s*/;
 
 // As specified here: http://www.ecma-international.org/ecma-262/6.0/#sec-line-terminators
 var lineTerminatorSeqExp =
-    /\u000D\u000A|\u000D(?!\u000A)|\u000A|\u2028|\u2029/;
+    /\u000D\u000A|\u000D(?!\u000A)|\u000A|\u2028|\u2029/g;
 
 /**
  * @param {Object} options - Options object that configures printing.
@@ -143,6 +143,7 @@ function fromString(string, options) {
     if (cacheable && hasOwn.call(fromStringCache, string))
         return fromStringCache[string];
 
+    var terminators = string.match(lineTerminatorSeqExp) || [];
     var lines = new Lines(string.split(lineTerminatorSeqExp).map(function(line) {
         var spaces = leadingSpaceExp.exec(line)[0];
         return {
@@ -157,6 +158,8 @@ function fromString(string, options) {
 
     if (cacheable)
         fromStringCache[string] = lines;
+
+    getSecret(lines).terminators = terminators;
 
     return lines;
 }
@@ -330,6 +333,8 @@ Lp.stripMargin = function(width, skipFirstLine) {
         });
     }
 
+    getSecret(lines).terminators = terminators;
+
     return lines;
 };
 
@@ -354,6 +359,8 @@ Lp.indent = function(by) {
             newMappings.push(mapping.indent(by));
         });
     }
+
+    getSecret(lines).terminators = secret.terminators;
 
     return lines;
 };
@@ -384,6 +391,8 @@ Lp.indentTail = function(by) {
         });
     }
 
+    getSecret(lines).terminators = secret.terminators;
+
     return lines;
 };
 
@@ -392,13 +401,16 @@ Lp.lockIndentTail = function () {
         return this;
     }
 
-    var infos = getSecret(this).infos;
-
-    return new Lines(infos.map(function (info, i) {
+    var secret = getSecret(this);
+    var lines = new Lines(secret.infos.map(function (info, i) {
         info = copyLineInfo(info);
         info.locked = i > 0;
         return info;
     }));
+
+    getSecret(lines).terminators = secret.terminators;
+
+    return lines;
 };
 
 Lp.getIndentAt = function(line) {
@@ -658,6 +670,8 @@ Lp.slice = function(start, end) {
         }, this);
     }
 
+    getSecret(lines).terminators = secret.terminators.slice(start.line - 1, end.line);
+
     return lines;
 };
 
@@ -713,6 +727,24 @@ function sliceInfo(info, startCol, endCol) {
     };
 }
 
+function guessLineTerminator(terminators) {
+    var seen = {};
+
+    var max = 0;
+    var term = null;
+
+    terminators.forEach(function(terminator) {
+        var count = (seen[terminator] || 0) + 1;
+        if (count > max) {
+            max = count;
+            term = terminator;
+        }
+        seen[terminator] = count;
+    });
+
+    return term;
+}
+
 Lp.bootstrapSliceString = function(start, end, options) {
     return this.slice(start, end).toString(options);
 };
@@ -730,9 +762,12 @@ Lp.sliceString = function(start, end, options) {
         end = this.lastPos();
     }
 
+    var lineTerminator;
+    var explicitLineTerminator = options && options.lineTerminator;
     options = normalizeOptions(options);
 
-    var infos = getSecret(this).infos;
+    var secret = getSecret(this);
+    var infos = secret.infos;
     var parts = [];
     var tabWidth = options.tabWidth;
 
@@ -783,7 +818,15 @@ Lp.sliceString = function(start, end, options) {
         parts.push(result);
     }
 
-    return parts.join(options.lineTerminator);
+    if (!explicitLineTerminator) {
+        lineTerminator = guessLineTerminator(secret.terminators);
+    }
+
+    if (!lineTerminator) {
+        lineTerminator = options.lineTerminator;
+    }
+
+    return parts.join(lineTerminator);
 };
 
 Lp.isEmpty = function() {
@@ -795,6 +838,7 @@ Lp.join = function(elements) {
     var separatorSecret = getSecret(separator);
     var infos = [];
     var mappings = [];
+    var terminators = [];
     var prevInfo;
 
     function appendSecret(secret) {
@@ -828,6 +872,8 @@ Lp.join = function(elements) {
             mappings.push.apply(mappings, secret.mappings);
         }
 
+        terminators.push.apply(terminators, secret.terminators);
+
         secret.infos.forEach(function(info, i) {
             if (!prevInfo || i > 0) {
                 prevInfo = copyLineInfo(info);
@@ -857,6 +903,7 @@ Lp.join = function(elements) {
     var lines = new Lines(infos);
 
     getSecret(lines).mappings = mappings;
+    getSecret(lines).terminators = terminators;
 
     return lines;
 };

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -47,6 +47,7 @@ var emptyPrintResult = new PrintResult("");
 function Printer(originalOptions) {
     assert.ok(this instanceof Printer);
 
+    var explicitLineTerminator = originalOptions && originalOptions.lineTerminator;
     var explicitTabWidth = originalOptions && originalOptions.tabWidth;
     var options = normalizeOptions(originalOptions);
     assert.notStrictEqual(options, originalOptions);
@@ -116,6 +117,10 @@ function Printer(originalOptions) {
         }
 
         var lines = print(FastPath.from(ast), true);
+
+        if (!explicitLineTerminator) {
+            delete options.lineTerminator;
+        }
 
         return new PrintResult(
             lines.toString(options),

--- a/test/printer.js
+++ b/test/printer.js
@@ -1285,6 +1285,41 @@ describe("printer", function() {
         );
     });
 
+    it("correctly guesses lineTerminator", function() {
+        ['\n', '\r\n'].forEach(function(term) {
+            var lines = [
+                "var first = 1;",
+                "var second = 2;"
+            ];
+            var code = lines.join(term);
+            var ast = parse(code);
+
+            assert.strictEqual(
+                new Printer().print(ast).code,
+                lines.join(term)
+            );
+        });
+    });
+
+    it("correctly guesses lineTerminator with mixed endings", function() {
+        var code =
+            "var first = 1\n" +
+            "var second = 2\n" +
+            "var third = 3\r\n" +
+            "var fourth = 4\n" +
+            "var fifth = 5\r\n";
+        var ast = parse(code);
+
+        assert.strictEqual(
+            new Printer().print(ast).code,
+            "var first = 1\n" +
+            "var second = 2\n" +
+            "var third = 3\n" +
+            "var fourth = 4\n" +
+            "var fifth = 5\n"
+        );
+    });
+
     it("preserves indentation in unmodified template expressions", function() {
         var printer = new Printer({
             tabWidth: 2


### PR DESCRIPTION
Uses the most commonly found line ending in the source as the terminators for the whole output. Hopefully it handles splitting and joining bunches of lines properly too.

Note: I have tested this relatively limited, with [mohebifar/lebab](https://github.com/mohebifar/lebab). Could do with being dropped into something more complicated for a more thorough test.