### PR TITLE
Add spaces around `=` in AssignmentPattern (default parameters)

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -251,7 +251,7 @@ function genericPrintNoParens(path, options, print) {
     case "AssignmentPattern":
         return concat([
             path.call(print, "left"),
-            "=",
+            " = ",
             path.call(print, "right")
         ]);
 
@@ -1712,7 +1712,7 @@ function printFunctionParams(path, options, print) {
             var i = defExprPath.getName();
             var p = printed[i];
             if (p && defExprPath.getValue()) {
-                printed[i] = concat([p, "=", print(defExprPath)]);
+                printed[i] = concat([p, " = ", print(defExprPath)]);
             }
         }, "defaults");
     }

--- a/test/printer.js
+++ b/test/printer.js
@@ -487,7 +487,7 @@ describe("printer", function() {
 
         assert.strictEqual(
             printer.print(funExpr).code,
-            "function a(b, c=1, ...d) {}"
+            "function a(b, c = 1, ...d) {}"
         );
 
         var arrowFunExpr = b.arrowFunctionExpression(
@@ -503,7 +503,7 @@ describe("printer", function() {
 
         assert.strictEqual(
             printer.print(arrowFunExpr).code,
-            "(b, c=1, ...d) => {}"
+            "(b, c = 1, ...d) => {}"
         );
     });
 
@@ -886,7 +886,7 @@ describe("printer", function() {
 
     it("should support AssignmentPattern and RestElement", function() {
         var code = [
-            "function foo(a, [b, c]=d(a), ...[e, f, ...rest]) {",
+            "function foo(a, [b, c] = d(a), ...[e, f, ...rest]) {",
             "  return [a, b, c, e, f, rest];",
             "}"
         ].join(eol);


### PR DESCRIPTION
This is a minor stylistic change that adds spaces around `=` in function default parameters. Not sure if you'll take it but it's more aligned with the modern code styles/guidelines. Thanks!