### PR TITLE
Enable JSX by default

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -24,6 +24,7 @@ exports.parse = function parse(source, options) {
 
     var comments = [];
     var program = options.parser.parse(sourceWithoutTabs, {
+        jsx: true,
         loc: true,
         locations: true,
         range: options.range,

--- a/test/jsx.js
+++ b/test/jsx.js
@@ -4,13 +4,10 @@ var types = require("../lib/types");
 
 describe("JSX Compatability", function() {
   var printer = new Printer({ tabWidth: 2 });
-  var parseOptions = {
-    parser: require("esprima-fb")
-  };
 
   function check(source) {
-    var ast1 = parse(source, parseOptions);
-    var ast2 = parse(printer.printGenerically(ast1).code, parseOptions);
+    var ast1 = parse(source);
+    var ast2 = parse(printer.printGenerically(ast1).code);
     types.astNodesAreEquivalent.assert(ast1, ast2);
   }
 


### PR DESCRIPTION
This is possible with the switch to Esprima 3.0 (PR #312).