### PR TITLE
Allow more granular control of trailing commas

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -60,9 +60,19 @@ var defaults = {
     // Otherwise, double quotes are used.
     quote: null,
 
-    // If you want to print trailing commas in object literals,
-    // array expressions, functions calls and function definitions pass true
-    // for this option.
+    // Controls the printing of trailing commas in object literals,
+    // array expressions and function parameters.
+    //
+    // This option could either be:
+    // * Boolean - enable/disable in all contexts (objects, arrays and function params).
+    // * Object - enable/disable per context.
+    //
+    // Example:
+    // trailingComma: {
+    //   objects: true,
+    //   arrays: true,
+    //   parameters: false,
+    // }
     trailingComma: false,
 
     // If you want parenthesis to wrap single-argument arrow function parameter

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -608,7 +608,7 @@ function genericPrintNoParens(path, options, print) {
                     allowBreak = !multiLine;
                 } else if (len !== 1 && isTypeAnnotation) {
                     parts.push(separator);
-                } else if (!oneLine && options.trailingComma) {
+                } else if (!oneLine && util.isTrailingCommaEnabled(options, "objects")) {
                     parts.push(separator);
                 }
                 i++;
@@ -678,7 +678,7 @@ function genericPrintNoParens(path, options, print) {
                     lines = lines.indent(options.tabWidth);
                 }
                 parts.push(lines);
-                if (i < len - 1 || (!oneLine && options.trailingComma))
+                if (i < len - 1 || (!oneLine && util.isTrailingCommaEnabled(options, "arrays")))
                     parts.push(",");
                 if (!oneLine)
                     parts.push("\n");
@@ -1687,6 +1687,7 @@ function printMethod(path, options, print) {
 
 function printArgumentsList(path, options, print) {
     var printed = path.map(print, "arguments");
+    var trailingComma = util.isTrailingCommaEnabled(options, "parameters");
 
     var joined = fromString(", ").join(printed);
     if (joined.getLineLength(1) > options.wrapColumn) {
@@ -1694,7 +1695,7 @@ function printArgumentsList(path, options, print) {
         return concat([
             "(\n",
             joined.indent(options.tabWidth),
-            options.trailingComma ? ",\n)" : "\n)"
+            trailingComma ? ",\n)" : "\n)"
         ]);
     }
 
@@ -1725,7 +1726,7 @@ function printFunctionParams(path, options, print) {
     if (joined.length > 1 ||
         joined.getLineLength(1) > options.wrapColumn) {
         joined = fromString(",\n").join(printed);
-        if (options.trailingComma && !fun.rest) {
+        if (util.isTrailingCommaEnabled(options, "parameters") && !fun.rest) {
             joined = concat([joined, ",\n"]);
         } else {
             joined = concat([joined, "\n"]);

--- a/lib/util.js
+++ b/lib/util.js
@@ -296,3 +296,11 @@ util.getParentExportDeclaration = function (path) {
 
   return null;
 };
+
+util.isTrailingCommaEnabled = function(options, context) {
+  var trailingComma = options.trailingComma;
+  if (typeof trailingComma === "object") {
+    return !!trailingComma[context];
+  }
+  return !!trailingComma;
+};

--- a/test/printer.js
+++ b/test/printer.js
@@ -815,6 +815,15 @@ describe("printer", function() {
 
         var pretty = printer.printGenerically(ast).code;
         assert.strictEqual(pretty, code);
+
+        // It should also work when using the `trailingComma` option as an object.
+        printer = new Printer({
+          tabWidth: 2,
+          trailingComma: { objects: true },
+        });
+
+        pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
     });
 
     it("prints trailing commas in function calls", function() {
@@ -837,6 +846,16 @@ describe("printer", function() {
         });
 
         var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+
+        // It should also work when using the `trailingComma` option as an object.
+        printer = new Printer({
+          tabWidth: 2,
+          wrapColumn: 1,
+          trailingComma: { parameters: true },
+        });
+
+        pretty = printer.printGenerically(ast).code;
         assert.strictEqual(pretty, code);
     });
 
@@ -861,6 +880,16 @@ describe("printer", function() {
 
         var pretty = printer.printGenerically(ast).code;
         assert.strictEqual(pretty, code);
+
+        // It should also work when using the `trailingComma` option as an object.
+        printer = new Printer({
+          tabWidth: 2,
+          wrapColumn: 1,
+          trailingComma: { arrays: true },
+        });
+
+        pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
     });
 
     it("prints trailing commas in function definitions", function() {
@@ -883,6 +912,16 @@ describe("printer", function() {
         });
 
         var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+
+        // It should also work when using the `trailingComma` option as an object.
+        printer = new Printer({
+          tabWidth: 2,
+          wrapColumn: 1,
+          trailingComma: { parameters: true },
+        });
+
+        pretty = printer.printGenerically(ast).code;
         assert.strictEqual(pretty, code);
     });
 


### PR DESCRIPTION
Issue #335

The `trailingComma` option accepts an object that provides more granular control of where to enable/disable trailing commas.

e.g.
```javascript
trailingComma: {
  objects: true, // Enable trailing commas in objects.
  arrays: true, // Enable trailing commas in arrays.
  parameters: false, // Disable trailing commas in function parameters.
}
```