### PR TITLE
A RestElement should not have a trailing comma

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1825,11 +1825,9 @@ function printFunctionParams(path, options, print) {
     if (joined.length > 1 ||
         joined.getLineLength(1) > options.wrapColumn) {
         joined = fromString(",\n").join(printed);
-        if (
-          util.isTrailingCommaEnabled(options, "parameters") &&
-          !fun.rest &&
-          fun.params[fun.params.length - 1].type !== 'RestElement'
-        ) {
+        if (util.isTrailingCommaEnabled(options, "parameters") &&
+            !fun.rest &&
+            fun.params[fun.params.length - 1].type !== 'RestElement') {
             joined = concat([joined, ",\n"]);
         } else {
             joined = concat([joined, "\n"]);

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1825,7 +1825,11 @@ function printFunctionParams(path, options, print) {
     if (joined.length > 1 ||
         joined.getLineLength(1) > options.wrapColumn) {
         joined = fromString(",\n").join(printed);
-        if (util.isTrailingCommaEnabled(options, "parameters") && !fun.rest) {
+        if (
+          util.isTrailingCommaEnabled(options, "parameters") &&
+          !fun.rest &&
+          fun.params[fun.params.length - 1].type !== 'RestElement'
+        ) {
             joined = concat([joined, ",\n"]);
         } else {
             joined = concat([joined, "\n"]);

--- a/test/printer.js
+++ b/test/printer.js
@@ -925,6 +925,30 @@ describe("printer", function() {
         assert.strictEqual(pretty, code);
     });
 
+    it("shouldn't print a trailing comma for a RestElement", function() {
+        var code = [
+            "function foo(",
+            "  a,",
+            "  b,",
+            "  ...rest",
+            ") {}"
+        ].join(eol);
+
+        var ast = parse(code, {
+            // The flow parser and Babylon recognize `...rest` as a `RestElement`
+            parser: require("babylon")
+        });
+
+        var printer = new Printer({
+            tabWidth: 2,
+            wrapColumn: 1,
+            trailingComma: true,
+        });
+
+        var pretty = printer.printGenerically(ast).code;
+        assert.strictEqual(pretty, code);
+    });
+
     it("should support AssignmentPattern and RestElement", function() {
         var code = [
             "function foo(a, [b, c] = d(a), ...[e, f, ...rest]) {",


### PR DESCRIPTION
Seems like the Flow parser and Babylon all recognize `...rest` as a `RestElement`. Which parser uses `.rest` to represent it? :)