### PR TITLE
Allow more granular control of spaces inside arrays/objects

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -75,22 +75,14 @@ var defaults = {
     // }
     trailingComma: false,
 
-    // Controls the printing of spaces inside array brackets and braces of
-    // object literals, destructuring assignments, and import/export specifiers.
-    //
-    // This option could either be:
-    // * Boolean - enable/disable in all contexts (object and arrays).
-    // * Object - enable/disable per context.
-    //
-    // Example:
-    // spacing: {
-    //   objects: true,
-    //   arrays: true,
-    // }
-    spacing: {
-      objects: true,
-      arrays: false,
-    },
+    // Controls the printing of spaces inside array brackets.
+    // See: http://eslint.org/docs/rules/array-bracket-spacing
+    arrayBracketSpacing: false,
+
+    // Controls the printing of spaces inside object literals,
+    // destructuring assignments, and import/export specifiers.
+    // See: http://eslint.org/docs/rules/object-curly-spacing
+    objectCurlySpacing: true,
 
     // If you want parenthesis to wrap single-argument arrow function parameter
     // lists, pass true for this option.
@@ -127,7 +119,8 @@ exports.normalize = function(options) {
         tolerant: get("tolerant"),
         quote: get("quote"),
         trailingComma: get("trailingComma"),
-        spacing: get("spacing"),
+        arrayBracketSpacing: get("arrayBracketSpacing"),
+        objectCurlySpacing: get("objectCurlySpacing"),
         arrowParensAlways: get("arrowParensAlways"),
         flowObjectCommas: get("flowObjectCommas"),
     };

--- a/lib/options.js
+++ b/lib/options.js
@@ -75,6 +75,23 @@ var defaults = {
     // }
     trailingComma: false,
 
+    // Controls the printing of spaces inside array brackets and braces of
+    // object literals, destructuring assignments, and import/export specifiers.
+    //
+    // This option could either be:
+    // * Boolean - enable/disable in all contexts (object and arrays).
+    // * Object - enable/disable per context.
+    //
+    // Example:
+    // spacing: {
+    //   objects: true,
+    //   arrays: true,
+    // }
+    spacing: {
+      objects: true,
+      arrays: false,
+    },
+
     // If you want parenthesis to wrap single-argument arrow function parameter
     // lists, pass true for this option.
     arrowParensAlways: false,
@@ -110,6 +127,7 @@ exports.normalize = function(options) {
         tolerant: get("tolerant"),
         quote: get("quote"),
         trailingComma: get("trailingComma"),
+        spacing: get("spacing"),
         arrowParensAlways: get("arrowParensAlways"),
         flowObjectCommas: get("flowObjectCommas"),
     };

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -514,7 +514,7 @@ function genericPrintNoParens(path, options, print) {
                     if (!foundImportSpecifier) {
                         foundImportSpecifier = true;
                         parts.push(
-                          util.isSpacingEnabled(options, "objects") ? "{ " : "{"
+                          options.objectCurlySpacing ? "{ " : "{"
                         );
                     }
                 }
@@ -524,7 +524,7 @@ function genericPrintNoParens(path, options, print) {
 
             if (foundImportSpecifier) {
                 parts.push(
-                  util.isSpacingEnabled(options, "objects") ? " }" : "}"
+                  options.objectCurlySpacing ? " }" : "}"
                 );
             }
 
@@ -649,7 +649,7 @@ function genericPrintNoParens(path, options, print) {
 
         parts.push(oneLine ? rightBrace : "\n" + rightBrace);
 
-        if (i !== 0 && oneLine && util.isSpacingEnabled(options, "objects")) {
+        if (i !== 0 && oneLine && options.objectCurlySpacing) {
             parts[leftBraceIndex] = leftBrace + " ";
             parts[parts.length - 1] = " " + rightBrace;
         }
@@ -704,7 +704,7 @@ function genericPrintNoParens(path, options, print) {
         var joined = fromString(", ").join(printed);
         var oneLine = joined.getLineLength(1) <= options.wrapColumn;
         if (oneLine) {
-          if (util.isSpacingEnabled(options, "arrays")) {
+          if (options.arrayBracketSpacing) {
             parts.push("[ ");
           } else {
             parts.push("[");
@@ -739,7 +739,7 @@ function genericPrintNoParens(path, options, print) {
             }
         }, "elements");
 
-        if (oneLine && util.isSpacingEnabled(options, "arrays")) {
+        if (oneLine && options.arrayBracketSpacing) {
           parts.push(" ]");
         } else {
           parts.push("]");
@@ -1888,7 +1888,7 @@ function printObjectMethod(path, options, print) {
 function printExportDeclaration(path, options, print) {
     var decl = path.getValue();
     var parts = ["export "];
-    var shouldPrintSpaces = util.isSpacingEnabled(options, "objects");
+    var shouldPrintSpaces = options.objectCurlySpacing;
 
     namedTypes.Declaration.assert(decl);
 

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -513,7 +513,9 @@ function genericPrintNoParens(path, options, print) {
                     namedTypes.ImportSpecifier.assert(value);
                     if (!foundImportSpecifier) {
                         foundImportSpecifier = true;
-                        parts.push("{");
+                        parts.push(
+                          util.isSpacingEnabled(options, "objects") ? "{ " : "{"
+                        );
                     }
                 }
 
@@ -521,7 +523,9 @@ function genericPrintNoParens(path, options, print) {
             }, "specifiers");
 
             if (foundImportSpecifier) {
-                parts.push("}");
+                parts.push(
+                  util.isSpacingEnabled(options, "objects") ? " }" : "}"
+                );
             }
 
             parts.push(" from ");
@@ -645,7 +649,7 @@ function genericPrintNoParens(path, options, print) {
 
         parts.push(oneLine ? rightBrace : "\n" + rightBrace);
 
-        if (i !== 0 && oneLine) {
+        if (i !== 0 && oneLine && util.isSpacingEnabled(options, "objects")) {
             parts[leftBraceIndex] = leftBrace + " ";
             parts[parts.length - 1] = " " + rightBrace;
         }
@@ -699,7 +703,15 @@ function genericPrintNoParens(path, options, print) {
         var printed = path.map(print, "elements");
         var joined = fromString(", ").join(printed);
         var oneLine = joined.getLineLength(1) <= options.wrapColumn;
-        parts.push(oneLine ? "[" : "[\n");
+        if (oneLine) {
+          if (util.isSpacingEnabled(options, "arrays")) {
+            parts.push("[ ");
+          } else {
+            parts.push("[");
+          }
+        } else {
+          parts.push("[\n");
+        }
 
         path.each(function(elemPath) {
             var i = elemPath.getName();
@@ -727,7 +739,11 @@ function genericPrintNoParens(path, options, print) {
             }
         }, "elements");
 
-        parts.push("]");
+        if (oneLine && util.isSpacingEnabled(options, "arrays")) {
+          parts.push(" ]");
+        } else {
+          parts.push("]");
+        }
 
         return concat(parts);
 
@@ -1872,6 +1888,7 @@ function printObjectMethod(path, options, print) {
 function printExportDeclaration(path, options, print) {
     var decl = path.getValue();
     var parts = ["export "];
+    var shouldPrintSpaces = util.isSpacingEnabled(options, "objects");
 
     namedTypes.Declaration.assert(decl);
 
@@ -1891,9 +1908,9 @@ function printExportDeclaration(path, options, print) {
             parts.push("*");
         } else {
             parts.push(
-                "{",
+                shouldPrintSpaces ? "{ " : "{",
                 fromString(", ").join(path.map(print, "specifiers")),
-                "}"
+                shouldPrintSpaces ? " }" : "}"
             );
         }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -304,3 +304,11 @@ util.isTrailingCommaEnabled = function(options, context) {
   }
   return !!trailingComma;
 };
+
+util.isSpacingEnabled = function(options, context) {
+  var spacing = options.spacing;
+  if (typeof spacing === "object") {
+    return !!spacing[context];
+  }
+  return !!spacing;
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -304,11 +304,3 @@ util.isTrailingCommaEnabled = function(options, context) {
   }
   return !!trailingComma;
 };
-
-util.isSpacingEnabled = function(options, context) {
-  var spacing = options.spacing;
-  if (typeof spacing === "object") {
-    return !!spacing[context];
-  }
-  return !!spacing;
-};

--- a/test/printer.js
+++ b/test/printer.js
@@ -1507,4 +1507,78 @@ describe("printer", function() {
         var pretty = printer.printGenerically(ast).code;
         assert.strictEqual(pretty, code);
     });
+
+    it("uses the `spacing` option to determine whether it should print spaces", function() {
+      var babylon = require("babylon");
+      var parseOptions = {
+        parser: {
+          parse: function (source) {
+            return babylon.parse(source, {
+              sourceType: 'module',
+              plugins: ['flow'],
+            });
+          }
+        }
+      };
+
+      var testCaseList = [{
+        printerConfig: {spacing: false},
+        code: [
+          'import {java, script} from "javascript";',
+          '',
+          'function foo(a) {',
+          '    type MyType = {message: string};',
+          '    return [1, 2, 3];',
+          '}',
+          '',
+          'export {foo};'
+        ].join(eol)
+      }, {
+        printerConfig: {spacing: {arrays: true}},
+        code: [
+          'import {java, script} from "javascript";',
+          '',
+          'function foo(a) {',
+          '    type MyType = {message: string};',
+          '    return [ 1, 2, 3 ];',
+          '}',
+          '',
+          'export {foo};'
+        ].join(eol)
+      }, {
+        printerConfig: {spacing: {objects: true}},
+        code: [
+          'import { java, script } from "javascript";',
+          '',
+          'function foo(a) {',
+          '    type MyType = { message: string };',
+          '    return [1, 2, 3];',
+          '}',
+          '',
+          'export { foo };'
+        ].join(eol)
+      }, {
+        printerConfig: {spacing: true},
+        code: [
+          'import { java, script } from "javascript";',
+          '',
+          'function foo(a) {',
+          '    type MyType = { message: string };',
+          '    return [ 1, 2, 3 ];',
+          '}',
+          '',
+          'export { foo };'
+        ].join(eol)
+      }];
+
+      testCaseList.forEach(function(testCase) {
+        var code = testCase.code;
+        var printer = new Printer(testCase.printerConfig);
+
+        var ast = parse(code, parseOptions);
+        var pretty = printer.printGenerically(ast).code;
+
+        assert.strictEqual(pretty, code);
+      });
+    });
 });

--- a/test/printer.js
+++ b/test/printer.js
@@ -1508,7 +1508,7 @@ describe("printer", function() {
         assert.strictEqual(pretty, code);
     });
 
-    it("uses the `spacing` option to determine whether it should print spaces", function() {
+    it("uses the `arrayBracketSpacing` and the `objectCurlySpacing` option", function() {
       var babylon = require("babylon");
       var parseOptions = {
         parser: {
@@ -1522,7 +1522,7 @@ describe("printer", function() {
       };
 
       var testCaseList = [{
-        printerConfig: {spacing: false},
+        printerConfig: {arrayBracketSpacing: false, objectCurlySpacing: false},
         code: [
           'import {java, script} from "javascript";',
           '',
@@ -1534,7 +1534,7 @@ describe("printer", function() {
           'export {foo};'
         ].join(eol)
       }, {
-        printerConfig: {spacing: {arrays: true}},
+        printerConfig: {arrayBracketSpacing: true, objectCurlySpacing: false},
         code: [
           'import {java, script} from "javascript";',
           '',
@@ -1546,7 +1546,7 @@ describe("printer", function() {
           'export {foo};'
         ].join(eol)
       }, {
-        printerConfig: {spacing: {objects: true}},
+        printerConfig: {arrayBracketSpacing: false, objectCurlySpacing: true},
         code: [
           'import { java, script } from "javascript";',
           '',
@@ -1558,7 +1558,7 @@ describe("printer", function() {
           'export { foo };'
         ].join(eol)
       }, {
-        printerConfig: {spacing: true},
+        printerConfig: {arrayBracketSpacing: true, objectCurlySpacing: true},
         code: [
           'import { java, script } from "javascript";',
           '',


### PR DESCRIPTION
Let's make everyone happy 😎 . The idea is from #336.

The `spacing` option controls the printing of spaces inside array brackets and braces of object literals, destructuring assignments, and import/export specifiers.

This option could either be:
* Boolean - enable/disable in all contexts (object and arrays).
* Object - enable/disable per context.

Example:
```js
spacing: {
  objects: true,
  arrays: false,
},
```

cc @hzoo 