### PR TITLE
Print comments when using the generic printer

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -107,7 +107,7 @@ function Printer(originalOptions) {
 
     // Print the entire AST generically.
     function printGenerically(path) {
-        return genericPrint(path, options, printGenerically);
+        return printComments(path, p => genericPrint(path, options, printGenerically));
     }
 
     this.print = function(ast) {

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -107,7 +107,9 @@ function Printer(originalOptions) {
 
     // Print the entire AST generically.
     function printGenerically(path) {
-        return printComments(path, p => genericPrint(path, options, printGenerically));
+        return printComments(path, function (path) {
+            return genericPrint(path, options, printGenerically);
+        });
     }
 
     this.print = function(ast) {


### PR DESCRIPTION
I noticed that if you use the generic pretty printer it doesn't keep the comments. I'm not sure if this is the right approach, but it works?