### PR TITLE
Surround arrow functions with parenthesis when binding

### DIFF
--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -326,10 +326,12 @@ FPp.needsParens = function(assumeExpressionContext) {
         }
 
     case "ArrowFunctionExpression":
-        if(parent.type === 'CallExpression' && 
-           name === 'callee') {
+        if(n.CallExpression.check(parent) && name === 'callee') {
             return true;
-        };
+        }
+        if(n.MemberExpression.check(parent) && name === 'object') {
+            return true;
+        }
 
         return isBinary(parent);
 

--- a/test/parens.js
+++ b/test/parens.js
@@ -283,4 +283,8 @@ describe("parens", function() {
         check("(()=>{})()");
         check("(function(){})()");
     });
+
+    it("should be added to bound arrow function expressions", function() {
+        check("(()=>{}).bind(x)");
+    });
 });

--- a/test/printer.js
+++ b/test/printer.js
@@ -1035,6 +1035,31 @@ describe("printer", function() {
       assert.strictEqual(pretty, code);
     });
 
+    it("adds parenthesis around arrow function when binding", function() {
+      var code = "var a = (x => y).bind(z);";
+
+      var fn = b.arrowFunctionExpression(
+          [b.identifier("x")],
+          b.identifier("y")
+      );
+
+      var declaration = b.variableDeclaration("var", [
+          b.variableDeclarator(
+              b.identifier("a"),
+              b.callExpression(
+                  b.memberExpression(fn, b.identifier("bind"), false),
+                  [b.identifier("z")]
+              )
+          )
+      ]);
+
+      var ast = b.program([declaration]);
+
+      var printer = new Printer();
+      var pretty = printer.printGenerically(ast).code;
+      assert.strictEqual(pretty, code);
+    });
+
     it("adds parenthesis around async arrow functions with args", function() {
         var code = "async () => {};";
 


### PR DESCRIPTION
Fixes the critical, long standing issue: #264 
Also fixes https://github.com/lebab/lebab/issues/105