### PR TITLE
`allowBreak` adds an extra newline.

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -637,7 +637,10 @@ function genericPrintNoParens(path, options, print) {
                     // Add an extra line break if the previous object property
                     // had a multi-line value.
                     parts.push(separator + (multiLine ? "\n\n" : "\n"));
-                    allowBreak = !multiLine;
+                    /*
+                        Commenting this passes my test case and breaks nothing else.
+                        allowBreak = !multiLine;
+                    */
                 } else if (len !== 1 && isTypeAnnotation) {
                     parts.push(separator);
                 } else if (!oneLine && util.isTrailingCommaEnabled(options, "objects")) {

--- a/test/printer.js
+++ b/test/printer.js
@@ -364,6 +364,32 @@ describe("printer", function() {
         ].join(eol));
     });
 
+    it("MultiLineVarWithObjPrinting", function() {
+        var printer = new Printer({ tabWidth: 2 });
+        var varDecl = b.variableDeclaration("var", [
+            b.variableDeclarator(b.identifier("x"), null),
+            b.variableDeclarator(
+                b.identifier("y"),
+                b.objectExpression([
+                    b.property("init", b.identifier("why"), b.literal("not")),
+                    b.property("init", b.identifier("options"), b.objectExpression([b.property("init", b.identifier("what"), b.literal("else"))]))
+                ])
+            ),
+            b.variableDeclarator(b.identifier("z"), null)
+        ]);
+
+        assert.strictEqual(printer.print(b.program([varDecl])).code, [
+            "var x,",
+            "    y = {",
+            "      why: \"not\",",
+            "      options: {",
+            "        what: \"else\"",
+            "      }",
+            "    },",
+            "    z;"
+        ].join(eol));
+    });
+
     it("ForLoopPrinting", function() {
         var printer = new Printer({ tabWidth: 2 });
         var loop = b.forStatement(


### PR DESCRIPTION
I was facing this issue in [this example](http://astexplorer.net/#/iBjDDgDrsg) , where if an `ObjectExpression` has a property of type `ObjectExpression` then the printer adds an extra new line on the property.

Added a test case for the printer where you can see it fails.
Added a fix for it where if I don't set `allowBreak`, no other test fails and my test passes.
The variables `multiLine`, `allowBreak`, `oneLine` are not clear to me. How can I fix this properly?