### PR TITLE
Add sourceFileName passthrough to File node

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -63,7 +63,7 @@ exports.parse = function parse(source, options) {
     // comments, wrap the original Program node with a File node.
     var file = program;
     if (file.type === "Program") {
-        var file = b.file(program);
+        var file = b.file(program, options.sourceFileName);
         file.loc = {
             lines: lines,
             indent: 0,

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -63,7 +63,7 @@ exports.parse = function parse(source, options) {
     // comments, wrap the original Program node with a File node.
     var file = program;
     if (file.type === "Program") {
-        var file = b.file(program, options.sourceFileName);
+        var file = b.file(program, options.sourceFileName || null);
         file.loc = {
             lines: lines,
             indent: 0,


### PR DESCRIPTION
This PR passes the `sourceFileName` through to the `File` node in `ast-types`.

It is dependant on `name` being added as an optional attribute to the `File` node. It thankfully is backwards compatible (in that it won't break anything) as it appears `ast-types` ignores any extra params.

The `ast-types` PR can be found at https://github.com/benjamn/ast-types/pull/200. More details of its use case there.