### PR TITLE
chore(package): use compatible version for ast-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "fs": false
   },
   "dependencies": {
-    "ast-types": "0.9.2",
+    "ast-types": "^0.9.2",
     "esprima": "~3.1.0",
     "private": "~0.1.5",
     "source-map": "~0.5.0"


### PR DESCRIPTION
Using a fixed version prevent dependencies deduplication in a project.

If someone wants to fix dependencies, it should use `yarn` or `npm shrinkwrap`.