### PR TITLE
Add option to avoid copying the AST

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -92,6 +92,11 @@ var defaults = {
     // The use of commas is in line with the more popular style and matches
     // how objects are defined in JS, making it a bit more natural to write.
     flowObjectCommas: true,
+
+    // By default, recast copies the entire AST so you can compare
+    // changes. This has a significant performance cost, however, so
+    // you can turn it off it you don't need it.
+    copyAST: true,
 }, hasOwn = defaults.hasOwnProperty;
 
 // Copy options and fill in default values.
@@ -123,5 +128,6 @@ exports.normalize = function(options) {
         objectCurlySpacing: get("objectCurlySpacing"),
         arrowParensAlways: get("arrowParensAlways"),
         flowObjectCommas: get("flowObjectCommas"),
+        copyAST: !!get("copyAST")
     };
 };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -84,8 +84,12 @@ exports.parse = function parse(source, options) {
     );
 
     // Return a copy of the original AST so that any changes made may be
-    // compared to the original.
-    return new TreeCopier(lines).copy(file);
+  // compared to the original.
+    if(options.copyAST) {
+      return new TreeCopier(lines).copy(file);
+    } else {
+      return file;
+    }
 };
 
 function TreeCopier(lines) {


### PR DESCRIPTION
In my project, I'm using recast to parse a large file. The file is 2000 lines long. Running my project takes ~970ms. I profiled it under Chrome:

<img width="772" alt="screen shot 2017-01-09 at 2 47 46 pm" src="https://cloud.githubusercontent.com/assets/17031/21780743/c2b982b8-d67a-11e6-9308-2d243b3e7feb.png">

You can see the `TCp.copy` function is taking a large chunk of the time. I looked into it and it's because recast copies the entire ast before returning it. Turning this off, my project runs in ~660ms, about 2/3 the time. Copying a big AST has a big performance penalty so I think it's worth making this an option, and possibly even defaulting to `false`.

Should the default be `false`? If so many projects using recast would see a 30% perf bump.