### PR TITLE
Fix precedence of exponentiation operator

### DIFF
--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -380,7 +380,8 @@ var PRECEDENCE = {};
  ["<", ">", "<=", ">=", "in", "instanceof"],
  [">>", "<<", ">>>"],
  ["+", "-"],
- ["*", "/", "%", "**"]
+ ["*", "/", "%"],
+ ["**"]
 ].forEach(function(tier, i) {
     tier.forEach(function(op) {
         PRECEDENCE[op] = i;

--- a/test/babylon.js
+++ b/test/babylon.js
@@ -314,24 +314,24 @@ describe("decorators", function () {
   it("should parenthesize ** operator arguments when lower precedence", function () {
     var ast = recast.parse('a ** b;', parseOptions);
 
-    ast.program.body[0].expression.left = parseExpression('x + y');
+    ast.program.body[0].expression.left = parseExpression('x * y');
     ast.program.body[0].expression.right = parseExpression('x || y');
 
     assert.strictEqual(
       recast.print(ast).code,
-      '(x + y) ** (x || y);'
+      '(x * y) ** (x || y);'
     );
   });
 
   it("should parenthesize ** operator arguments as needed when same precedence", function () {
     var ast = recast.parse('a ** b;', parseOptions);
 
-    ast.program.body[0].expression.left = parseExpression('x * y');
-    ast.program.body[0].expression.right = parseExpression('x / y');
+    ast.program.body[0].expression.left = parseExpression('x ** y');
+    ast.program.body[0].expression.right = parseExpression('x ** y');
 
     assert.strictEqual(
       recast.print(ast).code,
-      'x * y ** (x / y);'
+      'x ** y ** (x ** y);'
     );
   });
 


### PR DESCRIPTION
I implemented it by myself in PR #285

But somehow ended up adding it to the same precedence category
as `*`, `/`, `%`.  Turns out `**` is in a precendence category of its own,
above the `*`, `/`, `%`.

The spec is somewhat hard to digest:
- https://www.ecma-international.org/ecma-262/7.0/#sec-multiplicative-operators

A more firendly reference is provided by MDN:
- https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Operator_Precedence