### PR TITLE
Avoid an ASI bug by sometimes wrapping return expressions in parens

### DIFF
--- a/lib/lines.js
+++ b/lib/lines.js
@@ -458,7 +458,9 @@ Lp.isFirstLineOnlyComment = function () {
         return false;
     }
     var firstLineInfo = secret.infos[0],
-        firstLine = firstLineInfo.line.trim();
+        sliceStart = firstLineInfo.sliceStart,
+        sliceEnd = firstLineInfo.sliceEnd,
+        firstLine = firstLineInfo.line.slice(sliceStart, sliceEnd).trim();
     return firstLine.length === 0 ||
         firstLine.slice(0, 2) === "//" ||
         firstLine.slice(0, 2) === "/*";

--- a/lib/lines.js
+++ b/lib/lines.js
@@ -448,6 +448,22 @@ Lp.guessTabWidth = function() {
     return secret.cachedTabWidth = result;
 };
 
+// Determine if the list of lines has a first line that's empty of non-comment
+// tokens. If this is the case, the code may need to be wrapped in parens to
+// avoid ASI issues. Calling code should be more defensive if we return true,
+// so false positives are ok.
+Lp.isFirstLineOnlyComment = function () {
+    var secret = getSecret(this);
+    if (secret.infos.length === 0) {
+        return false;
+    }
+    var firstLineInfo = secret.infos[0],
+        firstLine = firstLineInfo.line.trim();
+    return firstLine.length === 0 ||
+        firstLine.slice(0, 2) === "//" ||
+        firstLine.slice(0, 2) === "/*";
+};
+
 Lp.isOnlyWhitespace = function() {
     return isOnlyWhitespace(this.toString());
 };

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -4,6 +4,7 @@ var types = require("./types");
 var getFieldValue = types.getFieldValue;
 var Printable = types.namedTypes.Printable;
 var Expression = types.namedTypes.Expression;
+var ReturnStatement = types.namedTypes.ReturnStatement;
 var SourceLocation = types.namedTypes.SourceLocation;
 var util = require("./util");
 var comparePos = util.comparePos;
@@ -518,6 +519,13 @@ function findChildReprints(newPath, oldPath, reprints) {
         if (!canReprint) {
             return false;
         }
+    }
+
+    // Return statements might end up running into ASI issues due to comments
+    // inserted deep within the tree, so reprint them if anything changed
+    // within them.
+    if (ReturnStatement.check(newPath.getNode()) && reprints.length > 0) {
+        return false;
     }
 
     return true;

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -509,6 +509,8 @@ function findChildReprints(newPath, oldPath, reprints) {
     // Don't bother traversing .loc objects looking for reprintable nodes.
     delete keys.loc;
 
+    var originalReprintCount = reprints.length;
+
     for (var k in keys) {
         newPath.stack.push(k, types.getFieldValue(newNode, k));
         oldPath.stack.push(k, types.getFieldValue(oldNode, k));
@@ -524,7 +526,8 @@ function findChildReprints(newPath, oldPath, reprints) {
     // Return statements might end up running into ASI issues due to comments
     // inserted deep within the tree, so reprint them if anything changed
     // within them.
-    if (ReturnStatement.check(newPath.getNode()) && reprints.length > 0) {
+    if (ReturnStatement.check(newPath.getNode()) &&
+        reprints.length > originalReprintCount) {
         return false;
     }
 

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -568,9 +568,11 @@ function genericPrintNoParens(path, options, print) {
 
         if (n.argument) {
             var argLines = path.call(print, "argument");
-            if (argLines.length > 1 &&
-                namedTypes.JSXElement &&
-                namedTypes.JSXElement.check(n.argument)) {
+            if (argLines.isFirstLineOnlyComment() ||
+                (argLines.length > 1 &&
+                    namedTypes.JSXElement &&
+                    namedTypes.JSXElement.check(n.argument)
+                )) {
                 parts.push(
                     " (\n",
                     argLines.indent(options.tabWidth),

--- a/test/comments.js
+++ b/test/comments.js
@@ -661,4 +661,74 @@ describe("comments", function() {
             code
         );
     });
+
+    it("should preserve correctness when a return expression has a comment", function () {
+        var code = [
+            "function f() {",
+            "  return 3;",
+            "}"
+        ].join(eol);
+
+        var ast = recast.parse(code);
+        ast.program.body[0].body.body[0].argument.comments = [b.line('Foo')];
+
+        assert.strictEqual(recast.print(ast).code, [
+            "function f() {",
+            "  return (",
+            "    //Foo",
+            "    3",
+            "  );",
+            "}"
+        ].join(eol));
+    });
+
+    it("should not wrap in parens when the return expression has an interior comment", function () {
+        var code = [
+            "function f() {",
+            "  return 1 + 2;",
+            "}"
+        ].join(eol);
+
+        var ast = recast.parse(code);
+        ast.program.body[0].body.body[0].argument.right.comments = [b.line('Foo')];
+
+        assert.strictEqual(recast.print(ast).code, [
+            "function f() {",
+            "  return 1 + //Foo",
+            "  2;",
+            "}"
+        ].join(eol));
+    });
+
+    it("should not reformat a return statement that is not modified", function () {
+        var code = [
+            "function f() {",
+            "  return      {",
+            "    a:     1,",
+            "    b: 2,",
+            "  };",
+            "}"
+        ].join(eol);
+
+        var ast = recast.parse(code);
+
+        assert.strictEqual(recast.print(ast).code, code);
+    });
+
+    it("should correctly handle a removing the argument from a return", function () {
+        var code = [
+            "function f() {",
+            "  return 'foo';",
+            "}"
+        ].join(eol);
+
+        var ast = recast.parse(code);
+        ast.program.body[0].body.body[0].argument = null;
+
+        assert.strictEqual(recast.print(ast).code, [
+            "function f() {",
+            "  return;",
+            "}"
+        ].join(eol));
+    });
 });

--- a/test/comments.js
+++ b/test/comments.js
@@ -682,6 +682,26 @@ describe("comments", function() {
         ].join(eol));
     });
 
+  it("should wrap in parens when the return expression has nested leftmost comment", function () {
+    var code = [
+      "function f() {",
+      "  return 1 + 2;",
+      "}"
+    ].join(eol);
+
+    var ast = recast.parse(code);
+    ast.program.body[0].body.body[0].argument.left.comments = [b.line('Foo')];
+
+    assert.strictEqual(recast.print(ast).code, [
+      "function f() {",
+      "  return (",
+      "    //Foo",
+      "    1 + 2",
+      "  );",
+      "}"
+    ].join(eol));
+  });
+
     it("should not wrap in parens when the return expression has an interior comment", function () {
         var code = [
             "function f() {",

--- a/test/mapping.js
+++ b/test/mapping.js
@@ -79,10 +79,8 @@ describe("source maps", function() {
 
         check(1, 0, 1, 0, null); // function
         check(1, 18, 1, 18, null); // {
-        check(2, 2, 2, 2, null); // return
         check(2, 13, 2, 9, null); // bar
         check(2, 9, 2, 15, null); // 1
-        check(2, 16, 2, 16, null); // ;
         check(3, 0, 3, 0, null); // }
     });
 

--- a/test/patcher.js
+++ b/test/patcher.js
@@ -116,7 +116,7 @@ describe("patcher", function() {
         returnStmt.argument = b.literal(null);
         assert.strictEqual(
             recast.print(strAST).code,
-            "return null" // Instead of returnnull.
+            "return null;" // Instead of returnnull.
         );
 
         var arrAST = parse("throw[1,2,3]");


### PR DESCRIPTION
Fixes #362

If the argument to a return statement starts with a comment-only line, then we
now wrap it in parens to avoid the `return` getting parsed as its own line:

```js
function f() {
  return (
    // Foo
    3
  );
}
```

This problem can be introduced by adding a leading comment to any leftmost child
of the return argument, so we need to be more defensive about when we reformat
`return` statements. For now, we reprint the `ReturnStatement` node (but leave
unchanged children intact) when any child had changes.