### PR TITLE
[test] Ensure both parentheses in a parenthesised unary expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-preset-es2015": "^6.22.0",
     "babylon": "~6.15.0",
     "esprima-fb": "^15001.1001.0-dev-harmony-fb",
+    "flow-parser": "^0.40.0",
     "mocha": "~3.1.2",
     "reify": "^0.4.16"
   },

--- a/test/printer.js
+++ b/test/printer.js
@@ -1015,6 +1015,37 @@ describe("printer", function() {
     assert.strictEqual(pretty, code);
   });
 
+  it("keeps trailing parenthesis in a parenthesized unary expression", function() {
+      var printer = new Printer({ tabWidth: 2 });
+
+      var code = "function pem() { return !(broke && welsh); }";
+
+      // This only broke under flow.
+      var ast = parse(code, {
+          parser: require("flow-parser")
+      });
+
+      var funDecl = ast.program.body[0];
+      n.FunctionDeclaration.assert(funDecl);
+
+      var returnStmt = funDecl.body.body[0];
+      n.ReturnStatement.assert(returnStmt);
+
+      var unaryExp = returnStmt.argument;
+      n.UnaryExpression.assert(unaryExp);
+
+      var logExp = unaryExp.argument;
+      n.LogicalExpression.assert(logExp);
+
+      // Replace with new identifier node.
+      logExp.left = b.identifier(logExp.left.name);
+
+      assert.strictEqual(
+          printer.print(returnStmt).code,
+          "return !(broke && welsh);"
+      );
+  });
+
   it("adds parenthesis around single arrow function arg when options.arrowParensAlways is true", function() {
     var code = "(a) => {};";
 


### PR DESCRIPTION
This test-only (no fix included, sorry!) is mainly submitted for consideration/comment.

While parentheses are properly maintained when coming from `babylon`, the trailing parenthesis is stripped when printing an AST originally from `flow-parser` (which I added to `devDependencies`) when it has been mutated.

In this case (as demonstrated in the test), this code when transformed:

    function pem() { return !(broke && welsh); }

Is `print`-ed again as:

    function pem() { return !(broke && welsh; }
    //                                      `--- ) omitted.

I'm happy to address an actual fix but didn't familiarize myself with the rest of the codebase much.  `FPp.needsParens`, maybe, but seems like this was more a matter of a parenthesis getting removed when it should have been preserved.