### PR TITLE
Add parens around Babel's numeric literals.

### DIFF
--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -304,6 +304,12 @@ FPp.needsParens = function(assumeExpressionContext) {
       && name === "object"
       && parent.object === node;
 
+  // Babel 6 Literal split
+  case "NumericLiteral":
+    return parent.type === "MemberExpression"
+      && name === "object"
+      && parent.object === node;
+
   case "AssignmentExpression":
   case "ConditionalExpression":
     switch (parent.type) {


### PR DESCRIPTION
From https://github.com/babel/babel/issues/5579

    b.memberExpression({type: "Literal", value: 1}, b.identifier('foo'))

outputs

    (1).foo

but

    b.memberExpression({type: "NumericLiteral", value: 1}, b.identifier('foo'))

outputs

    1.foo

which is a syntax error.

Not sure where tests for this might belong, let me know if you want me to add some.