### PR TITLE
Respect useTabs option when indenting an opening JSX element

### DIFF
--- a/lib/comments.js
+++ b/lib/comments.js
@@ -255,7 +255,7 @@ function addTrailingComment(node, comment) {
     addCommentHelper(node, comment);
 }
 
-function printLeadingComment(commentPath, print) {
+function printLeadingComment(commentPath, print, options) {
     var comment = commentPath.getValue();
     n.Comment.assert(comment);
 
@@ -288,10 +288,10 @@ function printLeadingComment(commentPath, print) {
         parts.push("\n");
     }
 
-    return concat(parts);
+    return concat(parts, options);
 }
 
-function printTrailingComment(commentPath, print) {
+function printTrailingComment(commentPath, print, options) {
     var comment = commentPath.getValue(commentPath);
     n.Comment.assert(comment);
 
@@ -316,10 +316,10 @@ function printTrailingComment(commentPath, print) {
 
     parts.push(print(commentPath));
 
-    return concat(parts);
+    return concat(parts, options);
 }
 
-exports.printComments = function(path, print) {
+exports.printComments = function(path, print, options) {
     var value = path.getValue();
     var innerLines = print(path);
     var comments = n.Node.check(value) &&
@@ -340,12 +340,12 @@ exports.printComments = function(path, print) {
         if (leading || (trailing && !(n.Statement.check(value) ||
                                       comment.type === "Block" ||
                                       comment.type === "CommentBlock"))) {
-            leadingParts.push(printLeadingComment(commentPath, print));
+            leadingParts.push(printLeadingComment(commentPath, print, options));
         } else if (trailing) {
-            trailingParts.push(printTrailingComment(commentPath, print));
+            trailingParts.push(printTrailingComment(commentPath, print, options));
         }
     }, "comments");
 
     leadingParts.push.apply(leadingParts, trailingParts);
-    return concat(leadingParts);
+    return concat(leadingParts, options);
 };

--- a/lib/lines.js
+++ b/lib/lines.js
@@ -751,7 +751,6 @@ Lp.sliceString = function(start, end, options) {
 
     var infos = getSecret(this).infos;
     var parts = [];
-    var tabWidth = options.tabWidth;
 
     for (var line = start.line; line <= end.line; ++line) {
         var info = infos[line - 1];
@@ -777,23 +776,7 @@ Lp.sliceString = function(start, end, options) {
             continue;
         }
 
-        var tabs = 0;
-        var spaces = indent;
-
-        if (options.useTabs) {
-            tabs = Math.floor(indent / tabWidth);
-            spaces -= tabs * tabWidth;
-        }
-
-        var result = "";
-
-        if (tabs > 0) {
-            result += new Array(tabs + 1).join("\t");
-        }
-
-        if (spaces > 0) {
-            result += new Array(spaces + 1).join(" ");
-        }
+		var result = indentString(indent, options);
 
         result += info.line.slice(info.sliceStart, info.sliceEnd);
 
@@ -807,7 +790,29 @@ Lp.isEmpty = function() {
     return this.length < 2 && this.getLineLength(1) < 1;
 };
 
-Lp.join = function(elements) {
+function indentString(indent, { useTabs, tabWidth } = {}) {
+	var tabs = 0;
+	var spaces = indent;
+
+	if (useTabs) {
+		tabs = Math.floor(indent / tabWidth);
+		spaces -= tabs * tabWidth;
+	}
+
+	var result = "";
+
+	if (tabs > 0) {
+		result += new Array(tabs + 1).join("\t");
+	}
+
+	if (spaces > 0) {
+		result += new Array(spaces + 1).join(" ");
+	}
+
+	return result;
+}
+
+Lp.join = function(elements, options) {
     var separator = this;
     var separatorSecret = getSecret(separator);
     var infos = [];
@@ -820,7 +825,7 @@ Lp.join = function(elements) {
 
         if (prevInfo) {
             var info = secret.infos[0];
-            var indent = new Array(info.indent + 1).join(" ");
+            var indent = indentString(info.indent, options);
             var prevLine = infos.length;
             var prevColumn = Math.max(prevInfo.indent, 0) +
                 prevInfo.sliceEnd - prevInfo.sliceStart;
@@ -878,8 +883,8 @@ Lp.join = function(elements) {
     return lines;
 };
 
-exports.concat = function(elements) {
-    return emptyLines.join(elements);
+exports.concat = function(elements, options) {
+    return emptyLines.join(elements, options);
 };
 
 Lp.concat = function(other) {

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -14,7 +14,7 @@ var isArray = types.builtInTypes.array;
 var isString = types.builtInTypes.string;
 var riskyAdjoiningCharExp = /[0-9a-z_$]/i;
 
-function Patcher(lines) {
+function Patcher(lines, options) {
   assert.ok(this instanceof Patcher);
   assert.ok(lines instanceof linesModule.Lines);
 
@@ -62,7 +62,7 @@ function Patcher(lines) {
 
     pushSlice(sliceFrom, loc.end);
 
-    return linesModule.concat(toConcat);
+    return linesModule.concat(toConcat, options);
   };
 }
 exports.Patcher = Patcher;
@@ -152,7 +152,7 @@ Pp.deleteComments = function(node) {
   });
 };
 
-exports.getReprinter = function(path) {
+exports.getReprinter = function(path, options) {
   assert.ok(path instanceof FastPath);
 
   // Make sure that this path refers specifically to a Node, rather than
@@ -170,7 +170,7 @@ exports.getReprinter = function(path) {
     return;
 
   return function(print) {
-    var patcher = new Patcher(lines);
+    var patcher = new Patcher(lines, options);
 
     reprints.forEach(function(reprint) {
       var newNode = reprint.newPath.getValue();
@@ -207,7 +207,7 @@ exports.getReprinter = function(path) {
         nls && newParts.push(" ");
         newParts.push(newLines);
         nts && newParts.push(" ");
-        newLines = linesModule.concat(newParts);
+        newLines = linesModule.concat(newParts, options);
       }
 
       patcher.replace(oldNode.loc, newLines);

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -58,7 +58,7 @@ function Printer(originalOptions) {
 
     function printWithComments(path) {
         assert.ok(path instanceof FastPath);
-        return printComments(path, print);
+        return printComments(path, print, options);
     }
 
     function print(path, includeComments) {
@@ -82,7 +82,7 @@ function Printer(originalOptions) {
     }
 
     function maybeReprint(path) {
-        var reprinter = getReprinter(path);
+        var reprinter = getReprinter(path, options);
         if (reprinter) {
             // Since the print function that we pass to the reprinter will
             // be used to print "new" nodes, it's tempting to think we
@@ -101,7 +101,7 @@ function Printer(originalOptions) {
     // children non-generically.
     function printRootGenerically(path, includeComments) {
         return includeComments
-            ? printComments(path, printRootGenerically)
+            ? printComments(path, printRootGenerically, options)
             : genericPrint(path, options, printWithComments);
     }
 
@@ -151,7 +151,7 @@ function Printer(originalOptions) {
 exports.Printer = Printer;
 
 function maybeAddParens(path, lines) {
-    return path.needsParens() ? concat(["(", lines, ")"]) : lines;
+    return path.needsParens() ? concat(["(", lines, ")"], options) : lines;
 }
 
 function genericPrint(path, options, printPath) {
@@ -202,7 +202,7 @@ function genericPrint(path, options, printPath) {
         parts.push(")");
     }
 
-    return concat(parts);
+    return concat(parts, options);
 }
 
 function genericPrintNoParens(path, options, print) {
@@ -236,17 +236,17 @@ function genericPrintNoParens(path, options, print) {
             return printStatementSequence(bodyPath, options, print);
         }, "body"));
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "Noop": // Babel extension.
     case "EmptyStatement":
         return fromString("");
 
     case "ExpressionStatement":
-        return concat([path.call(print, "expression"), ";"]);
+        return concat([path.call(print, "expression"), ";"], options);
 
     case "ParenthesizedExpression": // Babel extension.
-        return concat(["(", path.call(print, "expression"), ")"]);
+        return concat(["(", path.call(print, "expression"), ")"], options);
 
     case "BinaryExpression":
     case "LogicalExpression":
@@ -255,14 +255,14 @@ function genericPrintNoParens(path, options, print) {
             path.call(print, "left"),
             n.operator,
             path.call(print, "right")
-        ]);
+        ], options);
 
     case "AssignmentPattern":
         return concat([
             path.call(print, "left"),
             " = ",
             path.call(print, "right")
-        ]);
+        ], options);
 
     case "MemberExpression":
         parts.push(path.call(print, "object"));
@@ -274,7 +274,7 @@ function genericPrintNoParens(path, options, print) {
             parts.push(".", property);
         }
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "MetaProperty":
         return concat([
@@ -290,7 +290,7 @@ function genericPrintNoParens(path, options, print) {
 
         parts.push("::", path.call(print, "callee"));
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "Path":
         return fromString(".").join(n.body);
@@ -299,7 +299,7 @@ function genericPrintNoParens(path, options, print) {
         return concat([
             fromString(n.name, options),
             path.call(print, "typeAnnotation")
-        ]);
+        ], options);
 
     case "SpreadElement":
     case "SpreadElementPattern":
@@ -307,7 +307,7 @@ function genericPrintNoParens(path, options, print) {
     case "SpreadProperty":
     case "SpreadPropertyPattern":
     case "RestElement":
-        return concat(["...", path.call(print, "argument")]);
+        return concat(["...", path.call(print, "argument")], options);
 
     case "FunctionDeclaration":
     case "FunctionExpression":
@@ -336,7 +336,7 @@ function genericPrintNoParens(path, options, print) {
             path.call(print, "body")
         );
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "ArrowFunctionExpression":
         if (n.async)
@@ -366,7 +366,7 @@ function genericPrintNoParens(path, options, print) {
 
         parts.push(" => ", path.call(print, "body"));
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "MethodDefinition":
         if (n.static) {
@@ -375,7 +375,7 @@ function genericPrintNoParens(path, options, print) {
 
         parts.push(printMethod(path, options, print));
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "YieldExpression":
         parts.push("yield");
@@ -386,7 +386,7 @@ function genericPrintNoParens(path, options, print) {
         if (n.argument)
             parts.push(" ", path.call(print, "argument"));
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "AwaitExpression":
         parts.push("await");
@@ -397,7 +397,7 @@ function genericPrintNoParens(path, options, print) {
         if (n.argument)
             parts.push(" ", path.call(print, "argument"));
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "ModuleDeclaration":
         parts.push("module", path.call(print, "id"));
@@ -425,7 +425,7 @@ function genericPrintNoParens(path, options, print) {
             }
         }
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "ExportSpecifier":
         if (n.local) {
@@ -441,7 +441,7 @@ function genericPrintNoParens(path, options, print) {
             }
         }
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "ExportBatchSpecifier":
         return fromString("*");
@@ -453,7 +453,7 @@ function genericPrintNoParens(path, options, print) {
         } else if (n.id) {
             parts.push(path.call(print, "id"));
         }
-        return concat(parts);
+        return concat(parts, options);
 
     case "ImportDefaultSpecifier":
         if (n.local) {
@@ -478,10 +478,10 @@ function genericPrintNoParens(path, options, print) {
             path.call(print, "source")
         );
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "ExportNamespaceSpecifier":
-        return concat(["* as ", path.call(print, "exported")]);
+        return concat(["* as ", path.call(print, "exported")], options);
 
     case "ExportDefaultSpecifier":
         return path.call(print, "exported");
@@ -536,7 +536,7 @@ function genericPrintNoParens(path, options, print) {
 
         parts.push(path.call(print, "source"), ";");
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "BlockStatement":
         var naked = path.call(function(bodyPath) {
@@ -564,7 +564,7 @@ function genericPrintNoParens(path, options, print) {
         parts.push(naked.indent(options.tabWidth));
         parts.push("\n}");
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "ReturnStatement":
         parts.push("return");
@@ -588,13 +588,13 @@ function genericPrintNoParens(path, options, print) {
 
         parts.push(";");
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "CallExpression":
         return concat([
             path.call(print, "callee"),
             printArgumentsList(path, options, print)
-        ]);
+        ], options);
 
     case "ObjectExpression":
     case "ObjectPattern":
@@ -659,14 +659,14 @@ function genericPrintNoParens(path, options, print) {
             parts[parts.length - 1] = " " + rightBrace;
         }
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "PropertyPattern":
         return concat([
             path.call(print, "key"),
             ": ",
             path.call(print, "pattern")
-        ]);
+        ], options);
 
     case "ObjectProperty": // Babel 6
     case "Property": // Non-standard AST node type.
@@ -685,20 +685,20 @@ function genericPrintNoParens(path, options, print) {
             parts.push(": ", path.call(print, "value"));
         }
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "ClassMethod": // Babel 6
         if (n.static) {
             parts.push("static ");
         }
 
-        return concat([parts, printObjectMethod(path, options, print)]);
+        return concat([parts, printObjectMethod(path, options, print)], options);
 
     case "ObjectMethod": // Babel 6
         return printObjectMethod(path, options, print);
 
     case "Decorator":
-        return concat(["@", path.call(print, "expression")]);
+        return concat(["@", path.call(print, "expression")], options);
 
     case "ArrayExpression":
     case "ArrayPattern":
@@ -706,7 +706,7 @@ function genericPrintNoParens(path, options, print) {
             len = elems.length;
 
         var printed = path.map(print, "elements");
-        var joined = fromString(", ").join(printed);
+        var joined = fromString(", ").join(printed, options);
         var oneLine = joined.getLineLength(1) <= options.wrapColumn;
         if (oneLine) {
           if (options.arrayBracketSpacing) {
@@ -750,10 +750,10 @@ function genericPrintNoParens(path, options, print) {
           parts.push("]");
         }
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "SequenceExpression":
-        return fromString(", ").join(path.map(print, "expressions"));
+        return fromString(", ").join(path.map(print, "expressions"), options);
 
     case "ThisExpression":
         return fromString("this");
@@ -798,7 +798,7 @@ function genericPrintNoParens(path, options, print) {
         if (/[a-z]$/.test(n.operator))
             parts.push(" ");
         parts.push(path.call(print, "argument"));
-        return concat(parts);
+        return concat(parts, options);
 
     case "UpdateExpression":
         parts.push(
@@ -809,14 +809,14 @@ function genericPrintNoParens(path, options, print) {
         if (n.prefix)
             parts.reverse();
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "ConditionalExpression":
         return concat([
             "(", path.call(print, "test"),
             " ? ", path.call(print, "consequent"),
             " : ", path.call(print, "alternate"), ")"
-        ]);
+        ], options);
 
     case "NewExpression":
         parts.push("new ", path.call(print, "callee"));
@@ -825,7 +825,7 @@ function genericPrintNoParens(path, options, print) {
             parts.push(printArgumentsList(path, options, print));
         }
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "VariableDeclaration":
         parts.push(n.kind, " ");
@@ -837,10 +837,10 @@ function genericPrintNoParens(path, options, print) {
         }, "declarations");
 
         if (maxLen === 1) {
-            parts.push(fromString(", ").join(printed));
+            parts.push(fromString(", ").join(printed, options));
         } else if (printed.length > 1 ) {
             parts.push(
-                fromString(",\n").join(printed)
+                fromString(",\n").join(printed, options)
                     .indentTail(n.kind.length + 1)
             );
         } else {
@@ -859,13 +859,13 @@ function genericPrintNoParens(path, options, print) {
             parts.push(";");
         }
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "VariableDeclarator":
         return n.init ? fromString(" = ").join([
             path.call(print, "id"),
             path.call(print, "init")
-        ]) : path.call(print, "id");
+        ], options) : path.call(print, "id");
 
     case "WithStatement":
         return concat([
@@ -884,7 +884,7 @@ function genericPrintNoParens(path, options, print) {
                 endsWithBrace(con) ? " else" : "\nelse",
                 adjustClause(path.call(print, "alternate"), options));
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "ForStatement":
         // TODO Get the for (;;) case right.
@@ -895,8 +895,8 @@ function genericPrintNoParens(path, options, print) {
                 init,
                 path.call(print, "test"),
                 path.call(print, "update")
-            ]).indentTail(forParen.length),
-            head = concat([forParen, indented, ")"]),
+            ], options).indentTail(forParen.length),
+            head = concat([forParen, indented, ")"], options),
             clause = adjustClause(path.call(print, "body"), options),
             parts = [head];
 
@@ -907,7 +907,7 @@ function genericPrintNoParens(path, options, print) {
 
         parts.push(clause);
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "WhileStatement":
         return concat([
@@ -915,7 +915,7 @@ function genericPrintNoParens(path, options, print) {
             path.call(print, "test"),
             ")",
             adjustClause(path.call(print, "body"), options)
-        ]);
+        ], options);
 
     case "ForInStatement":
         // Note: esprima can't actually parse "for each (".
@@ -926,7 +926,7 @@ function genericPrintNoParens(path, options, print) {
             path.call(print, "right"),
             ")",
             adjustClause(path.call(print, "body"), options)
-        ]);
+        ], options);
 
     case "ForOfStatement":
         return concat([
@@ -936,7 +936,7 @@ function genericPrintNoParens(path, options, print) {
             path.call(print, "right"),
             ")",
             adjustClause(path.call(print, "body"), options)
-        ]);
+        ], options);
 
     case "ForAwaitStatement":
         return concat([
@@ -946,13 +946,13 @@ function genericPrintNoParens(path, options, print) {
             path.call(print, "right"),
             ")",
             adjustClause(path.call(print, "body"), options)
-        ]);
+        ], options);
 
     case "DoWhileStatement":
         var doBody = concat([
             "do",
             adjustClause(path.call(print, "body"), options)
-        ]), parts = [doBody];
+        ], options), parts = [doBody];
 
         if (endsWithBrace(doBody))
             parts.push(" while");
@@ -961,7 +961,7 @@ function genericPrintNoParens(path, options, print) {
 
         parts.push(" (", path.call(print, "test"), ");");
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "DoExpression":
         var statements = path.call(function(bodyPath) {
@@ -972,28 +972,28 @@ function genericPrintNoParens(path, options, print) {
             "do {\n",
             statements.indent(options.tabWidth),
             "\n}"
-        ]);
+        ], options);
 
     case "BreakStatement":
         parts.push("break");
         if (n.label)
             parts.push(" ", path.call(print, "label"));
         parts.push(";");
-        return concat(parts);
+        return concat(parts, options);
 
     case "ContinueStatement":
         parts.push("continue");
         if (n.label)
             parts.push(" ", path.call(print, "label"));
         parts.push(";");
-        return concat(parts);
+        return concat(parts, options);
 
     case "LabeledStatement":
         return concat([
             path.call(print, "label"),
             ":\n",
             path.call(print, "body")
-        ]);
+        ], options);
 
     case "TryStatement":
         parts.push(
@@ -1013,7 +1013,7 @@ function genericPrintNoParens(path, options, print) {
             parts.push(" finally ", path.call(print, "finalizer"));
         }
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "CatchClause":
         parts.push("catch (", path.call(print, "param"));
@@ -1024,19 +1024,19 @@ function genericPrintNoParens(path, options, print) {
 
         parts.push(") ", path.call(print, "body"));
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "ThrowStatement":
-        return concat(["throw ", path.call(print, "argument"), ";"]);
+        return concat(["throw ", path.call(print, "argument"), ";"], options);
 
     case "SwitchStatement":
         return concat([
             "switch (",
             path.call(print, "discriminant"),
             ") {\n",
-            fromString("\n").join(path.map(print, "cases")),
+            fromString("\n").join(path.map(print, "cases"), options),
             "\n}"
-        ]);
+        ], options);
 
         // Note: ignoring n.lexical because it has no printing consequences.
 
@@ -1052,7 +1052,7 @@ function genericPrintNoParens(path, options, print) {
             }, "consequent").indent(options.tabWidth));
         }
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "DebuggerStatement":
         return fromString("debugger;");
@@ -1063,7 +1063,7 @@ function genericPrintNoParens(path, options, print) {
         parts.push(path.call(print, "name"));
         if (n.value)
             parts.push("=", path.call(print, "value"));
-        return concat(parts);
+        return concat(parts, options);
 
     case "JSXIdentifier":
         return fromString(n.name, options);
@@ -1072,22 +1072,22 @@ function genericPrintNoParens(path, options, print) {
         return fromString(":").join([
             path.call(print, "namespace"),
             path.call(print, "name")
-        ]);
+        ], options);
 
     case "JSXMemberExpression":
         return fromString(".").join([
             path.call(print, "object"),
             path.call(print, "property")
-        ]);
+        ], options);
 
     case "JSXSpreadAttribute":
-        return concat(["{...", path.call(print, "argument"), "}"]);
+        return concat(["{...", path.call(print, "argument"), "}"], options);
 
     case "JSXSpreadChild":
-        return concat(["{...", path.call(print, "expression"), "}"]);
+        return concat(["{...", path.call(print, "expression"), "}"], options);
 
     case "JSXExpressionContainer":
-        return concat(["{", path.call(print, "expression"), "}"]);
+        return concat(["{", path.call(print, "expression"), "}"], options);
 
     case "JSXElement":
         var openingLines = path.call(print, "openingElement");
@@ -1111,7 +1111,8 @@ function genericPrintNoParens(path, options, print) {
                 }
 
                 return print(childPath);
-            }, "children")
+            }, "children"),
+			options
         ).indentTail(options.tabWidth);
 
         var closingLines = path.call(print, "closingElement");
@@ -1120,7 +1121,7 @@ function genericPrintNoParens(path, options, print) {
             openingLines,
             childLines,
             closingLines
-        ]);
+        ], options);
 
     case "JSXOpeningElement":
         parts.push("<", path.call(print, "name"));
@@ -1130,7 +1131,7 @@ function genericPrintNoParens(path, options, print) {
             attrParts.push(" ", print(attrPath));
         }, "attributes");
 
-        var attrLines = concat(attrParts);
+        var attrLines = concat(attrParts, options);
 
         var needLineWrap = (
             attrLines.length > 1 ||
@@ -1145,15 +1146,15 @@ function genericPrintNoParens(path, options, print) {
                 }
             });
 
-            attrLines = concat(attrParts).indentTail(options.tabWidth);
+            attrLines = concat(attrParts, options).indentTail(options.tabWidth);
         }
 
         parts.push(attrLines, n.selfClosing ? " />" : ">");
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "JSXClosingElement":
-        return concat(["</", path.call(print, "name"), ">"]);
+        return concat(["</", path.call(print, "name"), ">"], options);
 
     case "JSXText":
         return fromString(n.value, options);
@@ -1166,7 +1167,7 @@ function genericPrintNoParens(path, options, print) {
             path.call(print, "annotation"),
             " ",
             path.call(print, "identifier")
-        ]);
+        ], options);
 
     case "ClassBody":
         if (n.body.length === 0) {
@@ -1179,13 +1180,13 @@ function genericPrintNoParens(path, options, print) {
                 return printStatementSequence(bodyPath, options, print);
             }, "body").indent(options.tabWidth),
             "\n}"
-        ]);
+        ], options);
 
     case "ClassPropertyDefinition":
         parts.push("static ", path.call(print, "definition"));
         if (!namedTypes.MethodDefinition.check(n.definition))
             parts.push(";");
-        return concat(parts);
+        return concat(parts, options);
 
     case "ClassProperty":
         if (n.static)
@@ -1193,11 +1194,11 @@ function genericPrintNoParens(path, options, print) {
 
         var key = path.call(print, "key");
         if (n.computed) {
-            key = concat(["[", key, "]"]);
+            key = concat(["[", key, "]"], options);
         } else if (n.variance === "plus") {
-            key = concat(["+", key]);
+            key = concat(["+", key], options);
         } else if (n.variance === "minus") {
-            key = concat(["-", key]);
+            key = concat(["-", key], options);
         }
         parts.push(key);
 
@@ -1208,7 +1209,7 @@ function genericPrintNoParens(path, options, print) {
             parts.push(" = ", path.call(print, "value"));
 
         parts.push(";");
-        return concat(parts);
+        return concat(parts, options);
 
     case "ClassDeclaration":
     case "ClassExpression":
@@ -1233,13 +1234,13 @@ function genericPrintNoParens(path, options, print) {
         if (n["implements"] && n['implements'].length > 0) {
             parts.push(
                 " implements ",
-                fromString(", ").join(path.map(print, "implements"))
+                fromString(", ").join(path.map(print, "implements"), options)
             );
         }
 
         parts.push(" ", path.call(print, "body"));
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "TemplateElement":
         return fromString(n.value.raw, options).lockIndentTail();
@@ -1258,13 +1259,13 @@ function genericPrintNoParens(path, options, print) {
 
         parts.push("`");
 
-        return concat(parts).lockIndentTail();
+        return concat(parts, options).lockIndentTail();
 
     case "TaggedTemplateExpression":
         return concat([
             path.call(print, "tag"),
             path.call(print, "quasi")
-        ]);
+        ], options);
 
     // These types are unprintable because they serve as abstract
     // supertypes for other (printable) types.
@@ -1287,11 +1288,11 @@ function genericPrintNoParens(path, options, print) {
 
     case "CommentBlock": // Babel block comment.
     case "Block": // Esprima block comment.
-        return concat(["/*", fromString(n.value, options), "*/"]);
+        return concat(["/*", fromString(n.value, options), "*/"], options);
 
     case "CommentLine": // Babel line comment.
     case "Line": // Esprima line comment.
-        return concat(["//", fromString(n.value, options)]);
+        return concat(["//", fromString(n.value, options)], options);
 
     // Type Annotations for Facebook Flow, typically stripped out or
     // transformed away before printing.
@@ -1301,7 +1302,7 @@ function genericPrintNoParens(path, options, print) {
                 parts.push(": ");
             }
             parts.push(path.call(print, "typeAnnotation"));
-            return concat(parts);
+            return concat(parts, options);
         }
 
         return fromString("");
@@ -1323,7 +1324,7 @@ function genericPrintNoParens(path, options, print) {
         return concat([
             path.call(print, "elementType"),
             "[]"
-        ]);
+        ], options);
 
     case "BooleanTypeAnnotation":
         return fromString("boolean", options);
@@ -1338,14 +1339,14 @@ function genericPrintNoParens(path, options, print) {
             path.call(print, "id"),
             " ",
             path.call(print, "body"),
-        ]);
+        ], options);
 
     case "DeclareFunction":
         return printFlowDeclaration(path, [
             "function ",
             path.call(print, "id"),
             ";"
-        ]);
+        ], options);
 
     case "DeclareModule":
         return printFlowDeclaration(path, [
@@ -1353,27 +1354,27 @@ function genericPrintNoParens(path, options, print) {
             path.call(print, "id"),
             " ",
             path.call(print, "body"),
-        ]);
+        ], options);
 
     case "DeclareModuleExports":
         return printFlowDeclaration(path, [
             "module.exports",
             path.call(print, "typeAnnotation"),
-        ]);
+        ], options);
 
     case "DeclareVariable":
         return printFlowDeclaration(path, [
             "var ",
             path.call(print, "id"),
             ";"
-        ]);
+        ], options);
 
     case "DeclareExportDeclaration":
     case "DeclareExportAllDeclaration":
         return concat([
             "declare ",
             printExportDeclaration(path, options, print)
-        ]);
+        ], options);
 
     case "FunctionTypeAnnotation":
         // FunctionTypeAnnotation is ambiguous:
@@ -1395,7 +1396,7 @@ function genericPrintNoParens(path, options, print) {
 
         parts.push(
             "(",
-            fromString(", ").join(path.map(print, "params")),
+            fromString(", ").join(path.map(print, "params"), options),
             ")"
         );
 
@@ -1408,7 +1409,7 @@ function genericPrintNoParens(path, options, print) {
             );
         }
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "FunctionTypeParam":
         return concat([
@@ -1416,13 +1417,13 @@ function genericPrintNoParens(path, options, print) {
             n.optional ? '?' : '',
             ": ",
             path.call(print, "typeAnnotation"),
-        ]);
+        ], options);
 
     case "GenericTypeAnnotation":
         return concat([
             path.call(print, "id"),
             path.call(print, "typeParameters")
-        ]);
+        ], options);
 
     case "DeclareInterface":
         parts.push("declare ");
@@ -1438,29 +1439,29 @@ function genericPrintNoParens(path, options, print) {
         if (n["extends"]) {
             parts.push(
                 "extends ",
-                fromString(", ").join(path.map(print, "extends"))
+                fromString(", ").join(path.map(print, "extends"), options)
             );
         }
 
         parts.push(" ", path.call(print, "body"));
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "ClassImplements":
     case "InterfaceExtends":
         return concat([
             path.call(print, "id"),
             path.call(print, "typeParameters")
-        ]);
+        ], options);
 
     case "IntersectionTypeAnnotation":
-        return fromString(" & ").join(path.map(print, "types"));
+        return fromString(" & ").join(path.map(print, "types"), options);
 
     case "NullableTypeAnnotation":
         return concat([
             "?",
             path.call(print, "typeAnnotation")
-        ]);
+        ], options);
 
     case "NullLiteralTypeAnnotation":
         return fromString("null", options);
@@ -1487,7 +1488,7 @@ function genericPrintNoParens(path, options, print) {
             path.call(print, "key"),
             "]: ",
             path.call(print, "value")
-        ]);
+        ], options);
 
     case "ObjectTypeProperty":
         var variance =
@@ -1500,14 +1501,14 @@ function genericPrintNoParens(path, options, print) {
             n.optional ? "?" : "",
             ": ",
             path.call(print, "value")
-        ]);
+        ], options);
 
     case "QualifiedTypeIdentifier":
         return concat([
             path.call(print, "qualification"),
             ".",
             path.call(print, "id")
-        ]);
+        ], options);
 
     case "StringLiteralTypeAnnotation":
         return fromString(nodeStr(n.value, options), options);
@@ -1531,7 +1532,7 @@ function genericPrintNoParens(path, options, print) {
             " = ",
             path.call(print, "right"),
             ";"
-        ]);
+        ], options);
 
     case "TypeCastExpression":
         return concat([
@@ -1539,15 +1540,15 @@ function genericPrintNoParens(path, options, print) {
             path.call(print, "expression"),
             path.call(print, "typeAnnotation"),
             ")"
-        ]);
+        ], options);
 
     case "TypeParameterDeclaration":
     case "TypeParameterInstantiation":
         return concat([
             "<",
-            fromString(", ").join(path.map(print, "params")),
+            fromString(", ").join(path.map(print, "params"), options),
             ">"
-        ]);
+        ], options);
     case "TypeParameter":
         switch (n.variance) {
             case 'plus':
@@ -1569,16 +1570,16 @@ function genericPrintNoParens(path, options, print) {
             parts.push('=', path.call(print, 'default'));
         }
 
-        return concat(parts);
+        return concat(parts, options);
 
     case "TypeofTypeAnnotation":
         return concat([
             fromString("typeof ", options),
             path.call(print, "argument")
-        ]);
+        ], options);
 
     case "UnionTypeAnnotation":
-        return fromString(" | ").join(path.map(print, "types"));
+        return fromString(" | ").join(path.map(print, "types"), options);
 
     case "VoidTypeAnnotation":
         return fromString("void", options);
@@ -1738,7 +1739,7 @@ function printStatementSequence(path, options, print) {
         }
     });
 
-    return concat(parts);
+    return concat(parts, options);
 }
 
 function maxSpace(s1, s2) {
@@ -1790,7 +1791,7 @@ function printMethod(path, options, print) {
 
     var key = path.call(print, "key");
     if (node.computed) {
-        key = concat(["[", key, "]"]);
+        key = concat(["[", key, "]"], options);
     }
 
     parts.push(
@@ -1806,24 +1807,24 @@ function printMethod(path, options, print) {
         path.call(print, "value", "body")
     );
 
-    return concat(parts);
+    return concat(parts, options);
 }
 
 function printArgumentsList(path, options, print) {
     var printed = path.map(print, "arguments");
     var trailingComma = util.isTrailingCommaEnabled(options, "parameters");
 
-    var joined = fromString(", ").join(printed);
+    var joined = fromString(", ").join(printed, options);
     if (joined.getLineLength(1) > options.wrapColumn) {
-        joined = fromString(",\n").join(printed);
+        joined = fromString(",\n").join(printed, options);
         return concat([
             "(\n",
             joined.indent(options.tabWidth),
             trailingComma ? ",\n)" : "\n)"
-        ]);
+        ], options);
     }
 
-    return concat(["(", joined, ")"]);
+    return concat(["(", joined, ")"], options);
 }
 
 function printFunctionParams(path, options, print) {
@@ -1838,27 +1839,27 @@ function printFunctionParams(path, options, print) {
             var i = defExprPath.getName();
             var p = printed[i];
             if (p && defExprPath.getValue()) {
-                printed[i] = concat([p, " = ", print(defExprPath)]);
+                printed[i] = concat([p, " = ", print(defExprPath)], options);
             }
         }, "defaults");
     }
 
     if (fun.rest) {
-        printed.push(concat(["...", path.call(print, "rest")]));
+        printed.push(concat(["...", path.call(print, "rest")], options));
     }
 
-    var joined = fromString(", ").join(printed);
+    var joined = fromString(", ").join(printed, options);
     if (joined.length > 1 ||
         joined.getLineLength(1) > options.wrapColumn) {
-        joined = fromString(",\n").join(printed);
+        joined = fromString(",\n").join(printed, options);
         if (util.isTrailingCommaEnabled(options, "parameters") &&
             !fun.rest &&
             fun.params[fun.params.length - 1].type !== 'RestElement') {
-            joined = concat([joined, ",\n"]);
+            joined = concat([joined, ",\n"], options);
         } else {
-            joined = concat([joined, "\n"]);
+            joined = concat([joined, "\n"], options);
         }
-        return concat(["\n", joined.indent(options.tabWidth)]);
+        return concat(["\n", joined.indent(options.tabWidth)], options);
     }
 
     return joined;
@@ -1894,7 +1895,7 @@ function printObjectMethod(path, options, print) {
         path.call(print, "body")
     );
 
-    return concat(parts);
+    return concat(parts, options);
 }
 
 function printExportDeclaration(path, options, print) {
@@ -1921,7 +1922,7 @@ function printExportDeclaration(path, options, print) {
         } else {
             parts.push(
                 shouldPrintSpaces ? "{ " : "{",
-                fromString(", ").join(path.map(print, "specifiers")),
+                fromString(", ").join(path.map(print, "specifiers"), options),
                 shouldPrintSpaces ? " }" : "}"
             );
         }
@@ -1931,19 +1932,19 @@ function printExportDeclaration(path, options, print) {
         }
     }
 
-    var lines = concat(parts);
+    var lines = concat(parts, options);
 
     if (lastNonSpaceCharacter(lines) !== ";" &&
         ! (decl.declaration &&
            (decl.declaration.type === "FunctionDeclaration" ||
             decl.declaration.type === "ClassDeclaration"))) {
-        lines = concat([lines, ";"]);
+        lines = concat([lines, ";"], options);
     }
 
     return lines;
 }
 
-function printFlowDeclaration(path, parts) {
+function printFlowDeclaration(path, parts, options) {
     var parentExportDecl = util.getParentExportDeclaration(path);
 
     if (parentExportDecl) {
@@ -1958,17 +1959,17 @@ function printFlowDeclaration(path, parts) {
         parts.unshift("declare ");
     }
 
-    return concat(parts);
+    return concat(parts, options);
 }
 
 function adjustClause(clause, options) {
     if (clause.length > 1)
-        return concat([" ", clause]);
+        return concat([" ", clause], options);
 
     return concat([
         "\n",
-        maybeAddSemicolon(clause).indent(options.tabWidth)
-    ]);
+        maybeAddSemicolon(clause, options).indent(options.tabWidth)
+    ], options);
 }
 
 function lastNonSpaceCharacter(lines) {
@@ -2005,9 +2006,9 @@ function nodeStr(str, options) {
     }
 }
 
-function maybeAddSemicolon(lines) {
+function maybeAddSemicolon(lines, options) {
     var eoc = lastNonSpaceCharacter(lines);
     if (!eoc || "\n};".indexOf(eoc) < 0)
-        return concat([lines, ";"]);
+        return concat([lines, ";"], options);
     return lines;
 }


### PR DESCRIPTION
Steps to reproduce:
Run this node script:
```
const recast = require('.');

// parse some code into AST
let ast = recast.parse([
	"function x(a, b) {",
	"\treturn (",
	"\t\t<div>",
	"\t\t\t{ b }",
	"\t\t</div>",
	"\t);",
	"}"
].join("\n"));

// change the variable identifier in JSX to trigger reprint
ast.program.body[0].body.body[0].argument.children[1].expression.name = 'a';

// print the output with useTabs=true
let output = recast.print(ast, { useTabs: true }).code;

// replace tabs with '~' and spaces with '_'
output = output.replace(/ /g, "_").replace(/\t/g, "~");

// print the output code with visible whitespace
console.log(output);
```

Expected result:
The output is indented with tabs:
```
function_x(a,_b)_{
~return_(
~~<div>
~~~{_a_}
~~</div>
~);
}
```

Actual result:
There are spaces before the JSX opening element:
```
function_x(a,_b)_{
~return_(
~____<div>
~~~{_a_}
~~</div>
~);
}
```

The cause of the bug is:
- in return statement, a JSX element argument gets some [extra indentation](https://github.com/benjamn/recast/blob/master/lib/printer.js#L581)
- the `Lines.prototype.join` method [uses spaces to create the indent](https://github.com/benjamn/recast/blob/master/lib/lines.js#L823) and doesn't respect the `useTabs` option

The fix is to use a smarter algorithm from the `Lines.prototype.sliceString` function.

However, this requires passing a new parameter to the `join` method and recursively add `options` to many many calls. I'm wondering if there is a better solution for this.
