### PR TITLE
Don't wrap IIFEs in parens when using babylon

### DIFF
--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -525,7 +525,7 @@ function findChildReprints(newPath, oldPath, reprints) {
   var originalReprintCount = reprints.length;
 
   for (var k in keys) {
-    if (k.charAt(0) === "_") {
+    if (k.charAt(0) === "_" || k === 'extra') {
       // Ignore "private" AST properties added by e.g. Babel plugins and
       // parsers like Babylon.
       continue;

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -2,6 +2,7 @@ var assert = require("assert");
 var linesModule = require("./lines");
 var types = require("./types");
 var getFieldValue = types.getFieldValue;
+var Node = types.namedTypes.Node;
 var Printable = types.namedTypes.Printable;
 var Expression = types.namedTypes.Expression;
 var ReturnStatement = types.namedTypes.ReturnStatement;
@@ -498,10 +499,12 @@ function findChildReprints(newPath, oldPath, reprints) {
   // path.needsParens() && !hasParens(oldNode) check below, the absence of
   // a closing parenthesis after the FunctionExpression would trigger
   // pretty-printing unnecessarily.
-  if (!newPath.canBeFirstInStatement() &&
+  if (Node.check(newNode) &&
+      !newPath.canBeFirstInStatement() &&
       newPath.firstInStatement() &&
-      !hasOpeningParen(oldPath))
+      !hasOpeningParen(oldPath)) {
     return false;
+  }
 
   // If this node needs parentheses and will not be wrapped with
   // parentheses when reprinted, then return false to skip reprinting and
@@ -525,7 +528,7 @@ function findChildReprints(newPath, oldPath, reprints) {
   var originalReprintCount = reprints.length;
 
   for (var k in keys) {
-    if (k.charAt(0) === "_" || k === 'extra') {
+    if (k.charAt(0) === "_") {
       // Ignore "private" AST properties added by e.g. Babel plugins and
       // parsers like Babylon.
       continue;

--- a/test/babylon.js
+++ b/test/babylon.js
@@ -136,6 +136,18 @@ describe("decorators", function () {
     assert.strictEqual(output, code);
   });
 
+  it("babel 6: should not wrap IIFE when reusing nodes", function () {
+    var code = [
+      '(function(...c) {',
+      '  c();',
+      '})();',
+    ].join(eol);
+
+    var ast = recast.parse(code, parseOptions);
+    var output = recast.print(ast, { tabWidth: 2 }).code;
+    assert.strictEqual(output, code);
+  });
+
   it("should not disappear when surrounding code changes", function () {
     var code = [
       'import foo from "foo";',


### PR DESCRIPTION
This is not the right fix, but i couldn't figure out how to fix it properly. Babylon now tags nodes with an object:

```
extra: {
  parenthesized: true,
  parenStart: 0
}
```
I think Recast confuses it as a Node and then tries to reprint instead of using original node, causing iifes to be wrapped in parens.


