### PR TITLE
Update ast-types to the latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "fs": false
   },
   "dependencies": {
-    "ast-types": "0.9.11",
+    "ast-types": "0.9.12",
     "core-js": "^2.4.1",
     "esprima": "~4.0.0",
     "private": "~0.1.5",


### PR DESCRIPTION
`ast-types` 0.9.12 adds support for Flow type spreads.