### PR TITLE
Fix bug: avoid attaching "extends" to interface declarations.

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1444,7 +1444,7 @@ function genericPrintNoParens(path, options, print) {
             " "
         );
 
-        if (n["extends"]) {
+        if (n["extends"] && n["extends"].length > 0) {
             parts.push(
                 "extends ",
                 fromString(", ").join(path.map(print, "extends"))


### PR DESCRIPTION
This PR fixes #452 

Although this PR would be workaround for the issue, it won't break regular cases.