### PR TITLE
Preserve representation of numerics not in base 10

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -771,12 +771,23 @@ function genericPrintNoParens(path, options, print) {
     case "BigIntLiteral": // Babel 7 Literal split
         return fromString(n.value + "n");
 
+    case "NumericLiteral": // Babel 6 Literal Split
+        // keep original representation for values not in base 10
+        if (n.extra && typeof n.extra.raw === "string")
+            return fromString(n.extra.raw, options);
+
+        return fromString(n.value, options);
+
     case "BooleanLiteral": // Babel 6 Literal split
-    case "NumericLiteral": // Babel 6 Literal split
+
     case "StringLiteral": // Babel 6 Literal split
     case "Literal":
-        if (typeof n.value !== "string")
+        // numeric values may be in bases other than 10
+        // Use their raw representation for esprima
+        if (typeof n.value !== "string") {
+            if (typeof n.raw === "string") return fromString(n.raw, options);
             return fromString(n.value, options);
+        }
 
         return fromString(nodeStr(n.value, options), options);
 

--- a/test/babylon.js
+++ b/test/babylon.js
@@ -411,4 +411,17 @@ describe("Babel", function () {
       }
     });
   });
+
+  it("prints numbers in bases other than 10 without converting them", function() {
+    var code = [
+      'let decimal = 6;',
+      'let hex = 0xf00d;',
+      'let binary = 0b1010;',
+      'let octal = 0o744;'
+    ].join(eol);
+
+    var ast = recast.parse(code, parseOptions);
+    var output = recast.print(ast, { tabWidth: 2 }).code;
+    assert.strictEqual(output, code);
+  });
 });

--- a/test/printer.js
+++ b/test/printer.js
@@ -1699,4 +1699,18 @@ describe("printer", function() {
       "(1).foo"
     );
   });
+
+  it("prints numbers in bases other than 10 without converting them", function() {
+    var code = [
+      'let decimal = 6;',
+      'let hex = 0xf00d;',
+      'let binary = 0b1010;',
+      'let octal = 0o744;'
+    ].join(eol);
+    var ast = parse(code);
+    var printer = new Printer({});
+    var pretty = printer.printGenerically(ast).code;
+
+    assert.strictEqual(pretty, code);
+  });
 });


### PR DESCRIPTION
This fixes #457 

I still don't know if the existing behavior was by design, but if nothing else the PR can be a point of discussion. I'm also not sure if this approach is the preferred one, but I did my best to match the existing code. Esprima and Babylon handle this case pretty differently, and I had some trouble finding equivalent scenarios in the existing code.

Basically in babylon, numbers are parsed as NumericLiteral. If it's a non-base 10 number, the node has an "extra" field which contains a "raw" string, which itself contains whatever was parsed originally as is. In Esprima, the number is a plain Literal node with a raw property. I tried to make sure both cases are handled along with tests.