### PR TITLE
Fix lines test so line endings don't get in the way on windows

### DIFF
--- a/test/lines.js
+++ b/test/lines.js
@@ -60,8 +60,17 @@ describe("lines", function() {
     });
 
     it("ToString", function() {
-        var code = arguments.callee + "",
-            lines = fromString(code);
+        var code = [
+          'f("argument", function(x, y, z) {',
+          '    var foo = z',
+          '',
+          '    foo(y).',
+          '      bar(z)',
+          '      bar(z);',
+          '',
+          '}',
+        ].join(eol);
+        var lines = fromString(code);
 
         check(lines, code);
         check(lines.indentTail(5)
@@ -109,7 +118,16 @@ describe("lines", function() {
     }
 
     it("EachPos", function() {
-        var code = (arguments.callee + "");
+        var code = [
+            'f("argument", function(x, y, z) {',
+            '    var foo = z',
+            '',
+            '    foo(y).',
+            '      bar(z)',
+            '      bar(z);',
+            '',
+            '}',
+          ].join(eol);
         var lines = fromString(code);
 
         testEachPosHelper(lines, code);


### PR DESCRIPTION
Fixes #459 

Instead of using arguments.callee to create a fixture, hardcodes one that properly uses the operating system's eol (which is Recast's behavior, and rightly so).

I'm not 100% sure exactly what the original tests were looking for in the current function to test, but I tried to make fixtures that had similar properties.