### PR TITLE
Add better support for importKind and exportKind

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -421,6 +421,9 @@ function genericPrintNoParens(path, options, print) {
         return fromString(" ").join(parts);
 
     case "ImportSpecifier":
+        if (n.importKind && n.importKind !== "value") {
+            parts.push(n.importKind + " ");
+        }
         if (n.imported) {
             parts.push(path.call(print, "imported"));
             if (n.local &&
@@ -2541,6 +2544,9 @@ function printFunctionParams(path, options, print) {
 function printExportDeclaration(path, options, print) {
     var decl = path.getValue();
     var parts = ["export "];
+    if (decl.exportKind && decl.exportKind !== "value") {
+        parts.push(decl.exportKind + " ");
+    }
     var shouldPrintSpaces = options.objectCurlySpacing;
 
     namedTypes.Declaration.assert(decl);

--- a/test/type-syntax.js
+++ b/test/type-syntax.js
@@ -28,6 +28,10 @@ describe("type syntax", function() {
     // Import type annotations
     check("import type foo from 'foo';");
     check("import typeof foo from 'foo';");
+    check("import { type foo } from 'foo';", flowParserParseOptions);
+
+    // Export type annotations
+    check("export type { foo };");
 
     // Scalar type annotations
     check("var a: number;");


### PR DESCRIPTION
In addition to an importKind on an ImportDeclaration (`import type {Foo} from 'bar'`), it's also valid to have an importKind on an ImportSpecifier (`import {type Foo} from 'bar'`).

Additionally, it's valid to have an exportKind on an ExportNamedDeclaration (`export type {Foo};`).

This adds support for both these cases, and a couple simple tests.