### PR TITLE
Improve the assertion message about self-closing JSX

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -1162,7 +1162,10 @@ function genericPrintNoParens(path, options, print) {
         var openingLines = path.call(print, openingPropName);
 
         if (n[openingPropName].selfClosing) {
-            assert.ok(!n[closingPropName]);
+            assert.ok(
+                !n[closingPropName],
+                "unexpected " + closingPropName + " element in self-closing " + n.type
+            );
             return openingLines;
         }
 


### PR DESCRIPTION
For example: `AssertionError [ERR_ASSERTION]: unexpected closingElement element in self-closing JSXElement`

square/babel-codemod#102