### PR TITLE
Support the export-default-from syntax

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -2589,6 +2589,38 @@ function printExportDeclaration(path, options, print) {
         if (decl.specifiers.length === 1 &&
             decl.specifiers[0].type === "ExportBatchSpecifier") {
             parts.push("*");
+        } else if (decl.specifiers[0].type === 'ExportDefaultSpecifier') {
+            var lastSpecifierIndex = decl.specifiers.length - 1;
+            var hasMultipleExportSpecifiers = decl.specifiers.length > 2;
+            var exportDefaultSpecifierIndex = 0;
+
+            var elements = path.map(function(specifierPath, index) {
+                if (index === exportDefaultSpecifierIndex) {
+                    return print(specifierPath);
+                }
+                if (!hasMultipleExportSpecifiers) {
+                    return concat([
+                        shouldPrintSpaces ? "{ " : "{",
+                        print(specifierPath),
+                        shouldPrintSpaces ? " }" : "}"
+                    ]);
+                }
+                if (index === 1) {
+                    return concat([
+                        shouldPrintSpaces ? "{ " : "{",
+                        print(specifierPath)
+                    ]);
+                }
+                if (index === lastSpecifierIndex) {
+                    return concat([
+                        print(specifierPath),
+                        shouldPrintSpaces ? " }" : "}"
+                    ]);
+                }
+                return concat([print(specifierPath), ", "]);
+            }, "specifiers");
+
+            parts.push(fromString(", ").join(elements));
         } else {
             parts.push(
                 shouldPrintSpaces ? "{ " : "{",

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -2590,37 +2590,48 @@ function printExportDeclaration(path, options, print) {
             decl.specifiers[0].type === "ExportBatchSpecifier") {
             parts.push("*");
         } else if (decl.specifiers[0].type === 'ExportDefaultSpecifier') {
-            var lastSpecifierIndex = decl.specifiers.length - 1;
-            var hasMultipleExportSpecifiers = decl.specifiers.length > 2;
-            var exportDefaultSpecifierIndex = 0;
+            const unbracedSpecifiers = [];
+            const bracedSpecifiers = [];
 
-            var elements = path.map(function(specifierPath, index) {
-                if (index === exportDefaultSpecifierIndex) {
-                    return print(specifierPath);
+            path.each(function (specifierPath) {
+                const spec = specifierPath.getValue();
+                if (spec.type === "ExportDefaultSpecifier") {
+                    unbracedSpecifiers.push(print(specifierPath));
+                } else {
+                    bracedSpecifiers.push(print(specifierPath));
                 }
-                if (!hasMultipleExportSpecifiers) {
-                    return concat([
-                        shouldPrintSpaces ? "{ " : "{",
-                        print(specifierPath),
-                        shouldPrintSpaces ? " }" : "}"
-                    ]);
-                }
-                if (index === 1) {
-                    return concat([
-                        shouldPrintSpaces ? "{ " : "{",
-                        print(specifierPath)
-                    ]);
-                }
-                if (index === lastSpecifierIndex) {
-                    return concat([
-                        print(specifierPath),
-                        shouldPrintSpaces ? " }" : "}"
-                    ]);
-                }
-                return concat([print(specifierPath), ", "]);
             }, "specifiers");
 
-            parts.push(fromString(", ").join(elements));
+            unbracedSpecifiers.forEach((lines, i) => {
+                if (i > 0) {
+                    parts.push(", ");
+                }
+                parts.push(lines);
+            });
+
+            if (bracedSpecifiers.length > 0) {
+                let lines = fromString(", ").join(bracedSpecifiers);
+                if (lines.getLineLength(1) > options.wrapColumn) {
+                    lines = concat([
+                        fromString(",\n").join(
+                            bracedSpecifiers
+                        ).indent(options.tabWidth),
+                        ","
+                    ]);
+                }
+
+                if (unbracedSpecifiers.length > 0) {
+                    parts.push(", ");
+                }
+
+                if (lines.length > 1) {
+                    parts.push("{\n", lines, "\n}");
+                } else if (options.objectCurlySpacing) {
+                    parts.push("{ ", lines, " }");
+                } else {
+                    parts.push("{", lines, "}");
+                }
+            }
         } else {
             parts.push(
                 shouldPrintSpaces ? "{ " : "{",

--- a/test/babylon.js
+++ b/test/babylon.js
@@ -428,14 +428,29 @@ describe("Babel", function () {
   });
 
   it("prints the export-default-from syntax", function () {
-    var code = 'export { default as foo, bar } from "foo";';
+    var code = [
+      'export { default as foo, bar } from "foo";',
+      'export { default as veryLongIdentifier1, veryLongIdentifier2, veryLongIdentifier3, veryLongIdentifier4, veryLongIdentifier5 } from "long-identifiers";'
+    ].join(eol);
     var ast = recast.parse(code, parseOptions);
 
-    var replacement = b.exportDefaultSpecifier(b.identifier('foo'));
-    ast.program.body[0].specifiers[0] = replacement;
+    var replacement1 = b.exportDefaultSpecifier(b.identifier('foo'));
+    var replacement2 = b.exportDefaultSpecifier(
+      b.identifier('veryLongIdentifier1')
+    );
+    ast.program.body[0].specifiers[0] = replacement1;
+    ast.program.body[1].specifiers[0] = replacement2;
     assert.strictEqual(
         recast.print(ast).code,
-        'export foo, { bar } from "foo";'
+        [
+          'export foo, { bar } from "foo";',
+          'export veryLongIdentifier1, {',
+          '  veryLongIdentifier2,',
+          '  veryLongIdentifier3,',
+          '  veryLongIdentifier4,',
+          '  veryLongIdentifier5,',
+          '} from "long-identifiers";'
+        ].join(eol)
     );
   });
 });

--- a/test/babylon.js
+++ b/test/babylon.js
@@ -426,4 +426,16 @@ describe("Babel", function () {
     var output = recast.print(ast, { tabWidth: 2 }).code;
     assert.strictEqual(output, code);
   });
+
+  it("prints the export-default-from syntax", function () {
+    var code = 'export { default as foo, bar } from "foo";';
+    var ast = recast.parse(code, parseOptions);
+
+    var replacement = b.exportDefaultSpecifier(b.identifier('foo'));
+    ast.program.body[0].specifiers[0] = replacement;
+    assert.strictEqual(
+        recast.print(ast).code,
+        'export foo, { bar } from "foo";'
+    );
+  });
 });


### PR DESCRIPTION
The printer has a problem with the export-default-from syntax.

Instead of printing this:

```js
export foo, { bar } from 'foo';
```

we get this:

```js
export { foo, bar } from 'foo';
```

This PR adds a failing test for that case. (#480)

@benjamn I'm not really experienced with AST's but if this doesn't require too many changes and you think a beginner could tackle it, I'd try my best if you could point me to the relevant parts of the code 😊 