### PR TITLE
Fix eol-related test failures on windows; also fix async test

### DIFF
--- a/test/babylon.js
+++ b/test/babylon.js
@@ -358,7 +358,7 @@ describe("Babel", function () {
       'if (test) {',
       '  console.log(test);',
       '}',
-    ].join('\n');
+    ].join(eol);
 
     var ast = recast.parse(code, parseOptions);
 
@@ -373,7 +373,7 @@ describe("Babel", function () {
 
     assert.strictEqual(
       recast.print(ast).code,
-      '\nfn(test, true);'
+      eol + 'fn(test, true);'
     );
 
     recast.types.visit(ast, {
@@ -385,7 +385,7 @@ describe("Babel", function () {
 
     assert.strictEqual(
       recast.print(ast).code,
-      '\nfn(test, true);'
+      eol + 'fn(test, true);'
     );
   });
 

--- a/test/identity.js
+++ b/test/identity.js
@@ -1,11 +1,13 @@
 var assert = require("assert");
 var fs = require("fs");
 var path = require("path");
+var eol = require("os").EOL;
 var types = require("../lib/types");
 var main = require("../main");
 
 function testFile(path, done) {
     fs.readFile(path, "utf-8", function(err, source) {
+        source = source.replace(/\r?\n/g, eol);
         assert.equal(err, null);
         assert.strictEqual(typeof source, "string");
 

--- a/test/lines.js
+++ b/test/lines.js
@@ -63,7 +63,7 @@ describe("lines", function() {
     });
 
     it("ToString", function ToStringTest() {
-        var code = String(ToStringTest);
+        var code = String(ToStringTest).replace(/\r?\n/g, eol);
         var lines = fromString(code);
         check(lines, code);
         check(lines.indentTail(5)
@@ -111,7 +111,7 @@ describe("lines", function() {
     }
 
     it("EachPos", function EachPosTest() {
-        var code = String(EachPosTest);
+        var code = String(EachPosTest).replace(/\r?\n/g, eol);
         var lines = fromString(code);
 
         testEachPosHelper(lines, code);

--- a/test/parser.js
+++ b/test/parser.js
@@ -207,6 +207,7 @@ function runTestsForParser(parserId) {
     const printer = new Printer;
 
     function check(code) {
+      code = code.replace(/\r?\n/g, eol);
       const ast = parse(code, { parser });
       assert.strictEqual(
         printer.print(ast).code,

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -310,7 +310,7 @@ function testReprinting(pattern, description) {
       }
 
       const absPath = path.join(__dirname, file);
-      const source = fs.readFileSync(absPath, "utf8");
+      const source = fs.readFileSync(absPath, "utf8").replace(/\r?\n/g, eol);
       const ast = tryToParseFile(source, absPath);
 
       if (ast === null) {


### PR DESCRIPTION
Many tests fail on Windows because either the tests assume the working tree has os-specific line endings (which can only be guaranteed with `.gitattributes`) or they had hardcoded unix line endings.  This PR fixes those test failures.  Tests still pass on Unix.