### PR TITLE
Fix #492: reprinting erroneously stripped comments attached to empty statements

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -2304,7 +2304,9 @@ function printStatementSequence(path, options, print) {
 
         // Skip printing EmptyStatement nodes to avoid leaving stray
         // semicolons lying around.
-        if (stmt.type === "EmptyStatement") {
+        if (stmt.type === "EmptyStatement" && (
+            !stmt.comments || !stmt.comments.length
+        )) {
             return;
         }
 

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -2304,9 +2304,8 @@ function printStatementSequence(path, options, print) {
 
         // Skip printing EmptyStatement nodes to avoid leaving stray
         // semicolons lying around.
-        if (stmt.type === "EmptyStatement" && (
-            !stmt.comments || !stmt.comments.length
-        )) {
+        if (stmt.type === "EmptyStatement" &&
+            ! (stmt.comments && stmt.comments.length > 0)) {
             return;
         }
 

--- a/test/comments.js
+++ b/test/comments.js
@@ -810,4 +810,20 @@ function runTestsForParser(parserId) {
       "}"
     ].join(eol));
   });
+
+  pit("should preserve comments attached to EmptyStatement", function() {
+    var code = [
+      "removeThisStatement;",
+      "// comment",
+      ";(function() {})();"
+    ].join(eol);
+
+    var ast = recast.parse(code, { parser });
+    ast.program.body.shift();
+
+    assert.strictEqual(recast.print(ast).code, [
+      "// comment",
+      ";(function() {})();"
+    ].join(eol));
+  });
 }


### PR DESCRIPTION
Fixes #492.