### PR TITLE
[WIP] Fix 493: allow controlling line terminator of parsed AST (affects node offsets)

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -20,6 +20,7 @@ exports.parse = function parse(source, options) {
 
   const sourceWithoutTabs = lines.toString({
     tabWidth: options.tabWidth,
+    lineTerminator: options.lineTerminator,
     reuseWhitespace: false,
     useTabs: false
   });

--- a/parsers/esprima.js
+++ b/parsers/esprima.js
@@ -10,6 +10,11 @@
 const getOption = require("../lib/util.js").getOption;
 
 exports.parse = function (source, options) {
+  return exports.__parseInternal(source, options);
+};
+
+// required by unit tests to pass additional options to esprima
+exports.__parseInternal = function (source, options, extraOptions) {
   const comments = [];
   const ast = require("esprima").parse(source, {
     loc: true,
@@ -17,7 +22,8 @@ exports.parse = function (source, options) {
     comment: true,
     onComment: comments,
     tolerant: getOption(options, "tolerant", true),
-    tokens: getOption(options, "tokens", true)
+    tokens: getOption(options, "tokens", true),
+    ...extraOptions
   });
 
   if (! Array.isArray(ast.comments)) {

--- a/test/parser.js
+++ b/test/parser.js
@@ -15,11 +15,17 @@ var eol = require("os").EOL;
 // test functions with names and then export them later.
 
 describe("parser", function() {
-  ["../parsers/acorn",
-   "../parsers/babylon",
-   "../parsers/esprima",
-   "../parsers/flow",
-   "../parsers/typescript",
+  [["../parsers/acorn"],
+   ["../parsers/babylon"],
+   ["../parsers/esprima", function(p) {
+    return {
+      parse: function(source, options) {
+        return p.__parseInternal(source, options, {range: true});
+      }
+    }
+  }],
+   ["../parsers/flow"],
+   ["../parsers/typescript"],
   ].forEach(runTestsForParser);
 
   it("AlternateParser", function() {
@@ -51,9 +57,10 @@ describe("parser", function() {
   });
 });
 
-function runTestsForParser(parserId) {
+function runTestsForParser([parserId, parserFactory]) {
   const parserName = parserId.split("/").pop();
-  const parser = require(parserId);
+  let parser = require(parserId);
+  if(parserFactory) parser = parserFactory(parser);
 
   it("[" + parserName + "] empty source", function () {
     var printer = new Printer;
@@ -232,5 +239,23 @@ function runTestsForParser(parserId) {
     check("/* com\n\nment */");
     check("/* com\n\nment */ ");
     check(" /* com\n\nment */ ");
+  });
+
+  it("[" + parserName + "] node locations use specified lineTerminator", function() {
+
+    check('\n', '\n');
+    check('\r\n', '\n');
+    check('\n', '\r\n');
+    check('\r\n', '\r\n');
+
+    function check(lineTerminator, inputLineTerminator) {
+      const codeLines = [
+        "", // single leading newline (either \n or \r\n)
+        "foo;"
+      ];
+      const code = codeLines.join(inputLineTerminator);
+      const ast = parse(code, { parser, lineTerminator });
+      assert.strictEqual(ast.program.body[0].start || ast.program.body[0].range[0], lineTerminator.length);
+    }
   });
 }


### PR DESCRIPTION
Can I get a quick code review on this?  I had to hook into the esprima parser for the unit tests, so I'd like to potentially refactor it into whatever style you prefer.

Fixes #493.