### PR TITLE
add a fallback for default options.lineTerminator

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -18,7 +18,7 @@ var defaults = {
     reuseWhitespace: true,
 
     // Override this option to use a different line terminator, e.g. \r\n.
-    lineTerminator: require("os").EOL,
+    lineTerminator: require("os").EOL || "\n",
 
     // Some of the pretty-printer code (such as that for printing function
     // parameter lists) makes a valiant attempt to prevent really long


### PR DESCRIPTION
require("os").EOL may not be defined.  Use "\n" instead in this case.

Fixes #518