### PR TITLE
Avoid error when using @babel/parser@7.0.0-beta.52+

### DIFF
--- a/parsers/_babylon_options.js
+++ b/parsers/_babylon_options.js
@@ -32,7 +32,7 @@ module.exports = function (options) {
       "objectRestSpread",
       "optionalCatchBinding",
       "optionalChaining",
-      "pipelineOperator",
+      ["pipelineOperator", { proposal: "minimal" }],
       "throwExpressions",
     ]
   };


### PR DESCRIPTION
The following throws an error when using `@babel/parser@7.0.0-beta.52`:

```js
let parser = require('recast/parsers/babylon');
parser.parse('let foo = "whatever"');
```

With the following error:

```
'pipelineOperator' requires 'proposal' option whose value should be one of: minimal
```

This change to `parsers/_babylon_options.js` avoids the error.

I confirmed that this change does not cause issues when used with older `@babel/parser` versions (e.g. `7.0.0-beta.44`) or `babylon` (tested `6.18.9`).