### PR TITLE
Preserve parenthesis around an argument of unary arrow function

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -366,13 +366,15 @@ function genericPrintNoParens(path, options, print) {
             parts.push(path.call(print, "typeParameters"));
         }
 
-        const unaryWrappedInParens = n.params.length === 1 &&
+        const unaryWrappedInParens = n.params.length === 1 && (
             (n.start && n.start !== n.params[0].start) ||
             (
                 n.loc &&
                 n.params[0].loc &&
                 n.loc.start.column !== n.params[0].loc.start.column
-            );
+            )
+        );
+
         if (! unaryWrappedInParens &&
             ! options.arrowParensAlways &&
             n.params.length === 1 &&

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -367,9 +367,12 @@ function genericPrintNoParens(path, options, print) {
         }
 
         const unaryWrappedInParens = n.params.length === 1 &&
-            n.loc &&
-            n.params[0].loc &&
-            n.loc.start.column !== n.params[0].loc.start.column;
+            (n.start && n.start !== n.params[0].start) ||
+            (
+                n.loc &&
+                n.params[0].loc &&
+                n.loc.start.column !== n.params[0].loc.start.column
+            );
         if (! unaryWrappedInParens &&
             ! options.arrowParensAlways &&
             n.params.length === 1 &&

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -366,7 +366,12 @@ function genericPrintNoParens(path, options, print) {
             parts.push(path.call(print, "typeParameters"));
         }
 
-        if (! options.arrowParensAlways &&
+        const unaryWrappedInParens = n.params.length === 1 &&
+            n.loc &&
+            n.params[0].loc &&
+            n.loc.start.column !== n.params[0].loc.start.column;
+        if (! unaryWrappedInParens &&
+            ! options.arrowParensAlways &&
             n.params.length === 1 &&
             ! n.rest &&
             n.params[0].type === 'Identifier' &&

--- a/test/printer.js
+++ b/test/printer.js
@@ -1343,6 +1343,15 @@ describe("printer", function() {
     assert.strictEqual(pretty, code);
   });
 
+  
+  it("preserves parenthesis around single arrow function arg", function() {
+    var code = "const b = (a) => {};";
+    var ast = parse(code);
+    var printer = new Printer();
+    var result = printer.printGenerically(ast).code;
+    assert.strictEqual(result, code);
+  });
+
   it("preserves newlines at the beginning/end of files", function() {
     var code = [
       "",


### PR DESCRIPTION
Fix for https://github.com/benjamn/recast/issues/528