### PR TITLE
Pass `range` option along to esprima parser.

### DIFF
--- a/parsers/esprima.js
+++ b/parsers/esprima.js
@@ -16,6 +16,7 @@ exports.parse = function (source, options) {
     locations: true,
     comment: true,
     onComment: comments,
+    range: getOption(options, "range", false),
     tolerant: getOption(options, "tolerant", true),
     tokens: getOption(options, "tokens", true)
   });


### PR DESCRIPTION
https://github.com/fkling/astexplorer/issues/334 mentions how syntax highlighting doesn't work for recast by default. So I noticed that the `range` option isn't passed along to esprima. 

We could of course also make it `true` by default.