### PR TITLE
Use node.loc.tokens to improve handling of parentheses.

### DIFF
--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -181,49 +181,6 @@ FPp.map = function map(callback/*, name1, name2, ... */) {
   return result;
 };
 
-function expressionStartsWithCurlyBrace(node) {
-  // TODO detect when node is already wrapped in parentheses to avoid (admittedly harmless) wrapping in extra parentheses.
-  if(node == null) return false;
-  switch(node.type) {
-  // expressions guaranteed to start with a {
-  case "ObjectExpression":
-  case "ObjectPattern":
-    return true;
-
-  // All expressions that comprise nested expressions
-  case "BinaryExpression":
-  case "AssignmentExpression":
-  case "LogicalExpression":
-    return expressionStartsWithCurlyBrace(node.left);
-
-  case "MemberExpression":
-  case "BindExpression":
-    return expressionStartsWithCurlyBrace(node.object);
-
-  case "CallExpression":
-    return expressionStartsWithCurlyBrace(node.callee);
-
-  case "UpdateExpression":
-  case "UnaryExpression":
-    return node.prefix === false && expressionStartsWithCurlyBrace(node.argument);
-
-  case "TSNonNullExpression":
-    return expressionStartsWithCurlyBrace(node.expression);
-
-  case "ConditionalExpression":
-    return expressionStartsWithCurlyBrace(node.test);
-
-  case "SequenceExpression":
-    return expressionStartsWithCurlyBrace(node.expressions[0]);
-
-  case "TaggedTemplateExpression":
-    return expressionStartsWithCurlyBrace(node.tag);
-
-  default:
-    false;
-  }
-}
-
 // Returns true if the node at the tip of the path is wrapped with
 // parentheses, OR if the only reason the node needed parentheses was that
 // it couldn't be the first expression in the enclosing statement (see
@@ -346,10 +303,6 @@ FPp.needsParens = function(assumeExpressionContext) {
 
   if (parent.type === "ParenthesizedExpression") {
     return false;
-  }
-
-  if (parent.type === "ArrowFunctionExpression" && name === "body") {
-    return expressionStartsWithCurlyBrace(node);
   }
 
   switch (node.type) {
@@ -620,6 +573,12 @@ FPp.firstInStatement = function() {
     if (n.AssignmentExpression.check(parent) &&
         childName === "left") {
       assert.strictEqual(parent.left, child);
+      return true;
+    }
+
+    if (n.ArrowFunctionExpression.check(parent) &&
+        childName === "body") {
+      assert.strictEqual(parent.body, child);
       return true;
     }
 

--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -4,6 +4,7 @@ var n = types.namedTypes;
 var Node = n.Node;
 var isArray = types.builtInTypes.array;
 var isNumber = types.builtInTypes.number;
+var util = require("./util.js");
 
 function FastPath(value) {
   assert.ok(this instanceof FastPath);
@@ -222,6 +223,60 @@ function expressionStartsWithCurlyBrace(node) {
     false;
   }
 }
+
+FPp.hasParens = function () {
+  return this.hasOpeningParen() && this.hasClosingParen();
+};
+
+FPp.hasOpeningParen = function () {
+  const node = this.getNode();
+  const loc = node && node.loc;
+  const tokens = loc && loc.tokens;
+
+  if (tokens && loc.start.token > 0) {
+    const prevToken = tokens[loc.start.token - 1];
+    if (prevToken) {
+      const value = typeof prevToken.value === "string"
+        ? prevToken.value
+        : loc.lines.sliceString(prevToken.loc.start,
+                                prevToken.loc.end);
+      if (value === "(") {
+        // If we found an opening parenthesis but it occurred before the
+        // start of the original subtree for this reprinting, then we must
+        // not return true.
+        const rootLoc = this.getRootValue().loc;
+        return util.comparePos(rootLoc.start, prevToken.loc.start) <= 0;
+      }
+    }
+  }
+
+  return false;
+};
+
+FPp.hasClosingParen = function () {
+  const node = this.getNode();
+  const loc = node && node.loc;
+  const tokens = loc && loc.tokens;
+
+  if (tokens && loc.end.token < tokens.length) {
+    const nextToken = tokens[loc.end.token];
+    if (nextToken) {
+      const value = typeof nextToken.value === "string"
+        ? nextToken.value
+        : loc.lines.sliceString(nextToken.loc.start,
+                                nextToken.loc.end);
+      if (value === ")") {
+        // If we found a closing parenthesis but it occurred after the end
+        // of the original subtree for this reprinting, then we must not
+        // return true.
+        const rootLoc = this.getRootValue().loc;
+        return util.comparePos(nextToken.loc.end, rootLoc.end) <= 0;
+      }
+    }
+  }
+
+  return false;
+};
 
 // Inspired by require("ast-types").NodePath.prototype.needsParens, but
 // more efficient because we're iterating backwards through a stack.

--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -285,6 +285,7 @@ FPp.hasParens = function () {
 };
 
 FPp.getPrevToken = function (node) {
+  node = node || this.getNode();
   const loc = node && node.loc;
   const tokens = loc && loc.tokens;
   if (tokens && loc.start.token > 0) {
@@ -301,6 +302,7 @@ FPp.getPrevToken = function (node) {
 };
 
 FPp.getNextToken = function (node) {
+  node = node || this.getNode();
   const loc = node && node.loc;
   const tokens = loc && loc.tokens;
   if (tokens && loc.end.token < tokens.length) {

--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -224,58 +224,96 @@ function expressionStartsWithCurlyBrace(node) {
   }
 }
 
+// Returns true if the node at the tip of the path is wrapped with
+// parentheses, or if any ancestor that shares an opening or closing
+// parenthesis with the node is wrapped with parentheses. For example, the
+// FunctionExpression in `(function(){}())` has parentheses according to
+// this logic, even though it is not immediately followed by a `)` token,
+// because its CallExpression parent shares the same opening `(`, and the
+// CallExpression is immediately followed by a `)` token.
 FPp.hasParens = function () {
-  return this.hasOpeningParen() && this.hasClosingParen();
+  const origNode = this.getNode();
+
+  const origPrevToken = this.getPrevToken(origNode);
+  if (! origPrevToken) {
+    return false;
+  }
+
+  const origNextToken = this.getNextToken(origNode);
+  if (! origNextToken) {
+    return false;
+  }
+
+  if (origPrevToken.value === "(") {
+    if (origNextToken.value === ")") {
+      return true;
+    }
+
+    // Any ancestor that shares origPrevToken can provide a closing
+    // parenthesis to satisfy hasParens.
+    for (let i = this.stack.length - 1; i >= 0; i -= 2) {
+      const node = this.stack[i];
+      if (node !== origNode && Node.check(node)) {
+        if (this.getPrevToken(node) === origPrevToken) {
+          const nextToken = this.getNextToken(node);
+          if (! nextToken) return false;
+          if (nextToken.value === ")") {
+            return true;
+          }
+        } else break;
+      }
+    }
+
+  } else if (origNextToken.value === ")") {
+    // Any ancestor that shares origNextToken can provide an opening
+    // parenthesis to satisfy hasParens.
+    for (let i = this.stack.length - 1; i >= 0; i -= 2) {
+      const node = this.stack[i];
+      if (node !== origNode && Node.check(node)) {
+        if (this.getNextToken(node) === origNextToken) {
+          const prevToken = this.getPrevToken(node);
+          if (! prevToken) return false;
+          if (prevToken.value === "(") {
+            return true;
+          }
+        } else break;
+      }
+    }
+  }
+
+  return false;
 };
 
-FPp.hasOpeningParen = function () {
-  const node = this.getNode();
+FPp.getPrevToken = function (node) {
   const loc = node && node.loc;
   const tokens = loc && loc.tokens;
-
   if (tokens && loc.start.token > 0) {
-    const prevToken = tokens[loc.start.token - 1];
-    if (prevToken) {
-      const value = typeof prevToken.value === "string"
-        ? prevToken.value
-        : loc.lines.sliceString(prevToken.loc.start,
-                                prevToken.loc.end);
-      if (value === "(") {
-        // If we found an opening parenthesis but it occurred before the
-        // start of the original subtree for this reprinting, then we must
-        // not return true.
-        const rootLoc = this.getRootValue().loc;
-        return util.comparePos(rootLoc.start, prevToken.loc.start) <= 0;
+    const token = tokens[loc.start.token - 1];
+    if (token) {
+      // Do not return tokens that fall outside the root subtree.
+      const rootLoc = this.getRootValue().loc;
+      if (util.comparePos(rootLoc.start, token.loc.start) <= 0) {
+        return token;
       }
     }
   }
-
-  return false;
+  return null;
 };
 
-FPp.hasClosingParen = function () {
-  const node = this.getNode();
+FPp.getNextToken = function (node) {
   const loc = node && node.loc;
   const tokens = loc && loc.tokens;
-
   if (tokens && loc.end.token < tokens.length) {
-    const nextToken = tokens[loc.end.token];
-    if (nextToken) {
-      const value = typeof nextToken.value === "string"
-        ? nextToken.value
-        : loc.lines.sliceString(nextToken.loc.start,
-                                nextToken.loc.end);
-      if (value === ")") {
-        // If we found a closing parenthesis but it occurred after the end
-        // of the original subtree for this reprinting, then we must not
-        // return true.
-        const rootLoc = this.getRootValue().loc;
-        return util.comparePos(nextToken.loc.end, rootLoc.end) <= 0;
+    const token = tokens[loc.end.token];
+    if (token) {
+      // Do not return tokens that fall outside the root subtree.
+      const rootLoc = this.getRootValue().loc;
+      if (util.comparePos(token.loc.end, rootLoc.end) <= 0) {
+        return token;
       }
     }
   }
-
-  return false;
+  return null;
 };
 
 // Inspired by require("ast-types").NodePath.prototype.needsParens, but

--- a/lib/fast-path.js
+++ b/lib/fast-path.js
@@ -225,59 +225,49 @@ function expressionStartsWithCurlyBrace(node) {
 }
 
 // Returns true if the node at the tip of the path is wrapped with
-// parentheses, or if any ancestor that shares an opening or closing
-// parenthesis with the node is wrapped with parentheses. For example, the
-// FunctionExpression in `(function(){}())` has parentheses according to
-// this logic, even though it is not immediately followed by a `)` token,
-// because its CallExpression parent shares the same opening `(`, and the
-// CallExpression is immediately followed by a `)` token.
+// parentheses, OR if the only reason the node needed parentheses was that
+// it couldn't be the first expression in the enclosing statement (see
+// FastPath#canBeFirstInStatement), and it has an opening `(` character.
+// For example, the FunctionExpression in `(function(){}())` appears to
+// need parentheses only because it's the first expression in the AST, but
+// since it happens to be preceded by a `(` (which is not apparent from
+// the AST but can be determined using FastPath#getPrevToken), there is no
+// ambiguity about how to parse it, so it counts as having parentheses,
+// even though it is not immediately followed by a `)`.
 FPp.hasParens = function () {
-  const origNode = this.getNode();
+  const node = this.getNode();
 
-  const origPrevToken = this.getPrevToken(origNode);
-  if (! origPrevToken) {
+  const prevToken = this.getPrevToken(node);
+  if (! prevToken) {
     return false;
   }
 
-  const origNextToken = this.getNextToken(origNode);
-  if (! origNextToken) {
+  const nextToken = this.getNextToken(node);
+  if (! nextToken) {
     return false;
   }
 
-  if (origPrevToken.value === "(") {
-    if (origNextToken.value === ")") {
+  if (prevToken.value === "(") {
+    if (nextToken.value === ")") {
+      // If the node preceded by a `(` token and followed by a `)` token,
+      // then of course it has parentheses.
       return true;
     }
 
-    // Any ancestor that shares origPrevToken can provide a closing
-    // parenthesis to satisfy hasParens.
-    for (let i = this.stack.length - 1; i >= 0; i -= 2) {
-      const node = this.stack[i];
-      if (node !== origNode && Node.check(node)) {
-        if (this.getPrevToken(node) === origPrevToken) {
-          const nextToken = this.getNextToken(node);
-          if (! nextToken) return false;
-          if (nextToken.value === ")") {
-            return true;
-          }
-        } else break;
-      }
-    }
+    // If this is one of the few Expression types that can't come first in
+    // the enclosing statement because of parsing ambiguities (namely,
+    // FunctionExpression, ObjectExpression, and ClassExpression) and
+    // this.firstInStatement() returns true, and the node would not need
+    // parentheses in an expression context because this.needsParens(true)
+    // returns false, then it just needs an opening parenthesis to resolve
+    // the parsing ambiguity that made it appear to need parentheses.
+    const justNeedsOpeningParen =
+      ! this.canBeFirstInStatement() &&
+      this.firstInStatement() &&
+      ! this.needsParens(true);
 
-  } else if (origNextToken.value === ")") {
-    // Any ancestor that shares origNextToken can provide an opening
-    // parenthesis to satisfy hasParens.
-    for (let i = this.stack.length - 1; i >= 0; i -= 2) {
-      const node = this.stack[i];
-      if (node !== origNode && Node.check(node)) {
-        if (this.getNextToken(node) === origNextToken) {
-          const prevToken = this.getPrevToken(node);
-          if (! prevToken) return false;
-          if (prevToken.value === "(") {
-            return true;
-          }
-        } else break;
-      }
+    if (justNeedsOpeningParen) {
+      return true;
     }
   }
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,127 +1,125 @@
 var defaults = {
-    // If you want to use a different branch of esprima, or any other
-    // module that supports a .parse function, pass that module object to
-    // recast.parse as options.parser (legacy synonym: options.esprima).
-    parser: require("../parsers/esprima"),
+  // If you want to use a different branch of esprima, or any other module
+  // that supports a .parse function, pass that module object to
+  // recast.parse as options.parser (legacy synonym: options.esprima).
+  parser: require("../parsers/esprima"),
 
-    // Number of spaces the pretty-printer should use per tab for
-    // indentation. If you do not pass this option explicitly, it will be
-    // (quite reliably!) inferred from the original code.
-    tabWidth: 4,
+  // Number of spaces the pretty-printer should use per tab for
+  // indentation. If you do not pass this option explicitly, it will be
+  // (quite reliably!) inferred from the original code.
+  tabWidth: 4,
 
-    // If you really want the pretty-printer to use tabs instead of
-    // spaces, make this option true.
-    useTabs: false,
+  // If you really want the pretty-printer to use tabs instead of spaces,
+  // make this option true.
+  useTabs: false,
 
-    // The reprinting code leaves leading whitespace untouched unless it
-    // has to reindent a line, or you pass false for this option.
-    reuseWhitespace: true,
+  // The reprinting code leaves leading whitespace untouched unless it has
+  // to reindent a line, or you pass false for this option.
+  reuseWhitespace: true,
 
-    // Override this option to use a different line terminator, e.g. \r\n.
-    lineTerminator: require("os").EOL || "\n",
+  // Override this option to use a different line terminator, e.g. \r\n.
+  lineTerminator: require("os").EOL || "\n",
 
-    // Some of the pretty-printer code (such as that for printing function
-    // parameter lists) makes a valiant attempt to prevent really long
-    // lines. You can adjust the limit by changing this option; however,
-    // there is no guarantee that line length will fit inside this limit.
-    wrapColumn: 74, // Aspirational for now.
+  // Some of the pretty-printer code (such as that for printing function
+  // parameter lists) makes a valiant attempt to prevent really long
+  // lines. You can adjust the limit by changing this option; however,
+  // there is no guarantee that line length will fit inside this limit.
+  wrapColumn: 74, // Aspirational for now.
 
-    // Pass a string as options.sourceFileName to recast.parse to tell the
-    // reprinter to keep track of reused code so that it can construct a
-    // source map automatically.
-    sourceFileName: null,
+  // Pass a string as options.sourceFileName to recast.parse to tell the
+  // reprinter to keep track of reused code so that it can construct a
+  // source map automatically.
+  sourceFileName: null,
 
-    // Pass a string as options.sourceMapName to recast.print, and
-    // (provided you passed options.sourceFileName earlier) the
-    // PrintResult of recast.print will have a .map property for the
-    // generated source map.
-    sourceMapName: null,
+  // Pass a string as options.sourceMapName to recast.print, and (provided
+  // you passed options.sourceFileName earlier) the PrintResult of
+  // recast.print will have a .map property for the generated source map.
+  sourceMapName: null,
 
-    // If provided, this option will be passed along to the source map
-    // generator as a root directory for relative source file paths.
-    sourceRoot: null,
+  // If provided, this option will be passed along to the source map
+  // generator as a root directory for relative source file paths.
+  sourceRoot: null,
 
-    // If you provide a source map that was generated from a previous call
-    // to recast.print as options.inputSourceMap, the old source map will
-    // be composed with the new source map.
-    inputSourceMap: null,
+  // If you provide a source map that was generated from a previous call
+  // to recast.print as options.inputSourceMap, the old source map will be
+  // composed with the new source map.
+  inputSourceMap: null,
 
-    // If you want esprima to generate .range information (recast only
-    // uses .loc internally), pass true for this option.
-    range: false,
+  // If you want esprima to generate .range information (recast only uses
+  // .loc internally), pass true for this option.
+  range: false,
 
-    // If you want esprima not to throw exceptions when it encounters
-    // non-fatal errors, keep this option true.
-    tolerant: true,
+  // If you want esprima not to throw exceptions when it encounters
+  // non-fatal errors, keep this option true.
+  tolerant: true,
 
-    // If you want to override the quotes used in string literals, specify
-    // either "single", "double", or "auto" here ("auto" will select the one
-    // which results in the shorter literal)
-    // Otherwise, double quotes are used.
-    quote: null,
+  // If you want to override the quotes used in string literals, specify
+  // either "single", "double", or "auto" here ("auto" will select the one
+  // which results in the shorter literal) Otherwise, use double quotes.
+  quote: null,
 
-    // Controls the printing of trailing commas in object literals,
-    // array expressions and function parameters.
-    //
-    // This option could either be:
-    // * Boolean - enable/disable in all contexts (objects, arrays and function params).
-    // * Object - enable/disable per context.
-    //
-    // Example:
-    // trailingComma: {
-    //   objects: true,
-    //   arrays: true,
-    //   parameters: false,
-    // }
-    trailingComma: false,
+  // Controls the printing of trailing commas in object literals, array
+  // expressions and function parameters.
+  //
+  // This option could either be:
+  // * Boolean - enable/disable in all contexts (objects, arrays and function params).
+  // * Object - enable/disable per context.
+  //
+  // Example:
+  // trailingComma: {
+  //   objects: true,
+  //   arrays: true,
+  //   parameters: false,
+  // }
+  trailingComma: false,
 
-    // Controls the printing of spaces inside array brackets.
-    // See: http://eslint.org/docs/rules/array-bracket-spacing
-    arrayBracketSpacing: false,
+  // Controls the printing of spaces inside array brackets.
+  // See: http://eslint.org/docs/rules/array-bracket-spacing
+  arrayBracketSpacing: false,
 
-    // Controls the printing of spaces inside object literals,
-    // destructuring assignments, and import/export specifiers.
-    // See: http://eslint.org/docs/rules/object-curly-spacing
-    objectCurlySpacing: true,
+  // Controls the printing of spaces inside object literals,
+  // destructuring assignments, and import/export specifiers.
+  // See: http://eslint.org/docs/rules/object-curly-spacing
+  objectCurlySpacing: true,
 
-    // If you want parenthesis to wrap single-argument arrow function parameter
-    // lists, pass true for this option.
-    arrowParensAlways: false,
+  // If you want parenthesis to wrap single-argument arrow function
+  // parameter lists, pass true for this option.
+  arrowParensAlways: false,
 
-    // There are 2 supported syntaxes (`,` and `;`) in Flow Object Types;
-    // The use of commas is in line with the more popular style and matches
-    // how objects are defined in JS, making it a bit more natural to write.
-    flowObjectCommas: true,
+  // There are 2 supported syntaxes (`,` and `;`) in Flow Object Types;
+  // The use of commas is in line with the more popular style and matches
+  // how objects are defined in JS, making it a bit more natural to write.
+  flowObjectCommas: true,
 }, hasOwn = defaults.hasOwnProperty;
 
 // Copy options and fill in default values.
 exports.normalize = function(options) {
-    options = options || defaults;
+  options = options || defaults;
 
-    function get(key) {
-        return hasOwn.call(options, key)
-            ? options[key]
-            : defaults[key];
-    }
+  function get(key) {
+    return hasOwn.call(options, key)
+      ? options[key]
+      : defaults[key];
+  }
 
-    return {
-        tabWidth: +get("tabWidth"),
-        useTabs: !!get("useTabs"),
-        reuseWhitespace: !!get("reuseWhitespace"),
-        lineTerminator: get("lineTerminator"),
-        wrapColumn: Math.max(get("wrapColumn"), 0),
-        sourceFileName: get("sourceFileName"),
-        sourceMapName: get("sourceMapName"),
-        sourceRoot: get("sourceRoot"),
-        inputSourceMap: get("inputSourceMap"),
-        parser: get("esprima") || get("parser"),
-        range: get("range"),
-        tolerant: get("tolerant"),
-        quote: get("quote"),
-        trailingComma: get("trailingComma"),
-        arrayBracketSpacing: get("arrayBracketSpacing"),
-        objectCurlySpacing: get("objectCurlySpacing"),
-        arrowParensAlways: get("arrowParensAlways"),
-        flowObjectCommas: get("flowObjectCommas"),
-    };
+  return {
+    tabWidth: +get("tabWidth"),
+    useTabs: !!get("useTabs"),
+    reuseWhitespace: !!get("reuseWhitespace"),
+    lineTerminator: get("lineTerminator"),
+    wrapColumn: Math.max(get("wrapColumn"), 0),
+    sourceFileName: get("sourceFileName"),
+    sourceMapName: get("sourceMapName"),
+    sourceRoot: get("sourceRoot"),
+    inputSourceMap: get("inputSourceMap"),
+    parser: get("esprima") || get("parser"),
+    range: get("range"),
+    tolerant: get("tolerant"),
+    quote: get("quote"),
+    trailingComma: get("trailingComma"),
+    arrayBracketSpacing: get("arrayBracketSpacing"),
+    objectCurlySpacing: get("objectCurlySpacing"),
+    arrowParensAlways: get("arrowParensAlways"),
+    flowObjectCommas: get("flowObjectCommas"),
+  };
 };

--- a/lib/options.js
+++ b/lib/options.js
@@ -90,6 +90,10 @@ var defaults = {
   // The use of commas is in line with the more popular style and matches
   // how objects are defined in JS, making it a bit more natural to write.
   flowObjectCommas: true,
+
+  // Whether to return an array of .tokens on the root AST node.
+  tokens: true
+
 }, hasOwn = defaults.hasOwnProperty;
 
 // Copy options and fill in default values.
@@ -121,5 +125,6 @@ exports.normalize = function(options) {
     objectCurlySpacing: get("objectCurlySpacing"),
     arrowParensAlways: get("arrowParensAlways"),
     flowObjectCommas: get("flowObjectCommas"),
+    tokens: !!get("tokens")
   };
 };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -37,6 +37,19 @@ exports.parse = function parse(source, options) {
     sourceType: util.getOption(options, "sourceType", "module")
   });
 
+  // Use ast.tokens if possible, and otherwise fall back to the Esprima
+  // tokenizer. All the preconfigured ../parsers/* expose ast.tokens
+  // automatically, but custom parsers might need additional configuration
+  // to avoid this fallback.
+  const tokens = Array.isArray(ast.tokens)
+    ? ast.tokens
+    : require("esprima").tokenize(sourceWithoutTabs, {
+        loc: true
+      });
+
+  // We will reattach the tokens array to the file object below.
+  delete ast.tokens;
+
   if (Array.isArray(ast.comments)) {
     comments = ast.comments;
     delete ast.comments;
@@ -76,6 +89,11 @@ exports.parse = function parse(source, options) {
     program = file.program;
   }
 
+  // Expose file.tokens unless the caller passed false for options.tokens.
+  if (options.tokens) {
+    file.tokens = tokens;
+  }
+
   // Expand the Program's .loc to include all comments (not just those
   // attached to the Program node, as its children may have comments as
   // well), since sometimes program.loc.{start,end} will coincide with the
@@ -100,12 +118,15 @@ exports.parse = function parse(source, options) {
 
   // Return a copy of the original AST so that any changes made may be
   // compared to the original.
-  return new TreeCopier(lines).copy(file);
+  return new TreeCopier(lines, tokens).copy(file);
 };
 
-function TreeCopier(lines) {
+function TreeCopier(lines, tokens) {
   assert.ok(this instanceof TreeCopier);
   this.lines = lines;
+  this.tokens = tokens;
+  this.startTokenIndex = 0;
+  this.endTokenIndex = tokens.length;
   this.indent = 0;
   this.seen = new Map;
 }
@@ -147,6 +168,9 @@ TCp.copy = function(node) {
   var oldIndent = this.indent;
   var newIndent = oldIndent;
 
+  const oldStartTokenIndex = this.startTokenIndex;
+  const oldEndTokenIndex = this.endTokenIndex;
+
   if (loc) {
     // When node is a comment, we set node.loc.indent to
     // node.loc.start.column so that, when/if we print the comment by
@@ -159,8 +183,16 @@ TCp.copy = function(node) {
       newIndent = this.indent = loc.start.column;
     }
 
+    // Every node.loc has a reference to the original source lines as well
+    // as a complete list of source tokens.
     loc.lines = this.lines;
+    loc.tokens = this.tokens;
     loc.indent = newIndent;
+
+    // Set loc.start.token and loc.end.token such that
+    // loc.tokens.slice(loc.start.token, loc.end.token) returns a list of
+    // all the tokens that make up this node.
+    this.findTokenRange(loc);
   }
 
   var keys = Object.keys(node);
@@ -180,6 +212,59 @@ TCp.copy = function(node) {
   }
 
   this.indent = oldIndent;
+  this.startTokenIndex = oldStartTokenIndex;
+  this.endTokenIndex = oldEndTokenIndex;
 
   return copy;
+};
+
+// If we didn't have any idea where in loc.tokens to look for tokens
+// contained by this loc, a binary search would be appropriate, but
+// because we maintain this.startTokenIndex and this.endTokenIndex as we
+// traverse the AST, we only need to make small (linear) adjustments to
+// those indexes with each recursive iteration.
+TCp.findTokenRange = function (loc) {
+  // In the unlikely event that loc.tokens[this.startTokenIndex] starts
+  // *after* loc.start, we need to rewind this.startTokenIndex first.
+  while (this.startTokenIndex > 0) {
+    const token = loc.tokens[this.startTokenIndex];
+    if (util.comparePos(loc.start, token.loc.start) < 0) {
+      --this.startTokenIndex;
+    } else break;
+  }
+
+  // In the unlikely event that loc.tokens[this.endTokenIndex - 1] ends
+  // *before* loc.end, we need to fast-forward this.endTokenIndex first.
+  while (this.endTokenIndex < loc.tokens.length) {
+    const token = loc.tokens[this.endTokenIndex];
+    if (util.comparePos(token.loc.end, loc.end) < 0) {
+      ++this.endTokenIndex;
+    } else break;
+  }
+
+  // Increment this.startTokenIndex until we've found the first token
+  // contained by this node.
+  while (this.startTokenIndex < this.endTokenIndex) {
+    const token = loc.tokens[this.startTokenIndex];
+    if (util.comparePos(token.loc.start, loc.start) < 0) {
+      ++this.startTokenIndex;
+    } else break;
+  }
+
+  // Index into loc.tokens of the first token within this node.
+  loc.start.token = this.startTokenIndex;
+
+  // Decrement this.endTokenIndex until we've found the first token after
+  // this node (not contained by the node).
+  while (this.endTokenIndex > this.startTokenIndex) {
+    const token = loc.tokens[this.endTokenIndex - 1];
+    if (util.comparePos(loc.end, token.loc.end) < 0) {
+      --this.endTokenIndex;
+    } else break;
+  }
+
+  // Index into loc.tokens of the first token *after* this node.
+  // If loc.start.token === loc.end.token, the node contains no tokens,
+  // and the index is that of the next token following this node.
+  loc.end.token = this.endTokenIndex;
 };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -50,6 +50,13 @@ exports.parse = function parse(source, options) {
   // We will reattach the tokens array to the file object below.
   delete ast.tokens;
 
+  // Make sure every token has a token.value string.
+  tokens.forEach(function (token) {
+    if (typeof token.value !== "string") {
+      token.value = lines.sliceString(token.loc.start, token.loc.end);
+    }
+  });
+
   if (Array.isArray(ast.comments)) {
     comments = ast.comments;
     delete ast.comments;

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -216,7 +216,13 @@ exports.getReprinter = function(path) {
 
     // Recall that origLoc is the .loc of an ancestor node that is
     // guaranteed to contain all the reprinted nodes and comments.
-    return patcher.get(origLoc).indentTail(-orig.loc.indent);
+    const patchedLines = patcher.get(origLoc).indentTail(-orig.loc.indent);
+
+    if (path.needsParens()) {
+      return linesModule.concat(["(", patchedLines, ")"]);
+    }
+
+    return patchedLines;
   };
 };
 

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -190,10 +190,9 @@ exports.getReprinter = function(path) {
         patcher.deleteComments(oldNode);
       }
 
-      var newLines = print(
-        reprint.newPath,
-        needToPrintNewPathWithComments
-      ).indentTail(oldNode.loc.indent);
+      var newLines = print(reprint.newPath, {
+        includeComments: needToPrintNewPathWithComments
+      }).indentTail(oldNode.loc.indent);
 
       var nls = needsLeadingSpace(lines, oldNode.loc, newLines);
       var nts = needsTrailingSpace(lines, oldNode.loc, newLines);

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -191,7 +191,14 @@ exports.getReprinter = function(path) {
       }
 
       var newLines = print(reprint.newPath, {
-        includeComments: needToPrintNewPathWithComments
+        includeComments: needToPrintNewPathWithComments,
+        // If the oldNode we're replacing already had parentheses, we may
+        // not need to print the new node with any extra parentheses,
+        // because the existing parentheses will suffice. However, if the
+        // newNode has a different type than the oldNode, let the printer
+        // decide if reprint.newPath needs parentheses, as usual.
+        avoidRootParens: (oldNode.type === newNode.type &&
+                          reprint.oldPath.hasParens())
       }).indentTail(oldNode.loc.indent);
 
       var nls = needsLeadingSpace(lines, oldNode.loc, newLines);

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -403,78 +403,6 @@ function findObjectReprints(newPath, oldPath, reprints) {
   return findChildReprints(newPath, oldPath, reprints);
 }
 
-// This object is reused in hasOpeningParen and hasClosingParen to avoid
-// having to allocate a temporary object.
-var reusablePos = { line: 1, column: 0 };
-var nonSpaceExp = /\S/;
-
-function hasOpeningParen(oldPath) {
-  var oldNode = oldPath.getValue();
-  var loc = oldNode.loc;
-  var lines = loc && loc.lines;
-
-  if (lines) {
-    var pos = reusablePos;
-    pos.line = loc.start.line;
-    pos.column = loc.start.column;
-
-    while (lines.prevPos(pos)) {
-      var ch = lines.charAt(pos);
-
-      if (ch === "(") {
-        // If we found an opening parenthesis but it occurred before the
-        // start of the original subtree for this reprinting, then we must
-        // not return true for hasOpeningParen(oldPath).
-        return comparePos(oldPath.getRootValue().loc.start, pos) <= 0;
-      }
-
-      if (nonSpaceExp.test(ch)) {
-        return false;
-      }
-    }
-  }
-
-  return false;
-}
-
-function hasClosingParen(oldPath) {
-  var oldNode = oldPath.getValue();
-  var loc = oldNode.loc;
-  var lines = loc && loc.lines;
-
-  if (lines) {
-    var pos = reusablePos;
-    pos.line = loc.end.line;
-    pos.column = loc.end.column;
-
-    do {
-      var ch = lines.charAt(pos);
-
-      if (ch === ")") {
-        // If we found a closing parenthesis but it occurred after the end
-        // of the original subtree for this reprinting, then we must not
-        // return true for hasClosingParen(oldPath).
-        return comparePos(pos, oldPath.getRootValue().loc.end) <= 0;
-      }
-
-      if (nonSpaceExp.test(ch)) {
-        return false;
-      }
-
-    } while (lines.nextPos(pos));
-  }
-
-  return false;
-}
-
-function hasParens(oldPath) {
-  // This logic can technically be fooled if the node has parentheses but
-  // there are comments intervening between the parentheses and the
-  // node. In such cases the node will be harmlessly wrapped in an
-  // additional layer of parentheses.
-  return hasOpeningParen(oldPath) && hasClosingParen(oldPath);
-}
-
 function findChildReprints(newPath, oldPath, reprints) {
   var newNode = newPath.getValue();
   var oldNode = oldPath.getValue();
@@ -500,16 +428,17 @@ function findChildReprints(newPath, oldPath, reprints) {
   // a closing parenthesis after the FunctionExpression would trigger
   // pretty-printing unnecessarily.
   if (Node.check(newNode) &&
-      !newPath.canBeFirstInStatement() &&
+      ! newPath.canBeFirstInStatement() &&
       newPath.firstInStatement() &&
-      !hasOpeningParen(oldPath)) {
+      ! oldPath.hasOpeningParen()) {
     return false;
   }
 
   // If this node needs parentheses and will not be wrapped with
   // parentheses when reprinted, then return false to skip reprinting and
   // let it be printed generically.
-  if (newPath.needsParens(true) && !hasParens(oldPath)) {
+  if (newPath.needsParens(true) &&
+      ! oldPath.hasParens()) {
     return false;
   }
 

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -415,29 +415,10 @@ function findChildReprints(newPath, oldPath, reprints) {
     return false;
   }
 
-  // If this type of node cannot come lexically first in its enclosing
-  // statement (e.g. a function expression or object literal), and it
-  // seems to be doing so, then the only way we can ignore this problem
-  // and save ourselves from falling back to the pretty printer is if an
-  // opening parenthesis happens to precede the node.  For example,
-  // (function(){ ... }()); does not need to be reprinted, even though the
-  // FunctionExpression comes lexically first in the enclosing
-  // ExpressionStatement and fails the hasParens test, because the parent
-  // CallExpression passes the hasParens test. If we relied on the
-  // path.needsParens() && !hasParens(oldNode) check below, the absence of
-  // a closing parenthesis after the FunctionExpression would trigger
-  // pretty-printing unnecessarily.
-  if (Node.check(newNode) &&
-      ! newPath.canBeFirstInStatement() &&
-      newPath.firstInStatement() &&
-      ! oldPath.hasOpeningParen()) {
-    return false;
-  }
-
   // If this node needs parentheses and will not be wrapped with
   // parentheses when reprinted, then return false to skip reprinting and
   // let it be printed generically.
-  if (newPath.needsParens(true) &&
+  if (newPath.needsParens() &&
       ! oldPath.hasParens()) {
     return false;
   }

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -68,8 +68,9 @@ function Printer(config) {
 
     function print(path, options) {
         assert.ok(path instanceof FastPath);
+        options = options || {};
 
-        if (options && options.includeComments) {
+        if (options.includeComments) {
             return printComments(path, makePrintFunctionWith(options, {
                 includeComments: false
             }));
@@ -95,9 +96,15 @@ function Printer(config) {
             // right choice because it gives us the opportunity to reprint
             // such nodes using their original source.
             ? reprinter(print)
-            : genericPrint(path, config, makePrintFunctionWith(options, {
-                includeComments: true
-            }));
+            : genericPrint(
+                path,
+                config,
+                options,
+                makePrintFunctionWith(options, {
+                    includeComments: true,
+                    avoidRootParens: false
+                })
+            );
 
         config.tabWidth = oldTabWidth;
 
@@ -110,7 +117,8 @@ function Printer(config) {
         }
 
         const lines = print(FastPath.from(ast), {
-            includeComments: true
+            includeComments: true,
+            avoidRootParens: false
         });
 
         return new PrintResult(
@@ -133,7 +141,10 @@ function Printer(config) {
         // Print the entire AST generically.
         function printGenerically(path) {
             return printComments(path, function (path) {
-                return genericPrint(path, config, printGenerically);
+                return genericPrint(path, config, {
+                    includeComments: true,
+                    avoidRootParens: false
+                }, printGenerically);
             });
         }
 
@@ -153,42 +164,48 @@ function Printer(config) {
 
 exports.Printer = Printer;
 
-function genericPrint(path, options, printPath) {
+function genericPrint(path, config, options, printPath) {
     assert.ok(path instanceof FastPath);
 
     const node = path.getValue();
     const parts = [];
     const linesWithoutParens =
-        genericPrintNoParens(path, options, printPath);
+        genericPrintNoParens(path, config, printPath);
 
     if (! node || linesWithoutParens.isEmpty()) {
         return linesWithoutParens;
     }
 
-    let needsParens = false;
+    let shouldAddParens = false;
     const decoratorsLines = printDecorators(path, printPath);
 
     if (decoratorsLines.isEmpty()) {
         // Nodes with decorators can't have parentheses, so we can avoid
         // computing path.needsParens() except in this case.
-        needsParens = path.needsParens();
+        if (! options.avoidRootParens) {
+            shouldAddParens = path.needsParens();
+        }
     } else {
         parts.push(decoratorsLines);
     }
 
-    if (needsParens) {
+    if (shouldAddParens) {
         parts.unshift("(");
     }
 
     parts.push(linesWithoutParens);
 
-    if (needsParens) {
+    if (shouldAddParens) {
         parts.push(")");
     }
 
     return concat(parts);
 }
 
+// Note that the `options` parameter of this function is what other
+// functions in this file call the `config` object (that is, the
+// configuration object originally passed into the Printer constructor).
+// Its properties are documented in lib/options.js.
 function genericPrintNoParens(path, options, print) {
     var n = path.getValue();
 

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -63,28 +63,23 @@ function Printer(config) {
     }
 
     function print(path, includeComments) {
-        if (includeComments)
+        if (includeComments) {
             return printWithComments(path);
+        }
 
         assert.ok(path instanceof FastPath);
 
-        if (!explicitTabWidth) {
-            const oldTabWidth = config.tabWidth;
+        const oldTabWidth = config.tabWidth;
+
+        if (! explicitTabWidth) {
             const loc = path.getNode().loc;
             if (loc && loc.lines && loc.lines.guessTabWidth) {
                 config.tabWidth = loc.lines.guessTabWidth();
-                const lines = maybeReprint(path);
-                config.tabWidth = oldTabWidth;
-                return lines;
             }
         }
 
-        return maybeReprint(path);
-    }
-
-    function maybeReprint(path) {
         const reprinter = getReprinter(path);
-        if (reprinter) {
+        const lines = reprinter
             // Since the print function that we pass to the reprinter will
             // be used to print "new" nodes, it's tempting to think we
             // should pass printRootGenerically instead of print, to avoid
@@ -93,9 +88,12 @@ function Printer(config) {
             // moved from elsewhere in the AST. The print function is the
             // right choice because it gives us the opportunity to reprint
             // such nodes using their original source.
-            return reprinter(print);
-        }
-        return printRootGenerically(path);
+            ? reprinter(print)
+            : printRootGenerically(path);
+
+        config.tabWidth = oldTabWidth;
+
+        return lines;
     }
 
     // Print the root node generically, but then resume reprinting its

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -46,17 +46,16 @@ PRp.toString = function() {
 
 var emptyPrintResult = new PrintResult("");
 
-function Printer(originalOptions) {
+function Printer(config) {
     assert.ok(this instanceof Printer);
 
-    var explicitTabWidth = originalOptions && originalOptions.tabWidth;
-    var options = normalizeOptions(originalOptions);
-    assert.notStrictEqual(options, originalOptions);
+    const explicitTabWidth = config && config.tabWidth;
+    config = normalizeOptions(config);
 
     // It's common for client code to pass the same options into both
     // recast.parse and recast.print, but the Printer doesn't need (and
-    // can be confused by) options.sourceFileName, so we null it out.
-    options.sourceFileName = null;
+    // can be confused by) config.sourceFileName, so we null it out.
+    config.sourceFileName = null;
 
     function printWithComments(path) {
         assert.ok(path instanceof FastPath);
@@ -70,12 +69,12 @@ function Printer(originalOptions) {
         assert.ok(path instanceof FastPath);
 
         if (!explicitTabWidth) {
-            var oldTabWidth = options.tabWidth;
-            var loc = path.getNode().loc;
+            const oldTabWidth = config.tabWidth;
+            const loc = path.getNode().loc;
             if (loc && loc.lines && loc.lines.guessTabWidth) {
-                options.tabWidth = loc.lines.guessTabWidth();
-                var lines = maybeReprint(path);
-                options.tabWidth = oldTabWidth;
+                config.tabWidth = loc.lines.guessTabWidth();
+                const lines = maybeReprint(path);
+                config.tabWidth = oldTabWidth;
                 return lines;
             }
         }
@@ -84,7 +83,7 @@ function Printer(originalOptions) {
     }
 
     function maybeReprint(path) {
-        var reprinter = getReprinter(path);
+        const reprinter = getReprinter(path);
         if (reprinter) {
             // Since the print function that we pass to the reprinter will
             // be used to print "new" nodes, it's tempting to think we
@@ -104,13 +103,13 @@ function Printer(originalOptions) {
     function printRootGenerically(path, includeComments) {
         return includeComments
             ? printComments(path, printRootGenerically)
-            : genericPrint(path, options, printWithComments);
+            : genericPrint(path, config, printWithComments);
     }
 
     // Print the entire AST generically.
     function printGenerically(path) {
         return printComments(path, function (path) {
-            return genericPrint(path, options, printGenerically);
+            return genericPrint(path, config, printGenerically);
         });
     }
 
@@ -119,15 +118,15 @@ function Printer(originalOptions) {
             return emptyPrintResult;
         }
 
-        var lines = print(FastPath.from(ast), true);
+        const lines = print(FastPath.from(ast), true);
 
         return new PrintResult(
-            lines.toString(options),
+            lines.toString(config),
             util.composeSourceMaps(
-                options.inputSourceMap,
+                config.inputSourceMap,
                 lines.getSourceMap(
-                    options.sourceMapName,
-                    options.sourceRoot
+                    config.sourceMapName,
+                    config.sourceRoot
                 )
             )
         );
@@ -138,16 +137,16 @@ function Printer(originalOptions) {
             return emptyPrintResult;
         }
 
-        var path = FastPath.from(ast);
-        var oldReuseWhitespace = options.reuseWhitespace;
+        const path = FastPath.from(ast);
+        const oldReuseWhitespace = config.reuseWhitespace;
 
         // Do not reuse whitespace (or anything else, for that matter)
         // when printing generically.
-        options.reuseWhitespace = false;
+        config.reuseWhitespace = false;
 
         // TODO Allow printing of comments?
-        var pr = new PrintResult(printGenerically(path).toString(options));
-        options.reuseWhitespace = oldReuseWhitespace;
+        const pr = new PrintResult(printGenerically(path).toString(config));
+        config.reuseWhitespace = oldReuseWhitespace;
         return pr;
     };
 }

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -94,7 +94,7 @@ function Printer(originalOptions) {
             // moved from elsewhere in the AST. The print function is the
             // right choice because it gives us the opportunity to reprint
             // such nodes using their original source.
-            return maybeAddParens(path, reprinter(print));
+            return reprinter(print);
         }
         return printRootGenerically(path);
     }
@@ -153,10 +153,6 @@ function Printer(originalOptions) {
 }
 
 exports.Printer = Printer;
-
-function maybeAddParens(path, lines) {
-    return path.needsParens() ? concat(["(", lines, ")"]) : lines;
-}
 
 function genericPrint(path, options, printPath) {
     assert.ok(path instanceof FastPath);

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -146,39 +146,24 @@ exports.Printer = Printer;
 function genericPrint(path, options, printPath) {
     assert.ok(path instanceof FastPath);
 
-    var node = path.getValue();
-    var parts = [];
-    var needsParens = false;
-    var linesWithoutParens =
+    const node = path.getValue();
+    const parts = [];
+    const linesWithoutParens =
         genericPrintNoParens(path, options, printPath);
 
     if (! node || linesWithoutParens.isEmpty()) {
         return linesWithoutParens;
     }
 
-    if (node.decorators &&
-        node.decorators.length > 0 &&
-        // If the parent node is an export declaration, it will be
-        // responsible for printing node.decorators.
-        ! util.getParentExportDeclaration(path)) {
+    let needsParens = false;
+    const decoratorsLines = printDecorators(path, printPath);
 
-        path.each(function(decoratorPath) {
-            parts.push(printPath(decoratorPath), "\n");
-        }, "decorators");
-
-    } else if (util.isExportDeclaration(node) &&
-               node.declaration &&
-               node.declaration.decorators) {
-        // Export declarations are responsible for printing any decorators
-        // that logically apply to node.declaration.
-        path.each(function(decoratorPath) {
-            parts.push(printPath(decoratorPath), "\n");
-        }, "declaration", "decorators");
-
-    } else {
+    if (decoratorsLines.isEmpty()) {
         // Nodes with decorators can't have parentheses, so we can avoid
         // computing path.needsParens() except in this case.
         needsParens = path.needsParens();
+    } else {
+        parts.push(decoratorsLines);
     }
 
     if (needsParens) {
@@ -2339,6 +2324,33 @@ function genericPrintNoParens(path, options, print) {
     }
 
     return p;
+}
+
+function printDecorators(path, printPath) {
+    const parts = [];
+    const node = path.getValue();
+
+    if (node.decorators &&
+        node.decorators.length > 0 &&
+        // If the parent node is an export declaration, it will be
+        // responsible for printing node.decorators.
+        ! util.getParentExportDeclaration(path)) {
+
+        path.each(function(decoratorPath) {
+            parts.push(printPath(decoratorPath), "\n");
+        }, "decorators");
+
+    } else if (util.isExportDeclaration(node) &&
+               node.declaration &&
+               node.declaration.decorators) {
+        // Export declarations are responsible for printing any decorators
+        // that logically apply to node.declaration.
+        path.each(function(decoratorPath) {
+            parts.push(printPath(decoratorPath), "\n");
+        }, "declaration", "decorators");
+    }
+
+    return concat(parts);
 }
 
 function printStatementSequence(path, options, print) {

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -57,17 +57,23 @@ function Printer(config) {
     // can be confused by) config.sourceFileName, so we null it out.
     config.sourceFileName = null;
 
-    function printWithComments(path) {
-        assert.ok(path instanceof FastPath);
-        return printComments(path, print);
+    // Non-destructively modifies options with overrides, and returns a
+    // new print function that uses the modified options.
+    function makePrintFunctionWith(options, overrides) {
+        options = Object.assign({}, options, overrides);
+        return function (path) {
+            return print(path, options);
+        };
     }
 
-    function print(path, includeComments) {
-        if (includeComments) {
-            return printWithComments(path);
-        }
-
+    function print(path, options) {
         assert.ok(path instanceof FastPath);
+
+        if (options && options.includeComments) {
+            return printComments(path, makePrintFunctionWith(options, {
+                includeComments: false
+            }));
+        }
 
         const oldTabWidth = config.tabWidth;
 
@@ -89,18 +95,13 @@ function Printer(config) {
             // right choice because it gives us the opportunity to reprint
             // such nodes using their original source.
             ? reprinter(print)
-            : genericPrint(path, config, printWithComments);
+            : genericPrint(path, config, makePrintFunctionWith(options, {
+                includeComments: true
+            }));
 
         config.tabWidth = oldTabWidth;
 
         return lines;
-    }
-
-    // Print the entire AST generically.
-    function printGenerically(path) {
-        return printComments(path, function (path) {
-            return genericPrint(path, config, printGenerically);
-        });
     }
 
     this.print = function(ast) {
@@ -108,7 +109,9 @@ function Printer(config) {
             return emptyPrintResult;
         }
 
-        const lines = print(FastPath.from(ast), true);
+        const lines = print(FastPath.from(ast), {
+            includeComments: true
+        });
 
         return new PrintResult(
             lines.toString(config),
@@ -125,6 +128,13 @@ function Printer(config) {
     this.printGenerically = function(ast) {
         if (!ast) {
             return emptyPrintResult;
+        }
+
+        // Print the entire AST generically.
+        function printGenerically(path) {
+            return printComments(path, function (path) {
+                return genericPrint(path, config, printGenerically);
+            });
         }
 
         const path = FastPath.from(ast);

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -89,19 +89,11 @@ function Printer(config) {
             // right choice because it gives us the opportunity to reprint
             // such nodes using their original source.
             ? reprinter(print)
-            : printRootGenerically(path);
+            : genericPrint(path, config, printWithComments);
 
         config.tabWidth = oldTabWidth;
 
         return lines;
-    }
-
-    // Print the root node generically, but then resume reprinting its
-    // children non-generically.
-    function printRootGenerically(path, includeComments) {
-        return includeComments
-            ? printComments(path, printRootGenerically)
-            : genericPrint(path, config, printWithComments);
     }
 
     // Print the entire AST generically.

--- a/parsers/_babylon_options.js
+++ b/parsers/_babylon_options.js
@@ -11,7 +11,7 @@ module.exports = function (options) {
     allowImportExportEverywhere: true,
     allowReturnOutsideFunction: true,
     startLine: 1,
-    tokens: getOption(options, "tokens", true),
+    tokens: true,
     plugins: [
       "asyncGenerators",
       "bigInt",

--- a/parsers/esprima.js
+++ b/parsers/esprima.js
@@ -18,7 +18,7 @@ exports.parse = function (source, options) {
     onComment: comments,
     range: getOption(options, "range", false),
     tolerant: getOption(options, "tolerant", true),
-    tokens: getOption(options, "tokens", true)
+    tokens: true
   });
 
   if (! Array.isArray(ast.comments)) {

--- a/test/parens.js
+++ b/test/parens.js
@@ -292,4 +292,30 @@ describe("parens", function () {
   it("should be added to object destructuring assignment expressions", function () {
     check("({x}={x:1})");
   });
+
+  it("regression test for issue #327", function () {
+    const expr = "(function(){}())";
+    check(expr);
+
+    const ast = parse(expr);
+    const callExpression = ast.program.body[0].expression;
+    assert.strictEqual(callExpression.type, "CallExpression");
+    callExpression.callee.type = "ArrowFunctionExpression";
+    assert.strictEqual(
+      printer.print(ast).code,
+      "((() => {})())"
+    );
+    // Print just the callExpression without its enclosing AST context.
+    assert.strictEqual(
+      printer.print(callExpression).code,
+      "(() => {})()"
+    );
+    // Trigger pretty-printing of the callExpression to remove the outer
+    // layer of parentheses.
+    callExpression.original = null;
+    assert.strictEqual(
+      printer.print(ast).code,
+      "(() => {})();"
+    );
+  });
 });

--- a/test/parens.js
+++ b/test/parens.js
@@ -17,13 +17,16 @@ function parseExpression(expr) {
 }
 
 function check(expr) {
-  var ast1 = parseExpression(expr);
-  var printed = printer.printGenerically(ast1).code;
-  try {
-    var ast2 = parseExpression(printed);
-  } finally {
-    types.astNodesAreEquivalent.assert(ast1, ast2);
-  }
+  const ast = parse(expr);
+  const reprinted = printer.print(ast).code;
+  assert.strictEqual(reprinted, expr);
+
+  const expressionAst = parseExpression(expr);
+  const generic = printer.printGenerically(expressionAst).code;
+  types.astNodesAreEquivalent.assert(
+    expressionAst,
+    parseExpression(generic)
+  );
 }
 
 var operators = [

--- a/test/parens.js
+++ b/test/parens.js
@@ -291,6 +291,8 @@ describe("parens", function () {
 
   it("should be added to object destructuring assignment expressions", function () {
     check("({x}={x:1})");
+    // Issue #533
+    check("({ foo } = bar)");
   });
 
   it("regression test for issue #327", function () {

--- a/test/parens.js
+++ b/test/parens.js
@@ -10,286 +10,283 @@ var printer = new Printer;
 var eol = require("os").EOL;
 
 function parseExpression(expr) {
-    var ast = esprima.parse(expr);
-    n.Program.assert(ast);
-    ast = ast.body[0];
-    if (n.ExpressionStatement.check(ast))
-        return ast.expression;
-    return ast;
+  var ast = esprima.parse(expr);
+  n.Program.assert(ast);
+  ast = ast.body[0];
+  return n.ExpressionStatement.check(ast) ? ast.expression : ast;
 }
 
 function check(expr) {
-    var ast1 = parseExpression(expr);
-    var printed = printer.printGenerically(ast1).code;
-    try {
-        var ast2 = parseExpression(printed);
-    } finally {
-        types.astNodesAreEquivalent.assert(ast1, ast2);
-    }
+  var ast1 = parseExpression(expr);
+  var printed = printer.printGenerically(ast1).code;
+  try {
+    var ast2 = parseExpression(printed);
+  } finally {
+    types.astNodesAreEquivalent.assert(ast1, ast2);
+  }
 }
 
 var operators = [
-    "==", "!=", "===", "!==",
-    "<", "<=", ">", ">=",
-    "<<", ">>", ">>>",
-    "+", "-", "*", "/", "%",
-    "&", // TODO Missing from the Parser API.
-    "|", "^", "in",
-    "instanceof",
-    "&&", "||"
+  "==", "!=", "===", "!==",
+  "<", "<=", ">", ">=",
+  "<<", ">>", ">>>",
+  "+", "-", "*", "/", "%",
+  "&", // TODO Missing from the Parser API.
+  "|", "^", "in",
+  "instanceof",
+  "&&", "||"
 ];
 
-describe("parens", function() {
-    it("Arithmetic", function() {
-        check("1 - 2");
-        check("  2 +2 ");
+describe("parens", function () {
+  it("Arithmetic", function () {
+    check("1 - 2");
+    check("  2 +2 ");
 
-        operators.forEach(function(op1) {
-            operators.forEach(function(op2) {
-                check("(a " + op1 + " b) " + op2 + " c");
-                check("a " + op1 + " (b " + op2 + " c)");
-            });
-        });
+    operators.forEach(function (op1) {
+      operators.forEach(function (op2) {
+        check("(a " + op1 + " b) " + op2 + " c");
+        check("a " + op1 + " (b " + op2 + " c)");
+      });
+    });
+  });
+
+  it("Unary", function () {
+    check("(-a).b");
+    check("(+a).b");
+    check("(!a).b");
+    check("(~a).b");
+    check("(typeof a).b");
+    check("(void a).b");
+    check("(delete a.b).c");
+  });
+
+  it("Binary", function () {
+    check("(a && b)()");
+    check("typeof (a && b)");
+    check("(a && b)[c]");
+    check("(a && b).c");
+  });
+
+  it("Sequence", function () {
+    check("(a, b)()");
+    check("a(b, (c, d), e)");
+    check("!(a, b)");
+    check("a + (b, c) + d");
+    check("var a = (1, 2), b = a + a;");
+    check("(a, { b: 2 }).b");
+    check("[a, (b, c), d]");
+    check("({ a: (1, 2) }).a");
+    check("(a, b) ? (a = 1, b = 2) : (c = 3)");
+    check("a = (1, 2)");
+  });
+
+  it("NewExpression", function () {
+    check("new (a.b())");
+    check("new (a.b())(c)");
+    check("new a.b(c)");
+    check("+new Date");
+    check("(new Date).getTime()");
+    check("new a");
+    check("(new a)(b)");
+    check("(new (a.b(c))(d))(e)");
+    check("(new Date)['getTime']()");
+    check('(new Date)["getTime"]()');
+  });
+
+  it("Numbers", function () {
+    check("(1).foo");
+    check("(-1).foo");
+    check("+0");
+    check("NaN.foo");
+    check("(-Infinity).foo");
+  });
+
+  it("Assign", function () {
+    check("!(a = false)");
+    check("a + (b = 2) + c");
+    check("(a = fn)()");
+    check("(a = b) ? c : d");
+    check("(a = b)[c]");
+    check("(a = b).c");
+  });
+
+  it("Function", function () {
+    check("a(function (){}.bind(this))");
+    check("(function (){}).apply(this, arguments)");
+    check("function f() { (function (){}).call(this) }");
+    check("while (true) { (function (){}).call(this) }");
+    check("() => ({a:1,b:2})");
+    check("(x, y={z:1}) => x + y.z");
+    check("a || ((x, y={z:1}) => x + y.z)");
+  });
+
+  it("ObjectLiteral", function () {
+    check("a({b:c(d)}.b)");
+    check("({a:b(c)}).a");
+  });
+
+  it("ReprintedParens", function () {
+    var code = "a(function g(){}.call(this));";
+    var ast1 = parse(code);
+    var body = ast1.program.body;
+
+    // Copy the function from a position where it does not need
+    // parentheses to a position where it does need parentheses.
+    body.push(b.expressionStatement(
+      body[0].expression.arguments[0]));
+
+    var generic = printer.printGenerically(ast1).code;
+    var ast2 = parse(generic);
+    types.astNodesAreEquivalent.assert(ast1, ast2);
+
+    var reprint = printer.print(ast1).code;
+    var ast3 = parse(reprint);
+    types.astNodesAreEquivalent.assert(ast1, ast3);
+
+    body.shift();
+    reprint = printer.print(ast1).code;
+    var ast4 = parse(reprint);
+    assert.strictEqual(ast4.program.body.length, 1);
+    var callExp = ast4.program.body[0].expression;
+    n.CallExpression.assert(callExp);
+    n.MemberExpression.assert(callExp.callee);
+    n.FunctionExpression.assert(callExp.callee.object);
+    types.astNodesAreEquivalent.assert(ast1, ast4);
+
+    var objCode = "({ foo: 42 }.foo);";
+    var objAst = parse(objCode);
+    var memExp = objAst.program.body[0].expression;
+    n.MemberExpression.assert(memExp);
+    n.ObjectExpression.assert(memExp.object);
+    n.Identifier.assert(memExp.property);
+    assert.strictEqual(memExp.property.name, "foo");
+    var blockStmt = b.blockStatement([b.expressionStatement(memExp)]);
+    reprint = printer.print(blockStmt).code;
+    types.astNodesAreEquivalent.assert(
+      blockStmt,
+      parse(reprint).program.body[0]
+    );
+  });
+
+  it("don't reparenthesize valid IIFEs", function () {
+    var iifeCode = "(function     spaces   () {        }.call()  )  ;";
+    var iifeAst = parse(iifeCode);
+    var iifeReprint = printer.print(iifeAst).code;
+    assert.strictEqual(iifeReprint, iifeCode);
+  });
+
+  it("don't reparenthesize valid object literals", function () {
+    var objCode = "(  {    foo   :  42}.  foo )  ;";
+    var objAst = parse(objCode);
+    var objReprint = printer.print(objAst).code;
+    assert.strictEqual(objReprint, objCode);
+  });
+
+  it("don't parenthesize return statements with sequence expressions", function () {
+    var objCode = "function foo() { return 1, 2; }";
+    var objAst = parse(objCode);
+    var objReprint = printer.print(objAst).code;
+    assert.strictEqual(objReprint, objCode);
+  });
+
+  it("NegatedLoopCondition", function () {
+    var ast = parse([
+      "for (var i = 0; i < 10; ++i) {",
+      "  console.log(i);",
+      "}"
+    ].join(eol))
+
+    var loop = ast.program.body[0];
+    var test = loop.test;
+    var negation = b.unaryExpression("!", test);
+
+    assert.strictEqual(
+      printer.print(negation).code,
+      "!(i < 10)"
+    );
+
+    loop.test = negation;
+
+    assert.strictEqual(printer.print(ast).code, [
+      "for (var i = 0; !(i < 10); ++i) {",
+      "  console.log(i);",
+      "}"
+    ].join(eol));
+  });
+
+  it("MisleadingExistingParens", function () {
+    var ast = parse([
+      // The key === "oyez" expression appears to have parentheses
+      // already, but those parentheses won't help us when we negate the
+      // condition with a !.
+      'if (key === "oyez") {',
+      "  throw new Error(key);",
+      "}"
+    ].join(eol));
+
+    var ifStmt = ast.program.body[0];
+    ifStmt.test = b.unaryExpression("!", ifStmt.test);
+
+    var binaryPath = new NodePath(ast).get(
+      "program", "body", 0, "test", "argument");
+
+    assert.ok(binaryPath.needsParens());
+
+    assert.strictEqual(printer.print(ifStmt).code, [
+      'if (!(key === "oyez")) {',
+      "  throw new Error(key);",
+      "}"
+    ].join(eol));
+  });
+
+  it("DiscretionaryParens", function () {
+    var code = [
+      "if (info.line && (i > 0 || !skipFirstLine)) {",
+      "  info = copyLineInfo(info);",
+      "}"
+    ].join(eol);
+
+    var ast = parse(code);
+
+    var rightPath = new NodePath(ast).get(
+      "program", "body", 0, "test", "right");
+
+    assert.ok(rightPath.needsParens());
+    assert.strictEqual(printer.print(ast).code, code);
+  });
+
+  it("should not be added to multiline boolean expressions", function () {
+    var code = [
+      "function foo() {",
+      "  return !(",
+      "    a &&",
+      "    b &&",
+      "    c",
+      "  );",
+      "}"
+    ].join(eol);
+
+    var ast = parse(code);
+    var printer = new Printer({
+      tabWidth: 2
     });
 
-    it("Unary", function() {
-        check("(-a).b");
-        check("(+a).b");
-        check("(!a).b");
-        check("(~a).b");
-        check("(typeof a).b");
-        check("(void a).b");
-        check("(delete a.b).c");
-    });
+    assert.strictEqual(
+      printer.print(ast).code,
+      code
+    );
+  });
 
-    it("Binary", function() {
-        check("(a && b)()");
-        check("typeof (a && b)");
-        check("(a && b)[c]");
-        check("(a && b).c");
-    });
+  it("should be added to callees that are function expressions", function () {
+    check("(()=>{})()");
+    check("(function (){})()");
+  });
 
-    it("Sequence", function() {
-        check("(a, b)()");
-        check("a(b, (c, d), e)");
-        check("!(a, b)");
-        check("a + (b, c) + d");
-        check("var a = (1, 2), b = a + a;");
-        check("(a, { b: 2 }).b");
-        check("[a, (b, c), d]");
-        check("({ a: (1, 2) }).a");
-        check("(a, b) ? (a = 1, b = 2) : (c = 3)");
-        check("a = (1, 2)");
-    });
+  it("should be added to bound arrow function expressions", function () {
+    check("(()=>{}).bind(x)");
+  });
 
-    it("NewExpression", function() {
-        check("new (a.b())");
-        check("new (a.b())(c)");
-        check("new a.b(c)");
-        check("+new Date");
-        check("(new Date).getTime()");
-        check("new a");
-        check("(new a)(b)");
-        check("(new (a.b(c))(d))(e)");
-        check("(new Date)['getTime']()");
-        check('(new Date)["getTime"]()');
-    });
-
-    it("Numbers", function() {
-        check("(1).foo");
-        check("(-1).foo");
-        check("+0");
-        check("NaN.foo");
-        check("(-Infinity).foo");
-    });
-
-    it("Assign", function() {
-        check("!(a = false)");
-        check("a + (b = 2) + c");
-        check("(a = fn)()");
-        check("(a = b) ? c : d");
-        check("(a = b)[c]");
-        check("(a = b).c");
-    });
-
-    it("Function", function() {
-        check("a(function(){}.bind(this))");
-        check("(function(){}).apply(this, arguments)");
-        check("function f() { (function(){}).call(this) }");
-        check("while (true) { (function(){}).call(this) }");
-        check("() => ({a:1,b:2})");
-        check("(x, y={z:1}) => x + y.z");
-        check("a || ((x, y={z:1}) => x + y.z)");
-    });
-
-    it("ObjectLiteral", function() {
-        check("a({b:c(d)}.b)");
-        check("({a:b(c)}).a");
-    });
-
-    it("ReprintedParens", function() {
-        var code = "a(function g(){}.call(this));";
-        var ast1 = parse(code);
-        var body = ast1.program.body;
-
-        // Copy the function from a position where it does not need
-        // parentheses to a position where it does need parentheses.
-        body.push(b.expressionStatement(
-            body[0].expression.arguments[0]));
-
-        var generic = printer.printGenerically(ast1).code;
-        var ast2 = parse(generic);
-        types.astNodesAreEquivalent.assert(ast1, ast2);
-
-        var reprint = printer.print(ast1).code;
-        var ast3 = parse(reprint);
-        types.astNodesAreEquivalent.assert(ast1, ast3);
-
-        body.shift();
-        reprint = printer.print(ast1).code;
-        var ast4 = parse(reprint);
-        assert.strictEqual(ast4.program.body.length, 1);
-        var callExp = ast4.program.body[0].expression;
-        n.CallExpression.assert(callExp);
-        n.MemberExpression.assert(callExp.callee);
-        n.FunctionExpression.assert(callExp.callee.object);
-        types.astNodesAreEquivalent.assert(ast1, ast4);
-
-        var objCode = "({ foo: 42 }.foo);";
-        var objAst = parse(objCode);
-        var memExp = objAst.program.body[0].expression;
-        n.MemberExpression.assert(memExp);
-        n.ObjectExpression.assert(memExp.object);
-        n.Identifier.assert(memExp.property);
-        assert.strictEqual(memExp.property.name, "foo");
-        var blockStmt = b.blockStatement([b.expressionStatement(memExp)]);
-        reprint = printer.print(blockStmt).code;
-        types.astNodesAreEquivalent.assert(
-            blockStmt,
-            parse(reprint).program.body[0]
-        );
-    });
-
-    it("don't reparenthesize valid IIFEs", function() {
-        var iifeCode = "(function     spaces   () {        }.call()  )  ;";
-        var iifeAst = parse(iifeCode);
-        var iifeReprint = printer.print(iifeAst).code;
-        assert.strictEqual(iifeReprint, iifeCode);
-    });
-
-    it("don't reparenthesize valid object literals", function() {
-        var objCode = "(  {    foo   :  42}.  foo )  ;";
-        var objAst = parse(objCode);
-        var objReprint = printer.print(objAst).code;
-        assert.strictEqual(objReprint, objCode);
-    });
-
-    it("don't parenthesize return statements with sequence expressions", function() {
-        var objCode = "function foo() { return 1, 2; }";
-        var objAst = parse(objCode);
-        var objReprint = printer.print(objAst).code;
-        assert.strictEqual(objReprint, objCode);
-    });
-
-    it("NegatedLoopCondition", function() {
-        var ast = parse([
-            "for (var i = 0; i < 10; ++i) {",
-            "  console.log(i);",
-            "}"
-        ].join(eol))
-
-        var loop = ast.program.body[0];
-        var test = loop.test;
-        var negation = b.unaryExpression("!", test);
-
-        assert.strictEqual(
-            printer.print(negation).code,
-            "!(i < 10)"
-        );
-
-        loop.test = negation;
-
-        assert.strictEqual(printer.print(ast).code, [
-            "for (var i = 0; !(i < 10); ++i) {",
-            "  console.log(i);",
-            "}"
-        ].join(eol));
-    });
-
-    it("MisleadingExistingParens", function() {
-        var ast = parse([
-            // The key === "oyez" expression appears to have parentheses
-            // already, but those parentheses won't help us when we negate the
-            // condition with a !.
-            'if (key === "oyez") {',
-            "  throw new Error(key);",
-            "}"
-        ].join(eol));
-
-        var ifStmt = ast.program.body[0];
-        ifStmt.test = b.unaryExpression("!", ifStmt.test);
-
-        var binaryPath = new NodePath(ast).get(
-            "program", "body", 0, "test", "argument");
-
-        assert.ok(binaryPath.needsParens());
-
-        assert.strictEqual(printer.print(ifStmt).code, [
-            'if (!(key === "oyez")) {',
-            "  throw new Error(key);",
-            "}"
-        ].join(eol));
-    });
-
-    it("DiscretionaryParens", function() {
-        var code = [
-            "if (info.line && (i > 0 || !skipFirstLine)) {",
-            "  info = copyLineInfo(info);",
-            "}"
-        ].join(eol);
-
-        var ast = parse(code);
-
-        var rightPath = new NodePath(ast).get(
-            "program", "body", 0, "test", "right");
-
-        assert.ok(rightPath.needsParens());
-        assert.strictEqual(printer.print(ast).code, code);
-    });
-
-    it("should not be added to multiline boolean expressions", function() {
-        var code = [
-            "function foo() {",
-            "  return !(",
-            "    a &&",
-            "    b &&",
-            "    c",
-            "  );",
-            "}"
-        ].join(eol);
-
-        var ast = parse(code);
-        var printer = new Printer({
-            tabWidth: 2
-        });
-
-        assert.strictEqual(
-            printer.print(ast).code,
-            code
-        );
-    });
-
-    it("should be added to callees that are function expressions", function() {
-        check("(()=>{})()");
-        check("(function(){})()");
-    });
-
-    it("should be added to bound arrow function expressions", function() {
-        check("(()=>{}).bind(x)");
-    });
-
-    it("should be added to object destructuring assignment expressions", function() {
-        check("({x}={x:1})");
-    });
-
+  it("should be added to object destructuring assignment expressions", function () {
+    check("({x}={x:1})");
+  });
 });

--- a/test/parens.js
+++ b/test/parens.js
@@ -285,6 +285,14 @@ describe("parens", function () {
     check("(function (){})()");
   });
 
+  it("issues #504 and #512", function () {
+    check("() => ({})['foo']");
+    check("() => ({ foo: 123 }[foo] + 2) * 3");
+    check("() => ({ foo: 123 }['foo'] + 1 - 2 - 10)");
+    check("() => (function () { return 123 })()");
+    check("() => (function () { return 456 }())");
+  });
+
   it("should be added to bound arrow function expressions", function () {
     check("(()=>{}).bind(x)");
   });

--- a/test/parens.js
+++ b/test/parens.js
@@ -328,4 +328,19 @@ describe("parens", function () {
       "(() => {})();"
     );
   });
+
+  it("regression test for issue #366", function () {
+    const code = "typeof a ? b : c";
+    check(code);
+
+    const ast = parse(code);
+    const exprStmt = ast.program.body[0];
+    const callee = exprStmt.expression;
+    exprStmt.expression = b.callExpression(callee, []);
+
+    assert.strictEqual(
+      printer.print(ast).code,
+      "(typeof a ? b : c)()"
+    );
+  });
 });


### PR DESCRIPTION
Recast has suffered for a long time because it did not have reliable access to the lexical analysis of source tokens during reprinting, and instead relied on scanning source characters, which is error-prone because identifying comments, string literals, regular expression literals, and other large tokens is difficult/impossible without doing a full tokenization and sometimes a small amount of initial parsing.
    
Most importantly, accurate token information can be used to detect whether a node was originally wrapped with parentheses, even if those parentheses were separated from the node by comments or other incidental non-whitespace text, such as trailing commas. Here are just some of the issues that have resulted from the lack of reliable token information:

- [x] #533
- [ ] #528
- [ ] #513
- [x] #512
- [x] #504
- [x] #366
- [x] #327
- [ ] #286
    
With this change, every node in the AST returned by `recast.parse` will now have a `node.loc.tokens` reference to shared array containing the entire sequence of original source tokens, as well as `node.loc.{start,end}.token` indexes into this array of tokens, such that
```js
node.loc.tokens.slice(
  node.loc.start.token,
  node.loc.end.token
)
```
returns a complete list of all source tokens contained by the node. Note that some nodes (such as comments) may contain no source tokens, in which case `node.loc.start.token === node.loc.end.token`, which will be the index of the first token *after* the position where the node appeared.
    
Most parsers can expose token information for free / very cheaply, as a byproduct of the parsing process. In case a custom parser is provided that does not expose token information, we fall back to Esprima's tokenizer. While there is considerable variation between different parsers in terms of AST format, there is much less variation in tokenization, so the Esprima tokenizer should be adequate in most cases (even for JS dialects like TypeScript). If it is not adequate, the caller should simply ensure that the custom parser exposes an `ast.tokens` array containing token objects with `token.loc.{start,end}.{line,column}` information.