### PR TITLE
Fix optional member expression printer

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -288,7 +288,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         parts.push(path.call(print, "object"));
 
         var property = path.call(print, "property");
-        var optional = n.type === "OptionalMemberExpression";
+        var optional = n.type === "OptionalMemberExpression" && n.optional;
 
         if (n.computed) {
             parts.push(optional ? "?.[" : "[", property, "]");

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1729,7 +1729,6 @@ describe("printer", function() {
   });
 
   it("obeys 'optional' property of OptionalMemberExpression", function () {
-
     var node = b.optionalMemberExpression(
       b.identifier('foo'),
       b.identifier('bar')

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1728,6 +1728,31 @@ describe("printer", function() {
     );
   });
 
+  it("obeys 'optional' property of OptionalMemberExpression", function () {
+
+    var node = b.optionalMemberExpression(
+      b.identifier('foo'),
+      b.identifier('bar')
+    );
+
+    assert.strictEqual(
+      recast.print(node).code,
+      "foo?.bar"
+    );
+
+    var nonOptionalNode = b.optionalMemberExpression(
+      b.identifier('foo'),
+      b.identifier('bar'),
+      false,
+      false
+    );
+
+    assert.strictEqual(
+      recast.print(nonOptionalNode).code,
+      "foo.bar"
+    );
+  });
+
   it("prints numbers in bases other than 10 without converting them", function() {
     var code = [
       'let decimal = 6;',


### PR DESCRIPTION
OptionalMemberExpression has `optional` property which defines wether `?` is printed or not.

Try e.g `a?.b.c.d;` in [AST explorer](https://astexplorer.net/) to see how OptionalMemberExpression with optional=false is used.

E: ping @benjamn 