### PR TITLE
#368 - Print typeAnnotation for ObjectPattern

### DIFF
--- a/lib/printer.js
+++ b/lib/printer.js
@@ -700,6 +700,10 @@ function genericPrintNoParens(path, options, print) {
             parts[parts.length - 1] = " " + rightBrace;
         }
 
+        if (n.typeAnnotation) {
+            parts.push(path.call(print, "typeAnnotation"));
+        }
+
         return concat(parts);
 
     case "PropertyPattern":

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -292,6 +292,14 @@ describe("TypeScript", function() {
       '  public static async *[name]<T>(arg: U): V;',
       '}'
     ]);
+
+    check([
+      'function myFunction(',
+      '  {',
+      '    param1',
+      '  }: Params',
+      ') {}'
+    ]);
   });
 });
 


### PR DESCRIPTION
Fixes https://github.com/benjamn/recast/issues/368

Print typeAnnotation for ObjectPattern, if present

Example:
```
function SomeSFC({ prop1 }: Props) {}
```
The `: Props` was not being printed.


1. Wrote test

```
  1 failing

  1) TypeScript
       basic printing:

      AssertionError [ERR_ASSERTION]: Input A expected to strictly equal input B:
+ expected - actual

- 'function myFunction(\n  {\n    param1\n  }: Params\n) {}'
+ 'function myFunction(\n  {\n    param1\n  }\n) {}'
      + expected - actual

       function myFunction(
         {
           param1
      -  }: Params
      +  }
       ) {}
```

2. Applied fix
3. Reran tests