### PR TITLE
Fix issue with export default template literals

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -265,25 +265,28 @@ function fixTemplateLiteral(node, lines) {
     // If there are no quasi elements, then there is nothing to fix.
     return;
   }
+  
+  // node.loc is not present when using export default with a template literal
+  if (node.loc) {
+    // First we need to exclude the opening ` from the .loc of the first
+    // quasi element, in case the parser accidentally decided to include it.
+    var afterLeftBackTickPos = copyPos(node.loc.start);
+    assert.strictEqual(lines.charAt(afterLeftBackTickPos), "`");
+    assert.ok(lines.nextPos(afterLeftBackTickPos));
+    var firstQuasi = node.quasis[0];
+    if (comparePos(firstQuasi.loc.start, afterLeftBackTickPos) < 0) {
+      firstQuasi.loc.start = afterLeftBackTickPos;
+    }
 
-  // First we need to exclude the opening ` from the .loc of the first
-  // quasi element, in case the parser accidentally decided to include it.
-  var afterLeftBackTickPos = copyPos(node.loc.start);
-  assert.strictEqual(lines.charAt(afterLeftBackTickPos), "`");
-  assert.ok(lines.nextPos(afterLeftBackTickPos));
-  var firstQuasi = node.quasis[0];
-  if (comparePos(firstQuasi.loc.start, afterLeftBackTickPos) < 0) {
-    firstQuasi.loc.start = afterLeftBackTickPos;
-  }
-
-  // Next we need to exclude the closing ` from the .loc of the last quasi
-  // element, in case the parser accidentally decided to include it.
-  var rightBackTickPos = copyPos(node.loc.end);
-  assert.ok(lines.prevPos(rightBackTickPos));
-  assert.strictEqual(lines.charAt(rightBackTickPos), "`");
-  var lastQuasi = node.quasis[node.quasis.length - 1];
-  if (comparePos(rightBackTickPos, lastQuasi.loc.end) < 0) {
-    lastQuasi.loc.end = rightBackTickPos;
+    // Next we need to exclude the closing ` from the .loc of the last quasi
+    // element, in case the parser accidentally decided to include it.
+    var rightBackTickPos = copyPos(node.loc.end);
+    assert.ok(lines.prevPos(rightBackTickPos));
+    assert.strictEqual(lines.charAt(rightBackTickPos), "`");
+    var lastQuasi = node.quasis[node.quasis.length - 1];
+    if (comparePos(rightBackTickPos, lastQuasi.loc.end) < 0) {
+      lastQuasi.loc.end = rightBackTickPos;
+    }
   }
 
   // Now we need to exclude ${ and } characters from the .loc's of all

--- a/test/es6tests.js
+++ b/test/es6tests.js
@@ -109,6 +109,7 @@ describe("import/export syntax", function() {
     check("export default class {}");
     check("export default function foo () {}");
     check("export default class foo {}");
+    check("export default `hello world`");
 
     // variables exports
     check("export var foo = 1;");


### PR DESCRIPTION
This fixes an issue where exporting a template literal as default caused the parser to fail. It also adds a regression test.

Fixes #414 