### PR TITLE
fix util: nullify loc of ExportDefaultDeclaration declarator

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -177,10 +177,6 @@ export function fixFaultyLocations(node: any, lines: any) {
     });
 
   } else if (node.declaration && isExportDeclaration(node)) {
-    // Nullify .loc information for the child declaration so that we never
-    // try to reprint it without also reprinting the export declaration.
-    node.declaration.loc = null;
-
     // Expand the .loc of the node responsible for printing the decorators
     // (here, the export declaration) so that it includes node.decorators.
     var decorators = node.declaration.decorators;


### PR DESCRIPTION
You can't just set `loc` of `ExportDefaultDeclaration.declarator` to null:

```js
node.declaration.loc = null;
```

This information made for purpose 🙂.

I'm working on pluggable code transformer [putout](https://github.com/coderaiser/putout), and one of it's plugins [remove-unused-variables](https://github.com/coderaiser/putout/tree/master/packages/plugin-remove-unused-variables) uses this information to identify scope of a variable and determine is it used, declared or none of this.

And of course I observe `loc` property which is part of a [estree standard](https://github.com/estree/estree/blob/df2290b23a652e1ec354b6775459a3b42e22f108/es5.md#node-objects).

Here is example:

```js
export default function _addCommands() {
}
```

This is what I have before using `recast.parse`:

```json
{
    "type": "File",
    "program": {
        "type": "Program",
        "start": 0,
        "end": 44,
        "loc": {
            "start": {
                "line": 1,
                "column": 0
            },
            "end": {
                "line": 2,
                "column": 1
            }
        },
        "body": [
            {
                "type": "ExportDefaultDeclaration",
                "start": 0,
                "end": 42,
                "loc": {
                    "start": {
                        "line": 1,
                        "column": 0
                    },
                    "end": {
                        "line": 2,
                        "column": 1
                    }
                },
                "declaration": {
                    "type": "FunctionDeclaration",
                    "start": 15,
                    "end": 42,
                    "loc": {   /* I have loc ! */
                        "start": {
                            "line": 1,
                            "column": 15
                        },
                        "end": {
                            "line": 2,
                            "column": 1
                        }
                    },
                    "id": {
                        "type": "Identifier",
                        "start": 24,
                        "end": 36,
                        "loc": {
                            "start": {
                                "line": 1,
                                "column": 24
                            },
                            "end": {
                                "line": 1,
                                "column": 36
                            }
                        },
                        "name": "_addCommands"
                    },
                    "expression": false,
                    "generator": false,
                    "async": false,
                    "params": [],
                    "body": {
                        "type": "BlockStatement",
                        "start": 39,
                        "end": 42,
                        "loc": {
                            "start": {
                                "line": 1,
                                "column": 39
                            },
                            "end": {
                                "line": 2,
                                "column": 1
                            }
                        },
                        "body": []
                    }
                }
            }
        ],
        "sourceType": "module"
    },
    "comments": []
```

And here is what I have after:

```json
```json
{
    "type": "File",
    "program": {
        "type": "Program",
        "start": 0,
        "end": 44,
        "loc": {
            "start": {
                "line": 1,
                "column": 0
            },
            "end": {
                "line": 2,
                "column": 1
            }
        },
        "body": [
            {
                "type": "ExportDefaultDeclaration",
                "start": 0,
                "end": 42,
                "loc": {
                    "start": {
                        "line": 1,
                        "column": 0
                    },
                    "end": {
                        "line": 2,
                        "column": 1
                    }
                },
                "declaration": {
                    "type": "FunctionDeclaration",
                    "start": 15,
                    "end": 42,
                    "loc": null, /* this is really bad ! */
                    "id": {
                        "type": "Identifier",
                        "start": 24,
                        "end": 36,
                        "loc": {
                            "start": {
                                "line": 1,
                                "column": 24
                            },
                            "end": {
                                "line": 1,
                                "column": 36
                            }
                        },
                        "name": "_addCommands"
                    },
                    "expression": false,
                    "generator": false,
                    "async": false,
                    "params": [],
                    "body": {
                        "type": "BlockStatement",
                        "start": 39,
                        "end": 42,
                        "loc": {
                            "start": {
                                "line": 1,
                                "column": 39
                            },
                            "end": {
                                "line": 2,
                                "column": 1
                            }
                        },
                        "body": []
                    }
                }
            }
        ],
        "sourceType": "module"
    },
    "comments": []
```

Without this fix I should save `loc` information in this tree or in other place, anyway this would be a very ugly slow and strange hack, would be great to have this fixed 🙂. 