### PR TITLE
Convert Lines to class.

### DIFF
--- a/lib/comments.ts
+++ b/lib/comments.ts
@@ -268,7 +268,7 @@ function printLeadingComment(commentPath: any, print: any) {
   } else if (lines instanceof Lines) {
     var trailingSpace = lines.slice(
       loc.end,
-      lines.skipSpaces(loc.end)
+      lines.skipSpaces(loc.end) || lines.lastPos(),
     );
 
     if (trailingSpace.length === 1) {

--- a/lib/comments.ts
+++ b/lib/comments.ts
@@ -11,338 +11,338 @@ var childNodesCacheKey = makeUniqueKey();
 // TODO Move a non-caching implementation of this function into ast-types,
 // and implement a caching wrapper function here.
 function getSortedChildNodes(node: any, lines: any, resultArray?: any) {
-    if (!node) {
-        return;
-    }
+  if (!node) {
+    return;
+  }
 
-    // The .loc checks below are sensitive to some of the problems that
-    // are fixed by this utility function. Specifically, if it decides to
-    // set node.loc to null, indicating that the node's .loc information
-    // is unreliable, then we don't want to add node to the resultArray.
-    fixFaultyLocations(node, lines);
+  // The .loc checks below are sensitive to some of the problems that
+  // are fixed by this utility function. Specifically, if it decides to
+  // set node.loc to null, indicating that the node's .loc information
+  // is unreliable, then we don't want to add node to the resultArray.
+  fixFaultyLocations(node, lines);
 
-    if (resultArray) {
-        if (n.Node.check(node) &&
-            n.SourceLocation.check(node.loc)) {
-            // This reverse insertion sort almost always takes constant
-            // time because we almost always (maybe always?) append the
-            // nodes in order anyway.
-            for (var i = resultArray.length - 1; i >= 0; --i) {
-                if (comparePos(resultArray[i].loc.end,
-                               node.loc.start) <= 0) {
-                    break;
-                }
-            }
-            resultArray.splice(i + 1, 0, node);
-            return;
+  if (resultArray) {
+    if (n.Node.check(node) &&
+        n.SourceLocation.check(node.loc)) {
+      // This reverse insertion sort almost always takes constant
+      // time because we almost always (maybe always?) append the
+      // nodes in order anyway.
+      for (var i = resultArray.length - 1; i >= 0; --i) {
+        if (comparePos(resultArray[i].loc.end,
+                       node.loc.start) <= 0) {
+          break;
         }
-    } else if (node[childNodesCacheKey]) {
-        return node[childNodesCacheKey];
+      }
+      resultArray.splice(i + 1, 0, node);
+      return;
     }
+  } else if (node[childNodesCacheKey]) {
+    return node[childNodesCacheKey];
+  }
 
-    var names;
-    if (isArray.check(node)) {
-        names = Object.keys(node);
-    } else if (isObject.check(node)) {
-        names = types.getFieldNames(node);
-    } else {
-        return;
-    }
+  var names;
+  if (isArray.check(node)) {
+    names = Object.keys(node);
+  } else if (isObject.check(node)) {
+    names = types.getFieldNames(node);
+  } else {
+    return;
+  }
 
-    if (!resultArray) {
-        Object.defineProperty(node, childNodesCacheKey, {
-            value: resultArray = [],
-            enumerable: false
-        });
-    }
+  if (!resultArray) {
+    Object.defineProperty(node, childNodesCacheKey, {
+      value: resultArray = [],
+      enumerable: false
+    });
+  }
 
-    for (var i = 0, nameCount = names.length; i < nameCount; ++i) {
-        getSortedChildNodes(node[names[i]], lines, resultArray);
-    }
+  for (var i = 0, nameCount = names.length; i < nameCount; ++i) {
+    getSortedChildNodes(node[names[i]], lines, resultArray);
+  }
 
-    return resultArray;
+  return resultArray;
 }
 
 // As efficiently as possible, decorate the comment object with
 // .precedingNode, .enclosingNode, and/or .followingNode properties, at
 // least one of which is guaranteed to be defined.
 function decorateComment(node: any, comment: any, lines: any) {
-    var childNodes = getSortedChildNodes(node, lines);
+  var childNodes = getSortedChildNodes(node, lines);
 
-    // Time to dust off the old binary search robes and wizard hat.
-    var left = 0, right = childNodes.length;
-    while (left < right) {
-        var middle = (left + right) >> 1;
-        var child = childNodes[middle];
+  // Time to dust off the old binary search robes and wizard hat.
+  var left = 0, right = childNodes.length;
+  while (left < right) {
+    var middle = (left + right) >> 1;
+    var child = childNodes[middle];
 
-        if (comparePos(child.loc.start, comment.loc.start) <= 0 &&
-            comparePos(comment.loc.end, child.loc.end) <= 0) {
-            // The comment is completely contained by this child node.
-            decorateComment(comment.enclosingNode = child, comment, lines);
-            return; // Abandon the binary search at this level.
-        }
-
-        if (comparePos(child.loc.end, comment.loc.start) <= 0) {
-            // This child node falls completely before the comment.
-            // Because we will never consider this node or any nodes
-            // before it again, this node must be the closest preceding
-            // node we have encountered so far.
-            var precedingNode = child;
-            left = middle + 1;
-            continue;
-        }
-
-        if (comparePos(comment.loc.end, child.loc.start) <= 0) {
-            // This child node falls completely after the comment.
-            // Because we will never consider this node or any nodes after
-            // it again, this node must be the closest following node we
-            // have encountered so far.
-            var followingNode = child;
-            right = middle;
-            continue;
-        }
-
-        throw new Error("Comment location overlaps with node location");
+    if (comparePos(child.loc.start, comment.loc.start) <= 0 &&
+        comparePos(comment.loc.end, child.loc.end) <= 0) {
+      // The comment is completely contained by this child node.
+      decorateComment(comment.enclosingNode = child, comment, lines);
+      return; // Abandon the binary search at this level.
     }
 
-    if (precedingNode) {
-        comment.precedingNode = precedingNode;
+    if (comparePos(child.loc.end, comment.loc.start) <= 0) {
+      // This child node falls completely before the comment.
+      // Because we will never consider this node or any nodes
+      // before it again, this node must be the closest preceding
+      // node we have encountered so far.
+      var precedingNode = child;
+      left = middle + 1;
+      continue;
     }
 
-    if (followingNode) {
-        comment.followingNode = followingNode;
+    if (comparePos(comment.loc.end, child.loc.start) <= 0) {
+      // This child node falls completely after the comment.
+      // Because we will never consider this node or any nodes after
+      // it again, this node must be the closest following node we
+      // have encountered so far.
+      var followingNode = child;
+      right = middle;
+      continue;
     }
+
+    throw new Error("Comment location overlaps with node location");
+  }
+
+  if (precedingNode) {
+    comment.precedingNode = precedingNode;
+  }
+
+  if (followingNode) {
+    comment.followingNode = followingNode;
+  }
 }
 
 export function attach(comments: any[], ast: any, lines: any) {
-    if (!isArray.check(comments)) {
-        return;
-    }
+  if (!isArray.check(comments)) {
+    return;
+  }
 
-    var tiesToBreak: any[] = [];
+  var tiesToBreak: any[] = [];
 
-    comments.forEach(function(comment) {
-        comment.loc.lines = lines;
-        decorateComment(ast, comment, lines);
+  comments.forEach(function(comment) {
+    comment.loc.lines = lines;
+    decorateComment(ast, comment, lines);
 
-        var pn = comment.precedingNode;
-        var en = comment.enclosingNode;
-        var fn = comment.followingNode;
+    var pn = comment.precedingNode;
+    var en = comment.enclosingNode;
+    var fn = comment.followingNode;
 
-        if (pn && fn) {
-            var tieCount = tiesToBreak.length;
-            if (tieCount > 0) {
-                var lastTie = tiesToBreak[tieCount - 1];
+    if (pn && fn) {
+      var tieCount = tiesToBreak.length;
+      if (tieCount > 0) {
+        var lastTie = tiesToBreak[tieCount - 1];
 
-                assert.strictEqual(
-                    lastTie.precedingNode === comment.precedingNode,
-                    lastTie.followingNode === comment.followingNode
-                );
+        assert.strictEqual(
+          lastTie.precedingNode === comment.precedingNode,
+          lastTie.followingNode === comment.followingNode
+        );
 
-                if (lastTie.followingNode !== comment.followingNode) {
-                    breakTies(tiesToBreak, lines);
-                }
-            }
-
-            tiesToBreak.push(comment);
-
-        } else if (pn) {
-            // No contest: we have a trailing comment.
-            breakTies(tiesToBreak, lines);
-            addTrailingComment(pn, comment);
-
-        } else if (fn) {
-            // No contest: we have a leading comment.
-            breakTies(tiesToBreak, lines);
-            addLeadingComment(fn, comment);
-
-        } else if (en) {
-            // The enclosing node has no child nodes at all, so what we
-            // have here is a dangling comment, e.g. [/* crickets */].
-            breakTies(tiesToBreak, lines);
-            addDanglingComment(en, comment);
-
-        } else {
-            throw new Error("AST contains no nodes at all?");
+        if (lastTie.followingNode !== comment.followingNode) {
+          breakTies(tiesToBreak, lines);
         }
-    });
+      }
 
-    breakTies(tiesToBreak, lines);
+      tiesToBreak.push(comment);
 
-    comments.forEach(function(comment) {
-        // These node references were useful for breaking ties, but we
-        // don't need them anymore, and they create cycles in the AST that
-        // may lead to infinite recursion if we don't delete them here.
-        delete comment.precedingNode;
-        delete comment.enclosingNode;
-        delete comment.followingNode;
-    });
+    } else if (pn) {
+      // No contest: we have a trailing comment.
+      breakTies(tiesToBreak, lines);
+      addTrailingComment(pn, comment);
+
+    } else if (fn) {
+      // No contest: we have a leading comment.
+      breakTies(tiesToBreak, lines);
+      addLeadingComment(fn, comment);
+
+    } else if (en) {
+      // The enclosing node has no child nodes at all, so what we
+      // have here is a dangling comment, e.g. [/* crickets */].
+      breakTies(tiesToBreak, lines);
+      addDanglingComment(en, comment);
+
+    } else {
+      throw new Error("AST contains no nodes at all?");
+    }
+  });
+
+  breakTies(tiesToBreak, lines);
+
+  comments.forEach(function(comment) {
+    // These node references were useful for breaking ties, but we
+    // don't need them anymore, and they create cycles in the AST that
+    // may lead to infinite recursion if we don't delete them here.
+    delete comment.precedingNode;
+    delete comment.enclosingNode;
+    delete comment.followingNode;
+  });
 };
 
 function breakTies(tiesToBreak: any[], lines: any) {
-    var tieCount = tiesToBreak.length;
-    if (tieCount === 0) {
-        return;
+  var tieCount = tiesToBreak.length;
+  if (tieCount === 0) {
+    return;
+  }
+
+  var pn = tiesToBreak[0].precedingNode;
+  var fn = tiesToBreak[0].followingNode;
+  var gapEndPos = fn.loc.start;
+
+  // Iterate backwards through tiesToBreak, examining the gaps
+  // between the tied comments. In order to qualify as leading, a
+  // comment must be separated from fn by an unbroken series of
+  // whitespace-only gaps (or other comments).
+  for (var indexOfFirstLeadingComment = tieCount;
+       indexOfFirstLeadingComment > 0;
+       --indexOfFirstLeadingComment) {
+    var comment = tiesToBreak[indexOfFirstLeadingComment - 1];
+    assert.strictEqual(comment.precedingNode, pn);
+    assert.strictEqual(comment.followingNode, fn);
+
+    var gap = lines.sliceString(comment.loc.end, gapEndPos);
+    if (/\S/.test(gap)) {
+      // The gap string contained something other than whitespace.
+      break;
     }
 
-    var pn = tiesToBreak[0].precedingNode;
-    var fn = tiesToBreak[0].followingNode;
-    var gapEndPos = fn.loc.start;
+    gapEndPos = comment.loc.start;
+  }
 
-    // Iterate backwards through tiesToBreak, examining the gaps
-    // between the tied comments. In order to qualify as leading, a
-    // comment must be separated from fn by an unbroken series of
-    // whitespace-only gaps (or other comments).
-    for (var indexOfFirstLeadingComment = tieCount;
-         indexOfFirstLeadingComment > 0;
-         --indexOfFirstLeadingComment) {
-        var comment = tiesToBreak[indexOfFirstLeadingComment - 1];
-        assert.strictEqual(comment.precedingNode, pn);
-        assert.strictEqual(comment.followingNode, fn);
+  while (indexOfFirstLeadingComment <= tieCount &&
+         (comment = tiesToBreak[indexOfFirstLeadingComment]) &&
+         // If the comment is a //-style comment and indented more
+         // deeply than the node itself, reconsider it as trailing.
+         (comment.type === "Line" || comment.type === "CommentLine") &&
+         comment.loc.start.column > fn.loc.start.column) {
+    ++indexOfFirstLeadingComment;
+  }
 
-        var gap = lines.sliceString(comment.loc.end, gapEndPos);
-        if (/\S/.test(gap)) {
-            // The gap string contained something other than whitespace.
-            break;
-        }
-
-        gapEndPos = comment.loc.start;
+  tiesToBreak.forEach(function(comment, i) {
+    if (i < indexOfFirstLeadingComment) {
+      addTrailingComment(pn, comment);
+    } else {
+      addLeadingComment(fn, comment);
     }
+  });
 
-    while (indexOfFirstLeadingComment <= tieCount &&
-           (comment = tiesToBreak[indexOfFirstLeadingComment]) &&
-           // If the comment is a //-style comment and indented more
-           // deeply than the node itself, reconsider it as trailing.
-           (comment.type === "Line" || comment.type === "CommentLine") &&
-           comment.loc.start.column > fn.loc.start.column) {
-        ++indexOfFirstLeadingComment;
-    }
-
-    tiesToBreak.forEach(function(comment, i) {
-        if (i < indexOfFirstLeadingComment) {
-            addTrailingComment(pn, comment);
-        } else {
-            addLeadingComment(fn, comment);
-        }
-    });
-
-    tiesToBreak.length = 0;
+  tiesToBreak.length = 0;
 }
 
 function addCommentHelper(node: any, comment: any) {
-    var comments = node.comments || (node.comments = []);
-    comments.push(comment);
+  var comments = node.comments || (node.comments = []);
+  comments.push(comment);
 }
 
 function addLeadingComment(node: any, comment: any) {
-    comment.leading = true;
-    comment.trailing = false;
-    addCommentHelper(node, comment);
+  comment.leading = true;
+  comment.trailing = false;
+  addCommentHelper(node, comment);
 }
 
 function addDanglingComment(node: any, comment: any) {
-    comment.leading = false;
-    comment.trailing = false;
-    addCommentHelper(node, comment);
+  comment.leading = false;
+  comment.trailing = false;
+  addCommentHelper(node, comment);
 }
 
 function addTrailingComment(node: any, comment: any) {
-    comment.leading = false;
-    comment.trailing = true;
-    addCommentHelper(node, comment);
+  comment.leading = false;
+  comment.trailing = true;
+  addCommentHelper(node, comment);
 }
 
 function printLeadingComment(commentPath: any, print: any) {
-    var comment = commentPath.getValue();
-    n.Comment.assert(comment);
+  var comment = commentPath.getValue();
+  n.Comment.assert(comment);
 
-    var loc = comment.loc;
-    var lines = loc && loc.lines;
-    var parts = [print(commentPath)];
+  var loc = comment.loc;
+  var lines = loc && loc.lines;
+  var parts = [print(commentPath)];
 
-    if (comment.trailing) {
-        // When we print trailing comments as leading comments, we don't
-        // want to bring any trailing spaces along.
-        parts.push("\n");
+  if (comment.trailing) {
+    // When we print trailing comments as leading comments, we don't
+    // want to bring any trailing spaces along.
+    parts.push("\n");
 
-    } else if (lines instanceof Lines) {
-        var trailingSpace = lines.slice(
-            loc.end,
-            lines.skipSpaces(loc.end)
-        );
+  } else if (lines instanceof Lines) {
+    var trailingSpace = lines.slice(
+      loc.end,
+      lines.skipSpaces(loc.end)
+    );
 
-        if (trailingSpace.length === 1) {
-            // If the trailing space contains no newlines, then we want to
-            // preserve it exactly as we found it.
-            parts.push(trailingSpace);
-        } else {
-            // If the trailing space contains newlines, then replace it
-            // with just that many newlines, with all other spaces removed.
-            parts.push(new Array(trailingSpace.length).join("\n"));
-        }
-
+    if (trailingSpace.length === 1) {
+      // If the trailing space contains no newlines, then we want to
+      // preserve it exactly as we found it.
+      parts.push(trailingSpace);
     } else {
-        parts.push("\n");
+      // If the trailing space contains newlines, then replace it
+      // with just that many newlines, with all other spaces removed.
+      parts.push(new Array(trailingSpace.length).join("\n"));
     }
 
-    return concat(parts);
+  } else {
+    parts.push("\n");
+  }
+
+  return concat(parts);
 }
 
 function printTrailingComment(commentPath: any, print: any) {
-    var comment = commentPath.getValue(commentPath);
-    n.Comment.assert(comment);
+  var comment = commentPath.getValue(commentPath);
+  n.Comment.assert(comment);
 
-    var loc = comment.loc;
-    var lines = loc && loc.lines;
-    var parts = [];
+  var loc = comment.loc;
+  var lines = loc && loc.lines;
+  var parts = [];
 
-    if (lines instanceof Lines) {
-        var fromPos = lines.skipSpaces(loc.start, true) || lines.firstPos();
-        var leadingSpace = lines.slice(fromPos, loc.start);
+  if (lines instanceof Lines) {
+    var fromPos = lines.skipSpaces(loc.start, true) || lines.firstPos();
+    var leadingSpace = lines.slice(fromPos, loc.start);
 
-        if (leadingSpace.length === 1) {
-            // If the leading space contains no newlines, then we want to
-            // preserve it exactly as we found it.
-            parts.push(leadingSpace);
-        } else {
-            // If the leading space contains newlines, then replace it
-            // with just that many newlines, sans all other spaces.
-            parts.push(new Array(leadingSpace.length).join("\n"));
-        }
+    if (leadingSpace.length === 1) {
+      // If the leading space contains no newlines, then we want to
+      // preserve it exactly as we found it.
+      parts.push(leadingSpace);
+    } else {
+      // If the leading space contains newlines, then replace it
+      // with just that many newlines, sans all other spaces.
+      parts.push(new Array(leadingSpace.length).join("\n"));
     }
+  }
 
-    parts.push(print(commentPath));
+  parts.push(print(commentPath));
 
-    return concat(parts);
+  return concat(parts);
 }
 
 export function printComments(path: any, print: any) {
-    var value = path.getValue();
-    var innerLines = print(path);
-    var comments = n.Node.check(value) &&
-        types.getFieldValue(value, "comments");
+  var value = path.getValue();
+  var innerLines = print(path);
+  var comments = n.Node.check(value) &&
+    types.getFieldValue(value, "comments");
 
-    if (!comments || comments.length === 0) {
-        return innerLines;
+  if (!comments || comments.length === 0) {
+    return innerLines;
+  }
+
+  var leadingParts: any[] = [];
+  var trailingParts = [innerLines];
+
+  path.each(function(commentPath: any) {
+    var comment = commentPath.getValue();
+    var leading = types.getFieldValue(comment, "leading");
+    var trailing = types.getFieldValue(comment, "trailing");
+
+    if (leading || (trailing && !(n.Statement.check(value) ||
+                                  comment.type === "Block" ||
+                                  comment.type === "CommentBlock"))) {
+      leadingParts.push(printLeadingComment(commentPath, print));
+    } else if (trailing) {
+      trailingParts.push(printTrailingComment(commentPath, print));
     }
+  }, "comments");
 
-    var leadingParts: any[] = [];
-    var trailingParts = [innerLines];
-
-    path.each(function(commentPath: any) {
-        var comment = commentPath.getValue();
-        var leading = types.getFieldValue(comment, "leading");
-        var trailing = types.getFieldValue(comment, "trailing");
-
-        if (leading || (trailing && !(n.Statement.check(value) ||
-                                      comment.type === "Block" ||
-                                      comment.type === "CommentBlock"))) {
-            leadingParts.push(printLeadingComment(commentPath, print));
-        } else if (trailing) {
-            trailingParts.push(printTrailingComment(commentPath, print));
-        }
-    }, "comments");
-
-    leadingParts.push.apply(leadingParts, trailingParts);
-    return concat(leadingParts);
+  leadingParts.push.apply(leadingParts, trailingParts);
+  return concat(leadingParts);
 };

--- a/lib/lines.ts
+++ b/lib/lines.ts
@@ -188,8 +188,10 @@ export class Lines {
 
     var lines = new Lines(this.infos.map(function(info: any, i: any) {
       if (info.line && (i > 0 || !skipFirstLine)) {
-        info = copyLineInfo(info);
-        info.indent = Math.max(0, info.indent - width);
+        info = {
+          ...info,
+          indent: Math.max(0, info.indent - width),
+        };
       }
       return info;
     }));
@@ -212,8 +214,10 @@ export class Lines {
 
     var lines = new Lines(this.infos.map(function(info: any) {
       if (info.line && ! info.locked) {
-        info = copyLineInfo(info);
-        info.indent += by;
+        info = {
+          ...info,
+          indent: info.indent + by,
+        };
       }
       return info
     }));
@@ -240,8 +244,10 @@ export class Lines {
 
     var lines = new Lines(this.infos.map(function(info: any, i: any) {
       if (i > 0 && info.line && ! info.locked) {
-        info = copyLineInfo(info);
-        info.indent += by;
+        info = {
+          ...info,
+          indent: info.indent + by,
+        };
       }
 
       return info;
@@ -264,9 +270,10 @@ export class Lines {
     }
 
     return new Lines(this.infos.map(function (info: any, i: any) {
-      info = copyLineInfo(info);
-      info.locked = i > 0;
-      return info;
+      return {
+        ...info,
+        locked: i > 0,
+      };
     }));
   }
 
@@ -665,7 +672,7 @@ export class Lines {
 
       linesOrNull.infos.forEach(function(info: any, i: any) {
         if (!prevInfo || i > 0) {
-          prevInfo = copyLineInfo(info);
+          prevInfo = { ...info };
           infos.push(prevInfo);
         }
       });
@@ -706,16 +713,6 @@ export class Lines {
     assert.strictEqual(list.length, args.length + 1);
     return emptyLines.join(list);
   }
-}
-
-function copyLineInfo(info: any) {
-  return {
-    line: info.line,
-    indent: info.indent,
-    locked: info.locked,
-    sliceStart: info.sliceStart,
-    sliceEnd: info.sliceEnd
-  };
 }
 
 var fromStringCache: any = {};

--- a/lib/lines.ts
+++ b/lib/lines.ts
@@ -1,10 +1,7 @@
 import assert from "assert";
 import sourceMap from "source-map";
-import { normalize as normalizeOptions } from "./options";
-import { makeUniqueKey } from "private";
-var secretKey = makeUniqueKey();
-import types from "./types";
-var isString = types.builtInTypes.string;
+import { normalize as normalizeOptions, Options } from "./options";
+import { Position as Pos } from "./types";
 import { comparePos } from "./util";
 import Mapping from "./mapping";
 
@@ -15,106 +12,701 @@ import Mapping from "./mapping";
 // 4. Enforce immutability.
 // 5. No newline characters.
 
-var useSymbol = typeof Symbol === "function";
-// @ts-ignore Subsequent variable declarations must have the same type.
-var secretKey = "recastLinesSecret";
-if (useSymbol) {
-  secretKey = Symbol.for(secretKey);
-}
+type LineInfo = {
+  readonly line: string;
+  readonly indent: number;
+  readonly locked: boolean;
+  readonly sliceStart: number;
+  readonly sliceEnd: number;
+};
 
-function getSecret(lines: any) {
-  return lines[secretKey];
-}
+export class Lines {
+  public readonly length: number;
+  public readonly name: string | null;
+  private mappings: Mapping[] = [];
+  private cachedSourceMap: any = null;
+  private cachedTabWidth: number | void = void 0;
 
-export type Pos = { line: number, column: number };
+  constructor(
+    private infos: LineInfo[],
+    sourceFileName: string | null = null,
+  ) {
+    assert.ok(infos.length > 0);
+    this.length = infos.length;
+    this.name = sourceFileName || null;
 
-export interface LinesType {
-  length: any;
-  name: any;
-  toString(options?: any): any;
-  getSourceMap(sourceMapName: any, sourceRoot: any): any;
-  bootstrapCharAt(pos: any): any;
-  charAt(pos: any): any;
-  stripMargin(width: any, skipFirstLine: any): any;
-  indent(by: number): any;
-  indentTail(by: any): any;
-  lockIndentTail (): any;
-  getIndentAt(line: any): any;
-  guessTabWidth(): any;
-  startsWithComment (): any;
-  isOnlyWhitespace(): any;
-  isPrecededOnlyByWhitespace(pos: any): any;
-  getLineLength(line: any): any;
-  nextPos(pos: any, skipSpaces?: any): any;
-  prevPos(pos: any, skipSpaces?: any): any;
-  firstPos(): Pos;
-  lastPos(): Pos;
-  skipSpaces(pos: any, backward?: any, modifyInPlace?: any): any;
-  trimLeft(): any;
-  trimRight(): any;
-  trim(): any;
-  eachPos(callback: (pos: Pos) => any, startPos?: any, skipSpaces?: any): any;
-  bootstrapSlice(start: any, end: any): any;
-  slice(start?: Pos, end?: Pos): LinesType;
-  bootstrapSliceString(start: any, end: any, options: any): any;
-  sliceString(start: any, end: any, options?: any): any;
-  isEmpty(): any;
-  join(elements: any): any;
-  concat(...args: any[]): any;
-}
-
-interface LinesConstructor {
-  new(infos: any, sourceFileName?: any): LinesType;
-}
-
-const Lines = function Lines(this: LinesType, infos: any, sourceFileName?: any) {
-  assert.ok(this instanceof Lines);
-  assert.ok(infos.length > 0);
-
-  if (sourceFileName) {
-    isString.assert(sourceFileName);
-  } else {
-    sourceFileName = null;
+    if (this.name) {
+      this.mappings.push(new Mapping(this, {
+        start: this.firstPos(),
+        end: this.lastPos(),
+      }));
+    }
   }
 
-  setSymbolOrKey(this, secretKey, {
-    infos: infos,
-    mappings: [],
-    name: sourceFileName,
-    cachedSourceMap: null
-  });
+  toString(options?: Options) {
+    return this.sliceString(this.firstPos(), this.lastPos(), options);
+  }
 
-  this.length = infos.length;
-  this.name = sourceFileName;
+  getSourceMap(sourceMapName: string, sourceRoot?: string) {
+    if (!sourceMapName) {
+      // Although we could make up a name or generate an anonymous
+      // source map, instead we assume that any consumer who does not
+      // provide a name does not actually want a source map.
+      return null;
+    }
 
-  if (sourceFileName) {
-    getSecret(this).mappings.push(new Mapping(this, {
-      start: this.firstPos(),
-      end: this.lastPos()
+    var targetLines = this;
+
+    function updateJSON(json?: any) {
+      json = json || {};
+
+      json.file = sourceMapName;
+
+      if (sourceRoot) {
+        json.sourceRoot = sourceRoot;
+      }
+
+      return json;
+    }
+
+    if (targetLines.cachedSourceMap) {
+      // Since Lines objects are immutable, we can reuse any source map
+      // that was previously generated. Nevertheless, we return a new
+      // JSON object here to protect the cached source map from outside
+      // modification.
+      return updateJSON(targetLines.cachedSourceMap.toJSON());
+    }
+
+    var smg = new sourceMap.SourceMapGenerator(updateJSON());
+    var sourcesToContents: any = {};
+
+    targetLines.mappings.forEach(function(mapping: any) {
+      var sourceCursor = mapping.sourceLines.skipSpaces(
+        mapping.sourceLoc.start
+      ) || mapping.sourceLines.lastPos();
+
+      var targetCursor = targetLines.skipSpaces(
+        mapping.targetLoc.start
+      ) || targetLines.lastPos();
+
+      while (comparePos(sourceCursor, mapping.sourceLoc.end) < 0 &&
+             comparePos(targetCursor, mapping.targetLoc.end) < 0) {
+
+        var sourceChar = mapping.sourceLines.charAt(sourceCursor);
+        var targetChar = targetLines.charAt(targetCursor);
+        assert.strictEqual(sourceChar, targetChar);
+
+        var sourceName = mapping.sourceLines.name;
+
+        // Add mappings one character at a time for maximum resolution.
+        smg.addMapping({
+          source: sourceName,
+          original: { line: sourceCursor.line,
+                      column: sourceCursor.column },
+          generated: { line: targetCursor.line,
+                       column: targetCursor.column }
+        });
+
+        if (!hasOwn.call(sourcesToContents, sourceName)) {
+          var sourceContent = mapping.sourceLines.toString();
+          smg.setSourceContent(sourceName, sourceContent);
+          sourcesToContents[sourceName] = sourceContent;
+        }
+
+        targetLines.nextPos(targetCursor, true);
+        mapping.sourceLines.nextPos(sourceCursor, true);
+      }
+    });
+
+    targetLines.cachedSourceMap = smg;
+
+    return (smg as any).toJSON();
+  }
+
+  bootstrapCharAt(pos: Pos) {
+    assert.strictEqual(typeof pos, "object");
+    assert.strictEqual(typeof pos.line, "number");
+    assert.strictEqual(typeof pos.column, "number");
+
+    var line = pos.line,
+    column = pos.column,
+    strings = this.toString().split(lineTerminatorSeqExp),
+    string = strings[line - 1];
+
+    if (typeof string === "undefined")
+      return "";
+
+    if (column === string.length &&
+        line < strings.length)
+      return "\n";
+
+    if (column >= string.length)
+      return "";
+
+    return string.charAt(column);
+  }
+
+  charAt(pos: Pos) {
+    assert.strictEqual(typeof pos, "object");
+    assert.strictEqual(typeof pos.line, "number");
+    assert.strictEqual(typeof pos.column, "number");
+
+    var line = pos.line,
+    column = pos.column,
+    secret = this,
+    infos = secret.infos,
+    info = infos[line - 1],
+    c = column;
+
+    if (typeof info === "undefined" || c < 0)
+      return "";
+
+    var indent = this.getIndentAt(line);
+    if (c < indent)
+      return " ";
+
+    c += info.sliceStart - indent;
+
+    if (c === info.sliceEnd &&
+        line < this.length)
+      return "\n";
+
+    if (c >= info.sliceEnd)
+      return "";
+
+    return info.line.charAt(c);
+  }
+
+  stripMargin(width: number, skipFirstLine: boolean) {
+    if (width === 0)
+      return this;
+
+    assert.ok(width > 0, "negative margin: " + width);
+
+    if (skipFirstLine && this.length === 1)
+      return this;
+
+    var lines = new Lines(this.infos.map(function(info: any, i: any) {
+      if (info.line && (i > 0 || !skipFirstLine)) {
+        info = copyLineInfo(info);
+        info.indent = Math.max(0, info.indent - width);
+      }
+      return info;
+    }));
+
+    if (this.mappings.length > 0) {
+      var newMappings = lines.mappings;
+      assert.strictEqual(newMappings.length, 0);
+      this.mappings.forEach(function(mapping: any) {
+        newMappings.push(mapping.indent(width, skipFirstLine, true));
+      });
+    }
+
+    return lines;
+  }
+
+  indent(by: number) {
+    if (by === 0) {
+      return this;
+    }
+
+    var lines = new Lines(this.infos.map(function(info: any) {
+      if (info.line && ! info.locked) {
+        info = copyLineInfo(info);
+        info.indent += by;
+      }
+      return info
+    }));
+
+    if (this.mappings.length > 0) {
+      var newMappings = lines.mappings;
+      assert.strictEqual(newMappings.length, 0);
+      this.mappings.forEach(function(mapping: any) {
+        newMappings.push(mapping.indent(by));
+      });
+    }
+
+    return lines;
+  }
+
+  indentTail(by: number) {
+    if (by === 0) {
+      return this;
+    }
+
+    if (this.length < 2) {
+      return this;
+    }
+
+    var lines = new Lines(this.infos.map(function(info: any, i: any) {
+      if (i > 0 && info.line && ! info.locked) {
+        info = copyLineInfo(info);
+        info.indent += by;
+      }
+
+      return info;
+    }));
+
+    if (this.mappings.length > 0) {
+      var newMappings = lines.mappings;
+      assert.strictEqual(newMappings.length, 0);
+      this.mappings.forEach(function(mapping: any) {
+        newMappings.push(mapping.indent(by, true));
+      });
+    }
+
+    return lines;
+  }
+
+  lockIndentTail() {
+    if (this.length < 2) {
+      return this;
+    }
+
+    return new Lines(this.infos.map(function (info: any, i: any) {
+      info = copyLineInfo(info);
+      info.locked = i > 0;
+      return info;
     }));
   }
-} as any as LinesConstructor;
 
-// Exposed for instanceof checks. The fromString function should be used
-// to create new Lines objects.
-export { Lines };
-
-function setSymbolOrKey(obj: any, key: any, value: any) {
-  if (useSymbol) {
-    return obj[key] = value;
+  getIndentAt(line: number) {
+    assert.ok(line >= 1, "no line " + line + " (line numbers start from 1)");
+    return Math.max(this.infos[line - 1].indent, 0);
   }
 
-  Object.defineProperty(obj, key, {
-    value: value,
-    enumerable: false,
-    writable: false,
-    configurable: true
-  });
+  guessTabWidth() {
+    if (typeof this.cachedTabWidth === "number") {
+      return this.cachedTabWidth;
+    }
 
-  return value;
+    var counts: any[] = []; // Sparse array.
+    var lastIndent = 0;
+
+    for (var line = 1, last = this.length; line <= last; ++line) {
+      var info = this.infos[line - 1];
+      var sliced = info.line.slice(info.sliceStart, info.sliceEnd);
+
+      // Whitespace-only lines don't tell us much about the likely tab
+      // width of this code.
+      if (isOnlyWhitespace(sliced)) {
+        continue;
+      }
+
+      var diff = Math.abs(info.indent - lastIndent);
+      counts[diff] = ~~counts[diff] + 1;
+      lastIndent = info.indent;
+    }
+
+    var maxCount = -1;
+    var result = 2;
+
+    for (var tabWidth = 1;
+         tabWidth < counts.length;
+         tabWidth += 1) {
+      if (hasOwn.call(counts, tabWidth) &&
+          counts[tabWidth] > maxCount) {
+        maxCount = counts[tabWidth];
+        result = tabWidth;
+      }
+    }
+
+    return this.cachedTabWidth = result;
+  }
+
+  // Determine if the list of lines has a first line that starts with a //
+  // or /* comment. If this is the case, the code may need to be wrapped in
+  // parens to avoid ASI issues.
+  startsWithComment() {
+    if (this.infos.length === 0) {
+      return false;
+    }
+    var firstLineInfo = this.infos[0],
+    sliceStart = firstLineInfo.sliceStart,
+    sliceEnd = firstLineInfo.sliceEnd,
+    firstLine = firstLineInfo.line.slice(sliceStart, sliceEnd).trim();
+    return firstLine.length === 0 ||
+      firstLine.slice(0, 2) === "//" ||
+      firstLine.slice(0, 2) === "/*";
+  }
+
+  isOnlyWhitespace() {
+    return isOnlyWhitespace(this.toString());
+  }
+
+  isPrecededOnlyByWhitespace(pos: Pos) {
+    var info = this.infos[pos.line - 1];
+    var indent = Math.max(info.indent, 0);
+
+    var diff = pos.column - indent;
+    if (diff <= 0) {
+      // If pos.column does not exceed the indentation amount, then
+      // there must be only whitespace before it.
+      return true;
+    }
+
+    var start = info.sliceStart;
+    var end = Math.min(start + diff, info.sliceEnd);
+    var prefix = info.line.slice(start, end);
+
+    return isOnlyWhitespace(prefix);
+  }
+
+  getLineLength(line: number) {
+    const info = this.infos[line - 1];
+    return this.getIndentAt(line) + info.sliceEnd - info.sliceStart;
+  }
+
+  nextPos(pos: Pos, skipSpaces: boolean = false) {
+    var l = Math.max(pos.line, 0),
+    c = Math.max(pos.column, 0);
+
+    if (c < this.getLineLength(l)) {
+      pos.column += 1;
+
+      return skipSpaces
+        ? !!this.skipSpaces(pos, false, true)
+        : true;
+    }
+
+    if (l < this.length) {
+      pos.line += 1;
+      pos.column = 0;
+
+      return skipSpaces
+        ? !!this.skipSpaces(pos, false, true)
+        : true;
+    }
+
+    return false;
+  }
+
+  prevPos(pos: Pos, skipSpaces: boolean = false) {
+    var l = pos.line,
+    c = pos.column;
+
+    if (c < 1) {
+      l -= 1;
+
+      if (l < 1)
+        return false;
+
+      c = this.getLineLength(l);
+
+    } else {
+      c = Math.min(c - 1, this.getLineLength(l));
+    }
+
+    pos.line = l;
+    pos.column = c;
+
+    return skipSpaces
+      ? !!this.skipSpaces(pos, true, true)
+      : true;
+  }
+
+  firstPos() {
+    // Trivial, but provided for completeness.
+    return { line: 1, column: 0 };
+  }
+
+  lastPos() {
+    return {
+      line: this.length,
+      column: this.getLineLength(this.length)
+    };
+  }
+
+  skipSpaces(
+    pos: Pos,
+    backward: boolean = false,
+    modifyInPlace: boolean = false,
+  ) {
+    if (pos) {
+      pos = modifyInPlace ? pos : {
+        line: pos.line,
+        column: pos.column
+      };
+    } else if (backward) {
+      pos = this.lastPos();
+    } else {
+      pos = this.firstPos();
+    }
+
+    if (backward) {
+      while (this.prevPos(pos)) {
+        if (!isOnlyWhitespace(this.charAt(pos)) &&
+            this.nextPos(pos)) {
+          return pos;
+        }
+      }
+
+      return null;
+
+    } else {
+      while (isOnlyWhitespace(this.charAt(pos))) {
+        if (!this.nextPos(pos)) {
+          return null;
+        }
+      }
+
+      return pos;
+    }
+  }
+
+  trimLeft() {
+    var pos = this.skipSpaces(this.firstPos(), false, true);
+    return pos ? this.slice(pos) : emptyLines;
+  }
+
+  trimRight() {
+    var pos = this.skipSpaces(this.lastPos(), true, true);
+    return pos ? this.slice(this.firstPos(), pos) : emptyLines;
+  }
+
+  trim() {
+    const start = this.skipSpaces(this.firstPos(), false, true);
+    if (start === null) {
+      return emptyLines;
+    }
+
+    const end = this.skipSpaces(this.lastPos(), true, true);
+    if (end === null) {
+      return emptyLines;
+    }
+
+    return this.slice(start, end);
+  }
+
+  eachPos(
+    callback: (pos: Pos) => any,
+    startPos: Pos = this.firstPos(),
+    skipSpaces: boolean = false,
+  ) {
+    var pos = this.firstPos();
+
+    if (startPos) {
+      pos.line = startPos.line,
+      pos.column = startPos.column
+    }
+
+    if (skipSpaces && !this.skipSpaces(pos, false, true)) {
+      return; // Encountered nothing but spaces.
+    }
+
+    do callback.call(this, pos);
+    while (this.nextPos(pos, skipSpaces));
+  }
+
+  bootstrapSlice(start: Pos, end: Pos) {
+    var strings = this.toString().split(
+      lineTerminatorSeqExp
+    ).slice(
+      start.line - 1,
+      end.line
+    );
+
+    if (strings.length > 0) {
+      strings.push(strings.pop()!.slice(0, end.column));
+      strings[0] = strings[0].slice(start.column);
+    }
+
+    return fromString(strings.join("\n"));
+  }
+
+  slice(start?: Pos, end?: Pos) {
+    if (!end) {
+      if (!start) {
+        // The client seems to want a copy of this Lines object, but
+        // Lines objects are immutable, so it's perfectly adequate to
+        // return the same object.
+        return this;
+      }
+
+      // Slice to the end if no end position was provided.
+      end = this.lastPos();
+    }
+
+    if (!start) {
+      throw new Error("cannot slice with end but not start");
+    }
+
+    const sliced = this.infos.slice(start.line - 1, end.line);
+
+    if (start.line === end.line) {
+      sliced[0] = sliceInfo(sliced[0], start.column, end.column);
+    } else {
+      assert.ok(start.line < end.line);
+      sliced[0] = sliceInfo(sliced[0], start.column);
+      sliced.push(sliceInfo(sliced.pop(), 0, end.column));
+    }
+
+    var lines = new Lines(sliced);
+
+    if (this.mappings.length > 0) {
+      var newMappings = lines.mappings;
+      assert.strictEqual(newMappings.length, 0);
+      this.mappings.forEach(function(this: any, mapping: any) {
+        var sliced = mapping.slice(this, start, end);
+        if (sliced) {
+          newMappings.push(sliced);
+        }
+      }, this);
+    }
+
+    return lines;
+  }
+
+  bootstrapSliceString(start: Pos, end: Pos, options?: Options) {
+    return this.slice(start, end).toString(options);
+  }
+
+  sliceString(
+    start: Pos = this.firstPos(),
+    end: Pos = this.lastPos(),
+    options?: Options,
+  ) {
+    options = normalizeOptions(options);
+
+    const parts = [];
+    const { tabWidth = 2 } = options;
+
+    for (var line = start.line; line <= end.line; ++line) {
+      var info = this.infos[line - 1];
+
+      if (line === start.line) {
+        if (line === end.line) {
+          info = sliceInfo(info, start.column, end.column);
+        } else {
+          info = sliceInfo(info, start.column);
+        }
+      } else if (line === end.line) {
+        info = sliceInfo(info, 0, end.column);
+      }
+
+      var indent = Math.max(info.indent, 0);
+
+      var before = info.line.slice(0, info.sliceStart);
+      if (options.reuseWhitespace &&
+          isOnlyWhitespace(before) &&
+          countSpaces(before, options.tabWidth) === indent) {
+        // Reuse original spaces if the indentation is correct.
+        parts.push(info.line.slice(0, info.sliceEnd));
+        continue;
+      }
+
+      var tabs = 0;
+      var spaces = indent;
+
+      if (options.useTabs) {
+        tabs = Math.floor(indent / tabWidth);
+        spaces -= tabs * tabWidth;
+      }
+
+      var result = "";
+
+      if (tabs > 0) {
+        result += new Array(tabs + 1).join("\t");
+      }
+
+      if (spaces > 0) {
+        result += new Array(spaces + 1).join(" ");
+      }
+
+      result += info.line.slice(info.sliceStart, info.sliceEnd);
+
+      parts.push(result);
+    }
+
+    return parts.join(options.lineTerminator);
+  }
+
+  isEmpty() {
+    return this.length < 2 && this.getLineLength(1) < 1;
+  }
+
+  join(elements: (string | Lines)[]) {
+    var separator = this;
+    var infos: any[] = [];
+    var mappings: any[] = [];
+    var prevInfo: any;
+
+    function appendLines(linesOrNull: Lines | null) {
+      if (linesOrNull === null) {
+        return;
+      }
+
+      if (prevInfo) {
+        var info = linesOrNull.infos[0];
+        var indent = new Array(info.indent + 1).join(" ");
+        var prevLine = infos.length;
+        var prevColumn = Math.max(prevInfo.indent, 0) +
+          prevInfo.sliceEnd - prevInfo.sliceStart;
+
+        prevInfo.line = prevInfo.line.slice(
+          0, prevInfo.sliceEnd) + indent + info.line.slice(
+            info.sliceStart, info.sliceEnd);
+
+        // If any part of a line is indentation-locked, the whole line
+        // will be indentation-locked.
+        prevInfo.locked = prevInfo.locked || info.locked;
+
+        prevInfo.sliceEnd = prevInfo.line.length;
+
+        if (linesOrNull.mappings.length > 0) {
+          linesOrNull.mappings.forEach(function(mapping: any) {
+            mappings.push(mapping.add(prevLine, prevColumn));
+          });
+        }
+
+      } else if (linesOrNull.mappings.length > 0) {
+        mappings.push.apply(mappings, linesOrNull.mappings);
+      }
+
+      linesOrNull.infos.forEach(function(info: any, i: any) {
+        if (!prevInfo || i > 0) {
+          prevInfo = copyLineInfo(info);
+          infos.push(prevInfo);
+        }
+      });
+    }
+
+    function appendWithSeparator(linesOrNull: Lines | null, i: number) {
+      if (i > 0)
+        appendLines(separator);
+      appendLines(linesOrNull);
+    }
+
+    elements.map(function(elem: any) {
+      var lines = fromString(elem);
+      if (lines.isEmpty())
+        return null;
+      return lines;
+    }).forEach((linesOrNull, i) => {
+      if (separator.isEmpty()) {
+        appendLines(linesOrNull);
+      } else {
+        appendWithSeparator(linesOrNull, i);
+      }
+    });
+
+    if (infos.length < 1)
+      return emptyLines;
+
+    var lines = new Lines(infos);
+
+    lines.mappings = mappings;
+
+    return lines;
+  }
+
+  concat(...args: (string | Lines)[]) {
+    var list: typeof args = [this];
+    list.push.apply(list, args);
+    assert.strictEqual(list.length, args.length + 1);
+    return emptyLines.join(list);
+  }
 }
-
-var Lp: LinesType = Lines.prototype;
 
 function copyLineInfo(info: any) {
   return {
@@ -175,7 +767,10 @@ var lineTerminatorSeqExp =
 /**
  * @param {Object} options - Options object that configures printing.
  */
-export function fromString(string: string | LinesType, options?: any): LinesType {
+export function fromString(
+  string: string | Lines,
+  options?: Options,
+): Lines {
   if (string instanceof Lines)
     return string;
 
@@ -183,7 +778,6 @@ export function fromString(string: string | LinesType, options?: any): LinesType
 
   var tabWidth = options && options.tabWidth;
   var tabless = string.indexOf("\t") < 0;
-  var locked = !! (options && options.locked);
   var cacheable = !options && tabless && (string.length <= maxCacheKeyLen);
 
   assert.ok(tabWidth || tabless, "No tab width specified but encountered tabs in string\n" + string);
@@ -198,7 +792,7 @@ export function fromString(string: string | LinesType, options?: any): LinesType
       line: line,
       indent: countSpaces(spaces, tabWidth),
       // Boolean indicating whether this line can be reindented.
-      locked: locked,
+      locked: false,
       sliceStart: spaces.length,
       sliceEnd: line.length
     };
@@ -213,522 +807,6 @@ export function fromString(string: string | LinesType, options?: any): LinesType
 function isOnlyWhitespace(string: string) {
   return !/\S/.test(string);
 }
-
-Lp.toString = function(options) {
-  return this.sliceString(this.firstPos(), this.lastPos(), options);
-};
-
-Lp.getSourceMap = function(sourceMapName, sourceRoot) {
-  if (!sourceMapName) {
-    // Although we could make up a name or generate an anonymous
-    // source map, instead we assume that any consumer who does not
-    // provide a name does not actually want a source map.
-    return null;
-  }
-
-  var targetLines = this;
-
-  function updateJSON(json?: any) {
-    json = json || {};
-
-    isString.assert(sourceMapName);
-    json.file = sourceMapName;
-
-    if (sourceRoot) {
-      isString.assert(sourceRoot);
-      json.sourceRoot = sourceRoot;
-    }
-
-    return json;
-  }
-
-  var secret = getSecret(targetLines);
-  if (secret.cachedSourceMap) {
-    // Since Lines objects are immutable, we can reuse any source map
-    // that was previously generated. Nevertheless, we return a new
-    // JSON object here to protect the cached source map from outside
-    // modification.
-    return updateJSON(secret.cachedSourceMap.toJSON());
-  }
-
-  var smg = new sourceMap.SourceMapGenerator(updateJSON());
-  var sourcesToContents: any = {};
-
-  secret.mappings.forEach(function(mapping: any) {
-    var sourceCursor = mapping.sourceLines.skipSpaces(
-      mapping.sourceLoc.start
-    ) || mapping.sourceLines.lastPos();
-
-    var targetCursor = targetLines.skipSpaces(
-      mapping.targetLoc.start
-    ) || targetLines.lastPos();
-
-    while (comparePos(sourceCursor, mapping.sourceLoc.end) < 0 &&
-           comparePos(targetCursor, mapping.targetLoc.end) < 0) {
-
-      var sourceChar = mapping.sourceLines.charAt(sourceCursor);
-      var targetChar = targetLines.charAt(targetCursor);
-      assert.strictEqual(sourceChar, targetChar);
-
-      var sourceName = mapping.sourceLines.name;
-
-      // Add mappings one character at a time for maximum resolution.
-      smg.addMapping({
-        source: sourceName,
-        original: { line: sourceCursor.line,
-                    column: sourceCursor.column },
-        generated: { line: targetCursor.line,
-                     column: targetCursor.column }
-      });
-
-      if (!hasOwn.call(sourcesToContents, sourceName)) {
-        var sourceContent = mapping.sourceLines.toString();
-        smg.setSourceContent(sourceName, sourceContent);
-        sourcesToContents[sourceName] = sourceContent;
-      }
-
-      targetLines.nextPos(targetCursor, true);
-      mapping.sourceLines.nextPos(sourceCursor, true);
-    }
-  });
-
-  secret.cachedSourceMap = smg;
-
-  return (smg as any).toJSON();
-};
-
-Lp.bootstrapCharAt = function(pos) {
-  assert.strictEqual(typeof pos, "object");
-  assert.strictEqual(typeof pos.line, "number");
-  assert.strictEqual(typeof pos.column, "number");
-
-  var line = pos.line,
-  column = pos.column,
-  strings = this.toString().split(lineTerminatorSeqExp),
-  string = strings[line - 1];
-
-  if (typeof string === "undefined")
-    return "";
-
-  if (column === string.length &&
-      line < strings.length)
-    return "\n";
-
-  if (column >= string.length)
-    return "";
-
-  return string.charAt(column);
-};
-
-Lp.charAt = function(pos) {
-  assert.strictEqual(typeof pos, "object");
-  assert.strictEqual(typeof pos.line, "number");
-  assert.strictEqual(typeof pos.column, "number");
-
-  var line = pos.line,
-  column = pos.column,
-  secret = getSecret(this),
-  infos = secret.infos,
-  info = infos[line - 1],
-  c = column;
-
-  if (typeof info === "undefined" || c < 0)
-    return "";
-
-  var indent = this.getIndentAt(line);
-  if (c < indent)
-    return " ";
-
-  c += info.sliceStart - indent;
-
-  if (c === info.sliceEnd &&
-      line < this.length)
-    return "\n";
-
-  if (c >= info.sliceEnd)
-    return "";
-
-  return info.line.charAt(c);
-};
-
-Lp.stripMargin = function(width, skipFirstLine) {
-  if (width === 0)
-    return this;
-
-  assert.ok(width > 0, "negative margin: " + width);
-
-  if (skipFirstLine && this.length === 1)
-    return this;
-
-  var secret = getSecret(this);
-
-  var lines = new Lines(secret.infos.map(function(info: any, i: any) {
-    if (info.line && (i > 0 || !skipFirstLine)) {
-      info = copyLineInfo(info);
-      info.indent = Math.max(0, info.indent - width);
-    }
-    return info;
-  }));
-
-  if (secret.mappings.length > 0) {
-    var newMappings = getSecret(lines).mappings;
-    assert.strictEqual(newMappings.length, 0);
-    secret.mappings.forEach(function(mapping: any) {
-      newMappings.push(mapping.indent(width, skipFirstLine, true));
-    });
-  }
-
-  return lines;
-};
-
-Lp.indent = function(by) {
-  if (by === 0)
-    return this;
-
-  var secret = getSecret(this);
-
-  var lines = new Lines(secret.infos.map(function(info: any) {
-    if (info.line && ! info.locked) {
-      info = copyLineInfo(info);
-      info.indent += by;
-    }
-    return info
-  }));
-
-  if (secret.mappings.length > 0) {
-    var newMappings = getSecret(lines).mappings;
-    assert.strictEqual(newMappings.length, 0);
-    secret.mappings.forEach(function(mapping: any) {
-      newMappings.push(mapping.indent(by));
-    });
-  }
-
-  return lines;
-};
-
-Lp.indentTail = function(by) {
-  if (by === 0)
-    return this;
-
-  if (this.length < 2)
-    return this;
-
-  var secret = getSecret(this);
-
-  var lines = new Lines(secret.infos.map(function(info: any, i: any) {
-    if (i > 0 && info.line && ! info.locked) {
-      info = copyLineInfo(info);
-      info.indent += by;
-    }
-
-    return info;
-  }));
-
-  if (secret.mappings.length > 0) {
-    var newMappings = getSecret(lines).mappings;
-    assert.strictEqual(newMappings.length, 0);
-    secret.mappings.forEach(function(mapping: any) {
-      newMappings.push(mapping.indent(by, true));
-    });
-  }
-
-  return lines;
-};
-
-Lp.lockIndentTail = function () {
-  if (this.length < 2) {
-    return this;
-  }
-
-  var infos = getSecret(this).infos;
-
-  return new Lines(infos.map(function (info: any, i: any) {
-    info = copyLineInfo(info);
-    info.locked = i > 0;
-    return info;
-  }));
-};
-
-Lp.getIndentAt = function(line) {
-  assert.ok(line >= 1, "no line " + line + " (line numbers start from 1)");
-  var secret = getSecret(this),
-  info = secret.infos[line - 1];
-  return Math.max(info.indent, 0);
-};
-
-Lp.guessTabWidth = function() {
-  var secret = getSecret(this);
-  if (hasOwn.call(secret, "cachedTabWidth")) {
-    return secret.cachedTabWidth;
-  }
-
-  var counts: any[] = []; // Sparse array.
-  var lastIndent = 0;
-
-  for (var line = 1, last = this.length; line <= last; ++line) {
-    var info = secret.infos[line - 1];
-    var sliced = info.line.slice(info.sliceStart, info.sliceEnd);
-
-    // Whitespace-only lines don't tell us much about the likely tab
-    // width of this code.
-    if (isOnlyWhitespace(sliced)) {
-      continue;
-    }
-
-    var diff = Math.abs(info.indent - lastIndent);
-    counts[diff] = ~~counts[diff] + 1;
-    lastIndent = info.indent;
-  }
-
-  var maxCount = -1;
-  var result = 2;
-
-  for (var tabWidth = 1;
-       tabWidth < counts.length;
-       tabWidth += 1) {
-    if (hasOwn.call(counts, tabWidth) &&
-        counts[tabWidth] > maxCount) {
-      maxCount = counts[tabWidth];
-      result = tabWidth;
-    }
-  }
-
-  return secret.cachedTabWidth = result;
-};
-
-// Determine if the list of lines has a first line that starts with a //
-// or /* comment. If this is the case, the code may need to be wrapped in
-// parens to avoid ASI issues.
-Lp.startsWithComment = function () {
-  var secret = getSecret(this);
-  if (secret.infos.length === 0) {
-    return false;
-  }
-  var firstLineInfo = secret.infos[0],
-  sliceStart = firstLineInfo.sliceStart,
-  sliceEnd = firstLineInfo.sliceEnd,
-  firstLine = firstLineInfo.line.slice(sliceStart, sliceEnd).trim();
-  return firstLine.length === 0 ||
-    firstLine.slice(0, 2) === "//" ||
-    firstLine.slice(0, 2) === "/*";
-};
-
-Lp.isOnlyWhitespace = function() {
-  return isOnlyWhitespace(this.toString());
-};
-
-Lp.isPrecededOnlyByWhitespace = function(pos) {
-  var secret = getSecret(this);
-  var info = secret.infos[pos.line - 1];
-  var indent = Math.max(info.indent, 0);
-
-  var diff = pos.column - indent;
-  if (diff <= 0) {
-    // If pos.column does not exceed the indentation amount, then
-    // there must be only whitespace before it.
-    return true;
-  }
-
-  var start = info.sliceStart;
-  var end = Math.min(start + diff, info.sliceEnd);
-  var prefix = info.line.slice(start, end);
-
-  return isOnlyWhitespace(prefix);
-};
-
-Lp.getLineLength = function(line) {
-  var secret = getSecret(this),
-  info = secret.infos[line - 1];
-  return this.getIndentAt(line) + info.sliceEnd - info.sliceStart;
-};
-
-Lp.nextPos = function(pos, skipSpaces) {
-  var l = Math.max(pos.line, 0),
-  c = Math.max(pos.column, 0);
-
-  if (c < this.getLineLength(l)) {
-    pos.column += 1;
-
-    return skipSpaces
-      ? !!this.skipSpaces(pos, false, true)
-      : true;
-  }
-
-  if (l < this.length) {
-    pos.line += 1;
-    pos.column = 0;
-
-    return skipSpaces
-      ? !!this.skipSpaces(pos, false, true)
-      : true;
-  }
-
-  return false;
-};
-
-Lp.prevPos = function(pos, skipSpaces) {
-  var l = pos.line,
-  c = pos.column;
-
-  if (c < 1) {
-    l -= 1;
-
-    if (l < 1)
-      return false;
-
-    c = this.getLineLength(l);
-
-  } else {
-    c = Math.min(c - 1, this.getLineLength(l));
-  }
-
-  pos.line = l;
-  pos.column = c;
-
-  return skipSpaces
-    ? !!this.skipSpaces(pos, true, true)
-    : true;
-};
-
-Lp.firstPos = function() {
-  // Trivial, but provided for completeness.
-  return { line: 1, column: 0 };
-};
-
-Lp.lastPos = function() {
-  return {
-    line: this.length,
-    column: this.getLineLength(this.length)
-  };
-};
-
-Lp.skipSpaces = function(pos, backward, modifyInPlace) {
-  if (pos) {
-    pos = modifyInPlace ? pos : {
-      line: pos.line,
-      column: pos.column
-    };
-  } else if (backward) {
-    pos = this.lastPos();
-  } else {
-    pos = this.firstPos();
-  }
-
-  if (backward) {
-    while (this.prevPos(pos)) {
-      if (!isOnlyWhitespace(this.charAt(pos)) &&
-          this.nextPos(pos)) {
-        return pos;
-      }
-    }
-
-    return null;
-
-  } else {
-    while (isOnlyWhitespace(this.charAt(pos))) {
-      if (!this.nextPos(pos)) {
-        return null;
-      }
-    }
-
-    return pos;
-  }
-};
-
-Lp.trimLeft = function() {
-  var pos = this.skipSpaces(this.firstPos(), false, true);
-  return pos ? this.slice(pos) : emptyLines;
-};
-
-Lp.trimRight = function() {
-  var pos = this.skipSpaces(this.lastPos(), true, true);
-  return pos ? this.slice(this.firstPos(), pos) : emptyLines;
-};
-
-Lp.trim = function() {
-  var start = this.skipSpaces(this.firstPos(), false, true);
-  if (start === null)
-    return emptyLines;
-
-  var end = this.skipSpaces(this.lastPos(), true, true);
-  assert.notStrictEqual(end, null);
-
-  return this.slice(start, end);
-};
-
-Lp.eachPos = function(callback, startPos, skipSpaces) {
-  var pos = this.firstPos();
-
-  if (startPos) {
-    pos.line = startPos.line,
-    pos.column = startPos.column
-  }
-
-  if (skipSpaces && !this.skipSpaces(pos, false, true)) {
-    return; // Encountered nothing but spaces.
-  }
-
-  do callback.call(this, pos);
-  while (this.nextPos(pos, skipSpaces));
-};
-
-Lp.bootstrapSlice = function(start, end) {
-  var strings = this.toString().split(
-    lineTerminatorSeqExp
-  ).slice(
-    start.line - 1,
-    end.line
-  );
-
-  strings.push(strings.pop().slice(0, end.column));
-  strings[0] = strings[0].slice(start.column);
-
-  return fromString(strings.join("\n"));
-};
-
-Lp.slice = function(start, end) {
-  if (!end) {
-    if (!start) {
-      // The client seems to want a copy of this Lines object, but
-      // Lines objects are immutable, so it's perfectly adequate to
-      // return the same object.
-      return this;
-    }
-
-    // Slice to the end if no end position was provided.
-    end = this.lastPos();
-  }
-
-  if (!start) {
-    throw new Error("cannot slice with end but not start");
-  }
-
-  var secret = getSecret(this);
-  var sliced = secret.infos.slice(start.line - 1, end.line);
-
-  if (start.line === end.line) {
-    sliced[0] = sliceInfo(sliced[0], start.column, end.column);
-  } else {
-    assert.ok(start.line < end.line);
-    sliced[0] = sliceInfo(sliced[0], start.column);
-    sliced.push(sliceInfo(sliced.pop(), 0, end.column));
-  }
-
-  var lines = new Lines(sliced);
-
-  if (secret.mappings.length > 0) {
-    var newMappings = getSecret(lines).mappings;
-    assert.strictEqual(newMappings.length, 0);
-    secret.mappings.forEach(function(this: any, mapping: any) {
-      var sliced = mapping.slice(this, start, end);
-      if (sliced) {
-        newMappings.push(sliced);
-      }
-    }, this);
-  }
-
-  return lines;
-};
 
 function sliceInfo(info: any, startCol: number, endCol?: number) {
   var sliceStart = info.sliceStart;
@@ -782,165 +860,10 @@ function sliceInfo(info: any, startCol: number, endCol?: number) {
   };
 }
 
-Lp.bootstrapSliceString = function(start, end, options) {
-  return this.slice(start, end).toString(options);
-};
-
-Lp.sliceString = function(start, end, options) {
-  if (!end) {
-    if (!start) {
-      // The client seems to want a copy of this Lines object, but
-      // Lines objects are immutable, so it's perfectly adequate to
-      // return the same object.
-      return this;
-    }
-
-    // Slice to the end if no end position was provided.
-    end = this.lastPos();
-  }
-
-  options = normalizeOptions(options);
-
-  var infos = getSecret(this).infos;
-  var parts = [];
-  var tabWidth = options.tabWidth;
-
-  for (var line = start.line; line <= end.line; ++line) {
-    var info = infos[line - 1];
-
-    if (line === start.line) {
-      if (line === end.line) {
-        info = sliceInfo(info, start.column, end.column);
-      } else {
-        info = sliceInfo(info, start.column);
-      }
-    } else if (line === end.line) {
-      info = sliceInfo(info, 0, end.column);
-    }
-
-    var indent = Math.max(info.indent, 0);
-
-    var before = info.line.slice(0, info.sliceStart);
-    if (options.reuseWhitespace &&
-        isOnlyWhitespace(before) &&
-        countSpaces(before, options.tabWidth) === indent) {
-      // Reuse original spaces if the indentation is correct.
-      parts.push(info.line.slice(0, info.sliceEnd));
-      continue;
-    }
-
-    var tabs = 0;
-    var spaces = indent;
-
-    if (options.useTabs) {
-      tabs = Math.floor(indent / tabWidth);
-      spaces -= tabs * tabWidth;
-    }
-
-    var result = "";
-
-    if (tabs > 0) {
-      result += new Array(tabs + 1).join("\t");
-    }
-
-    if (spaces > 0) {
-      result += new Array(spaces + 1).join(" ");
-    }
-
-    result += info.line.slice(info.sliceStart, info.sliceEnd);
-
-    parts.push(result);
-  }
-
-  return parts.join(options.lineTerminator);
-};
-
-Lp.isEmpty = function() {
-  return this.length < 2 && this.getLineLength(1) < 1;
-};
-
-Lp.join = function(elements) {
-  var separator = this;
-  var separatorSecret = getSecret(separator);
-  var infos: any[] = [];
-  var mappings: any[] = [];
-  var prevInfo: any;
-
-  function appendSecret(secret: any) {
-    if (secret === null)
-      return;
-
-    if (prevInfo) {
-      var info = secret.infos[0];
-      var indent = new Array(info.indent + 1).join(" ");
-      var prevLine = infos.length;
-      var prevColumn = Math.max(prevInfo.indent, 0) +
-        prevInfo.sliceEnd - prevInfo.sliceStart;
-
-      prevInfo.line = prevInfo.line.slice(
-        0, prevInfo.sliceEnd) + indent + info.line.slice(
-          info.sliceStart, info.sliceEnd);
-
-      // If any part of a line is indentation-locked, the whole line
-      // will be indentation-locked.
-      prevInfo.locked = prevInfo.locked || info.locked;
-
-      prevInfo.sliceEnd = prevInfo.line.length;
-
-      if (secret.mappings.length > 0) {
-        secret.mappings.forEach(function(mapping: any) {
-          mappings.push(mapping.add(prevLine, prevColumn));
-        });
-      }
-
-    } else if (secret.mappings.length > 0) {
-      mappings.push.apply(mappings, secret.mappings);
-    }
-
-    secret.infos.forEach(function(info: any, i: any) {
-      if (!prevInfo || i > 0) {
-        prevInfo = copyLineInfo(info);
-        infos.push(prevInfo);
-      }
-    });
-  }
-
-  function appendWithSeparator(secret: any, i: any) {
-    if (i > 0)
-      appendSecret(separatorSecret);
-    appendSecret(secret);
-  }
-
-  elements.map(function(elem: any) {
-    var lines = fromString(elem);
-    if (lines.isEmpty())
-      return null;
-    return getSecret(lines);
-  }).forEach(separator.isEmpty()
-             ? appendSecret
-             : appendWithSeparator);
-
-  if (infos.length < 1)
-    return emptyLines;
-
-  var lines = new Lines(infos);
-
-  getSecret(lines).mappings = mappings;
-
-  return lines;
-};
-
 export function concat(elements: any) {
   return emptyLines.join(elements);
 };
 
-Lp.concat = function(...args) {
-  var list = [this];
-  list.push.apply(list, args);
-  assert.strictEqual(list.length, args.length + 1);
-  return emptyLines.join(list);
-};
-
 // The emptyLines object needs to be created all the way down here so that
 // Lines.prototype will be fully populated.
-var emptyLines = fromString("");
+const emptyLines = fromString("");

--- a/lib/mapping.ts
+++ b/lib/mapping.ts
@@ -1,149 +1,162 @@
 import assert from "assert";
-import types from "./types";
-var isNumber = types.builtInTypes.number;
-var SourceLocation = types.namedTypes.SourceLocation;
-var Position = types.namedTypes.Position;
-import * as linesModule from "./lines";
 import { comparePos } from "./util";
+import {
+  SourceLocation as Loc,
+  Position as Pos,
+} from "./types";
+import { Lines } from "./lines";
 
-interface MappingType {
-  sourceLines: any;
-  sourceLoc: any;
-  targetLoc: any;
-  slice(lines: any, start: any, end: any): MappingType | null;
-  add(line: number, column: number): MappingType;
-  subtract(line: number, column: number): MappingType;
-  indent(by: any, skipFirstLine: any, noNegativeColumns: any): MappingType;
+export default class Mapping {
+  constructor(
+    public sourceLines: Lines,
+    public sourceLoc: Loc,
+    public targetLoc: Loc = sourceLoc,
+  ) {}
+
+  slice(
+    lines: Lines,
+    start: Pos,
+    end: Pos = lines.lastPos(),
+  ) {
+    var sourceLines = this.sourceLines;
+    var sourceLoc = this.sourceLoc;
+    var targetLoc = this.targetLoc;
+
+    function skip(name: "start" | "end") {
+      var sourceFromPos = sourceLoc[name];
+      var targetFromPos = targetLoc[name];
+      var targetToPos = start;
+
+      if (name === "end") {
+        targetToPos = end;
+      } else {
+        assert.strictEqual(name, "start");
+      }
+
+      return skipChars(
+        sourceLines, sourceFromPos,
+        lines, targetFromPos, targetToPos
+      );
+    }
+
+    if (comparePos(start, targetLoc.start) <= 0) {
+      if (comparePos(targetLoc.end, end) <= 0) {
+        targetLoc = {
+          start: subtractPos(targetLoc.start, start.line, start.column),
+          end: subtractPos(targetLoc.end, start.line, start.column)
+        };
+
+        // The sourceLoc can stay the same because the contents of the
+        // targetLoc have not changed.
+
+      } else if (comparePos(end, targetLoc.start) <= 0) {
+        return null;
+
+      } else {
+        sourceLoc = {
+          start: sourceLoc.start,
+          end: skip("end")
+        };
+
+        targetLoc = {
+          start: subtractPos(targetLoc.start, start.line, start.column),
+          end: subtractPos(end, start.line, start.column)
+        };
+      }
+
+    } else {
+      if (comparePos(targetLoc.end, start) <= 0) {
+        return null;
+      }
+
+      if (comparePos(targetLoc.end, end) <= 0) {
+        sourceLoc = {
+          start: skip("start"),
+          end: sourceLoc.end
+        };
+
+        targetLoc = {
+          // Same as subtractPos(start, start.line, start.column):
+          start: { line: 1, column: 0 },
+          end: subtractPos(targetLoc.end, start.line, start.column)
+        };
+
+      } else {
+        sourceLoc = {
+          start: skip("start"),
+          end: skip("end")
+        };
+
+        targetLoc = {
+          // Same as subtractPos(start, start.line, start.column):
+          start: { line: 1, column: 0 },
+          end: subtractPos(end, start.line, start.column)
+        };
+      }
+    }
+
+    return new Mapping(this.sourceLines, sourceLoc, targetLoc);
+  }
+
+  add(line: number, column: number) {
+    return new Mapping(this.sourceLines, this.sourceLoc, {
+      start: addPos(this.targetLoc.start, line, column),
+      end: addPos(this.targetLoc.end, line, column)
+    });
+  }
+
+  subtract(line: number, column: number) {
+    return new Mapping(this.sourceLines, this.sourceLoc, {
+      start: subtractPos(this.targetLoc.start, line, column),
+      end: subtractPos(this.targetLoc.end, line, column)
+    });
+  }
+
+  indent(
+    by: number,
+    skipFirstLine: boolean = false,
+    noNegativeColumns: boolean = false,
+  ) {
+    if (by === 0) {
+      return this;
+    }
+
+    var targetLoc = this.targetLoc;
+    var startLine = targetLoc.start.line;
+    var endLine = targetLoc.end.line;
+
+    if (skipFirstLine && startLine === 1 && endLine === 1) {
+      return this;
+    }
+
+    targetLoc = {
+      start: targetLoc.start,
+      end: targetLoc.end
+    };
+
+    if (!skipFirstLine || startLine > 1) {
+      var startColumn = targetLoc.start.column + by;
+      targetLoc.start = {
+        line: startLine,
+        column: noNegativeColumns
+          ? Math.max(0, startColumn)
+          : startColumn
+      };
+    }
+
+    if (!skipFirstLine || endLine > 1) {
+      var endColumn = targetLoc.end.column + by;
+      targetLoc.end = {
+        line: endLine,
+        column: noNegativeColumns
+          ? Math.max(0, endColumn)
+          : endColumn
+      };
+    }
+
+    return new Mapping(this.sourceLines, this.sourceLoc, targetLoc);
+  }
 }
-
-interface MappingConstructor {
-  new(sourceLines: any, sourceLoc: any, targetLoc?: any): MappingType;
-}
-
-const Mapping = function Mapping(this: MappingType, sourceLines: any, sourceLoc: any, targetLoc?: any) {
-  assert.ok(this instanceof Mapping);
-  assert.ok(sourceLines instanceof linesModule.Lines);
-  SourceLocation.assert(sourceLoc);
-
-  if (targetLoc) {
-    // In certain cases it's possible for targetLoc.{start,end}.column
-    // values to be negative, which technically makes them no longer
-    // valid SourceLocation nodes, so we need to be more forgiving.
-    assert.ok(isNumber.check(targetLoc.start.line) &&
-              isNumber.check(targetLoc.start.column) &&
-              isNumber.check(targetLoc.end.line) &&
-              isNumber.check(targetLoc.end.column));
-  } else {
-    // Assume identity mapping if no targetLoc specified.
-    targetLoc = sourceLoc;
-  }
-
-  Object.defineProperties(this, {
-    sourceLines: { value: sourceLines },
-    sourceLoc: { value: sourceLoc },
-    targetLoc: { value: targetLoc }
-  });
-} as any as MappingConstructor;
-
-var Mp: MappingType = Mapping.prototype;
-export default Mapping;
-
-Mp.slice = function(lines, start, end) {
-  assert.ok(lines instanceof linesModule.Lines);
-  Position.assert(start);
-
-  if (end) {
-    Position.assert(end);
-  } else {
-    end = lines.lastPos();
-  }
-
-  var sourceLines = this.sourceLines;
-  var sourceLoc = this.sourceLoc;
-  var targetLoc = this.targetLoc;
-
-  function skip(name: string) {
-    var sourceFromPos = sourceLoc[name];
-    var targetFromPos = targetLoc[name];
-    var targetToPos = start;
-
-    if (name === "end") {
-      targetToPos = end;
-    } else {
-      assert.strictEqual(name, "start");
-    }
-
-    return skipChars(
-      sourceLines, sourceFromPos,
-      lines, targetFromPos, targetToPos
-    );
-  }
-
-  if (comparePos(start, targetLoc.start) <= 0) {
-    if (comparePos(targetLoc.end, end) <= 0) {
-      targetLoc = {
-        start: subtractPos(targetLoc.start, start.line, start.column),
-        end: subtractPos(targetLoc.end, start.line, start.column)
-      };
-
-      // The sourceLoc can stay the same because the contents of the
-      // targetLoc have not changed.
-
-    } else if (comparePos(end, targetLoc.start) <= 0) {
-      return null;
-
-    } else {
-      sourceLoc = {
-        start: sourceLoc.start,
-        end: skip("end")
-      };
-
-      targetLoc = {
-        start: subtractPos(targetLoc.start, start.line, start.column),
-        end: subtractPos(end, start.line, start.column)
-      };
-    }
-
-  } else {
-    if (comparePos(targetLoc.end, start) <= 0) {
-      return null;
-    }
-
-    if (comparePos(targetLoc.end, end) <= 0) {
-      sourceLoc = {
-        start: skip("start"),
-        end: sourceLoc.end
-      };
-
-      targetLoc = {
-        // Same as subtractPos(start, start.line, start.column):
-        start: { line: 1, column: 0 },
-        end: subtractPos(targetLoc.end, start.line, start.column)
-      };
-
-    } else {
-      sourceLoc = {
-        start: skip("start"),
-        end: skip("end")
-      };
-
-      targetLoc = {
-        // Same as subtractPos(start, start.line, start.column):
-        start: { line: 1, column: 0 },
-        end: subtractPos(end, start.line, start.column)
-      };
-    }
-  }
-
-  return new Mapping(this.sourceLines, sourceLoc, targetLoc);
-};
-
-Mp.add = function(line, column) {
-  return new Mapping(this.sourceLines, this.sourceLoc, {
-    start: addPos(this.targetLoc.start, line, column),
-    end: addPos(this.targetLoc.end, line, column)
-  });
-};
 
 function addPos(toPos: any, line: number, column: number) {
   return {
@@ -154,13 +167,6 @@ function addPos(toPos: any, line: number, column: number) {
   };
 }
 
-Mp.subtract = function(line, column) {
-  return new Mapping(this.sourceLines, this.sourceLoc, {
-    start: subtractPos(this.targetLoc.start, line, column),
-    end: subtractPos(this.targetLoc.end, line, column)
-  });
-};
-
 function subtractPos(fromPos: any, line: number, column: number) {
   return {
     line: fromPos.line - line + 1,
@@ -170,57 +176,13 @@ function subtractPos(fromPos: any, line: number, column: number) {
   };
 }
 
-Mp.indent = function(by, skipFirstLine, noNegativeColumns) {
-  if (by === 0) {
-    return this;
-  }
-
-  var targetLoc = this.targetLoc;
-  var startLine = targetLoc.start.line;
-  var endLine = targetLoc.end.line;
-
-  if (skipFirstLine && startLine === 1 && endLine === 1) {
-    return this;
-  }
-
-  targetLoc = {
-    start: targetLoc.start,
-    end: targetLoc.end
-  };
-
-  if (!skipFirstLine || startLine > 1) {
-    var startColumn = targetLoc.start.column + by;
-    targetLoc.start = {
-      line: startLine,
-      column: noNegativeColumns
-        ? Math.max(0, startColumn)
-        : startColumn
-    };
-  }
-
-  if (!skipFirstLine || endLine > 1) {
-    var endColumn = targetLoc.end.column + by;
-    targetLoc.end = {
-      line: endLine,
-      column: noNegativeColumns
-        ? Math.max(0, endColumn)
-        : endColumn
-    };
-  }
-
-  return new Mapping(this.sourceLines, this.sourceLoc, targetLoc);
-};
-
 function skipChars(
-  sourceLines: any, sourceFromPos: any,
-  targetLines: any, targetFromPos: any, targetToPos: any
+  sourceLines: Lines,
+  sourceFromPos: Pos,
+  targetLines: Lines,
+  targetFromPos: Pos,
+  targetToPos: Pos,
 ) {
-  assert.ok(sourceLines instanceof linesModule.Lines);
-  assert.ok(targetLines instanceof linesModule.Lines);
-  Position.assert(sourceFromPos);
-  Position.assert(targetFromPos);
-  Position.assert(targetToPos);
-
   var targetComparison = comparePos(targetFromPos, targetToPos);
   if (targetComparison === 0) {
     // Trivial case: no characters to skip.
@@ -229,9 +191,8 @@ function skipChars(
 
   if (targetComparison < 0) {
     // Skipping forward.
-
-    var sourceCursor = sourceLines.skipSpaces(sourceFromPos);
-    var targetCursor = targetLines.skipSpaces(targetFromPos);
+    var sourceCursor = sourceLines.skipSpaces(sourceFromPos) || sourceLines.lastPos();
+    var targetCursor = targetLines.skipSpaces(targetFromPos) || targetLines.lastPos();
 
     var lineDiff = targetToPos.line - targetCursor.line;
     sourceCursor.line += lineDiff;
@@ -257,9 +218,8 @@ function skipChars(
 
   } else {
     // Skipping backward.
-
-    var sourceCursor = sourceLines.skipSpaces(sourceFromPos, true);
-    var targetCursor = targetLines.skipSpaces(targetFromPos, true);
+    var sourceCursor = sourceLines.skipSpaces(sourceFromPos, true) || sourceLines.firstPos();
+    var targetCursor = targetLines.skipSpaces(targetFromPos, true) || targetLines.firstPos();
 
     var lineDiff = targetToPos.line - targetCursor.line;
     sourceCursor.line += lineDiff;

--- a/lib/mapping.ts
+++ b/lib/mapping.ts
@@ -7,284 +7,282 @@ import * as linesModule from "./lines";
 import { comparePos } from "./util";
 
 interface MappingType {
-    sourceLines: any;
-    sourceLoc: any;
-    targetLoc: any;
-    slice(lines: any, start: any, end: any): MappingType | null;
-    add(line: number, column: number): MappingType;
-    subtract(line: number, column: number): MappingType;
-    indent(by: any, skipFirstLine: any, noNegativeColumns: any): MappingType;
+  sourceLines: any;
+  sourceLoc: any;
+  targetLoc: any;
+  slice(lines: any, start: any, end: any): MappingType | null;
+  add(line: number, column: number): MappingType;
+  subtract(line: number, column: number): MappingType;
+  indent(by: any, skipFirstLine: any, noNegativeColumns: any): MappingType;
 }
 
 interface MappingConstructor {
-    new(sourceLines: any, sourceLoc: any, targetLoc?: any): MappingType;
+  new(sourceLines: any, sourceLoc: any, targetLoc?: any): MappingType;
 }
 
 const Mapping = function Mapping(this: MappingType, sourceLines: any, sourceLoc: any, targetLoc?: any) {
-    assert.ok(this instanceof Mapping);
-    assert.ok(sourceLines instanceof linesModule.Lines);
-    SourceLocation.assert(sourceLoc);
+  assert.ok(this instanceof Mapping);
+  assert.ok(sourceLines instanceof linesModule.Lines);
+  SourceLocation.assert(sourceLoc);
 
-    if (targetLoc) {
-        // In certain cases it's possible for targetLoc.{start,end}.column
-        // values to be negative, which technically makes them no longer
-        // valid SourceLocation nodes, so we need to be more forgiving.
-        assert.ok(
-            isNumber.check(targetLoc.start.line) &&
-            isNumber.check(targetLoc.start.column) &&
-            isNumber.check(targetLoc.end.line) &&
-            isNumber.check(targetLoc.end.column)
-        );
-    } else {
-        // Assume identity mapping if no targetLoc specified.
-        targetLoc = sourceLoc;
-    }
+  if (targetLoc) {
+    // In certain cases it's possible for targetLoc.{start,end}.column
+    // values to be negative, which technically makes them no longer
+    // valid SourceLocation nodes, so we need to be more forgiving.
+    assert.ok(isNumber.check(targetLoc.start.line) &&
+              isNumber.check(targetLoc.start.column) &&
+              isNumber.check(targetLoc.end.line) &&
+              isNumber.check(targetLoc.end.column));
+  } else {
+    // Assume identity mapping if no targetLoc specified.
+    targetLoc = sourceLoc;
+  }
 
-    Object.defineProperties(this, {
-        sourceLines: { value: sourceLines },
-        sourceLoc: { value: sourceLoc },
-        targetLoc: { value: targetLoc }
-    });
+  Object.defineProperties(this, {
+    sourceLines: { value: sourceLines },
+    sourceLoc: { value: sourceLoc },
+    targetLoc: { value: targetLoc }
+  });
 } as any as MappingConstructor;
 
 var Mp: MappingType = Mapping.prototype;
 export default Mapping;
 
 Mp.slice = function(lines, start, end) {
-    assert.ok(lines instanceof linesModule.Lines);
-    Position.assert(start);
+  assert.ok(lines instanceof linesModule.Lines);
+  Position.assert(start);
 
-    if (end) {
-        Position.assert(end);
+  if (end) {
+    Position.assert(end);
+  } else {
+    end = lines.lastPos();
+  }
+
+  var sourceLines = this.sourceLines;
+  var sourceLoc = this.sourceLoc;
+  var targetLoc = this.targetLoc;
+
+  function skip(name: string) {
+    var sourceFromPos = sourceLoc[name];
+    var targetFromPos = targetLoc[name];
+    var targetToPos = start;
+
+    if (name === "end") {
+      targetToPos = end;
     } else {
-        end = lines.lastPos();
+      assert.strictEqual(name, "start");
     }
 
-    var sourceLines = this.sourceLines;
-    var sourceLoc = this.sourceLoc;
-    var targetLoc = this.targetLoc;
+    return skipChars(
+      sourceLines, sourceFromPos,
+      lines, targetFromPos, targetToPos
+    );
+  }
 
-    function skip(name: string) {
-        var sourceFromPos = sourceLoc[name];
-        var targetFromPos = targetLoc[name];
-        var targetToPos = start;
+  if (comparePos(start, targetLoc.start) <= 0) {
+    if (comparePos(targetLoc.end, end) <= 0) {
+      targetLoc = {
+        start: subtractPos(targetLoc.start, start.line, start.column),
+        end: subtractPos(targetLoc.end, start.line, start.column)
+      };
 
-        if (name === "end") {
-            targetToPos = end;
-        } else {
-            assert.strictEqual(name, "start");
-        }
+      // The sourceLoc can stay the same because the contents of the
+      // targetLoc have not changed.
 
-        return skipChars(
-            sourceLines, sourceFromPos,
-            lines, targetFromPos, targetToPos
-        );
-    }
-
-    if (comparePos(start, targetLoc.start) <= 0) {
-        if (comparePos(targetLoc.end, end) <= 0) {
-            targetLoc = {
-                start: subtractPos(targetLoc.start, start.line, start.column),
-                end: subtractPos(targetLoc.end, start.line, start.column)
-            };
-
-            // The sourceLoc can stay the same because the contents of the
-            // targetLoc have not changed.
-
-        } else if (comparePos(end, targetLoc.start) <= 0) {
-            return null;
-
-        } else {
-            sourceLoc = {
-                start: sourceLoc.start,
-                end: skip("end")
-            };
-
-            targetLoc = {
-                start: subtractPos(targetLoc.start, start.line, start.column),
-                end: subtractPos(end, start.line, start.column)
-            };
-        }
+    } else if (comparePos(end, targetLoc.start) <= 0) {
+      return null;
 
     } else {
-        if (comparePos(targetLoc.end, start) <= 0) {
-            return null;
-        }
+      sourceLoc = {
+        start: sourceLoc.start,
+        end: skip("end")
+      };
 
-        if (comparePos(targetLoc.end, end) <= 0) {
-            sourceLoc = {
-                start: skip("start"),
-                end: sourceLoc.end
-            };
-
-            targetLoc = {
-                // Same as subtractPos(start, start.line, start.column):
-                start: { line: 1, column: 0 },
-                end: subtractPos(targetLoc.end, start.line, start.column)
-            };
-
-        } else {
-            sourceLoc = {
-                start: skip("start"),
-                end: skip("end")
-            };
-
-            targetLoc = {
-                // Same as subtractPos(start, start.line, start.column):
-                start: { line: 1, column: 0 },
-                end: subtractPos(end, start.line, start.column)
-            };
-        }
+      targetLoc = {
+        start: subtractPos(targetLoc.start, start.line, start.column),
+        end: subtractPos(end, start.line, start.column)
+      };
     }
 
-    return new Mapping(this.sourceLines, sourceLoc, targetLoc);
+  } else {
+    if (comparePos(targetLoc.end, start) <= 0) {
+      return null;
+    }
+
+    if (comparePos(targetLoc.end, end) <= 0) {
+      sourceLoc = {
+        start: skip("start"),
+        end: sourceLoc.end
+      };
+
+      targetLoc = {
+        // Same as subtractPos(start, start.line, start.column):
+        start: { line: 1, column: 0 },
+        end: subtractPos(targetLoc.end, start.line, start.column)
+      };
+
+    } else {
+      sourceLoc = {
+        start: skip("start"),
+        end: skip("end")
+      };
+
+      targetLoc = {
+        // Same as subtractPos(start, start.line, start.column):
+        start: { line: 1, column: 0 },
+        end: subtractPos(end, start.line, start.column)
+      };
+    }
+  }
+
+  return new Mapping(this.sourceLines, sourceLoc, targetLoc);
 };
 
 Mp.add = function(line, column) {
-    return new Mapping(this.sourceLines, this.sourceLoc, {
-        start: addPos(this.targetLoc.start, line, column),
-        end: addPos(this.targetLoc.end, line, column)
-    });
+  return new Mapping(this.sourceLines, this.sourceLoc, {
+    start: addPos(this.targetLoc.start, line, column),
+    end: addPos(this.targetLoc.end, line, column)
+  });
 };
 
 function addPos(toPos: any, line: number, column: number) {
-    return {
-        line: toPos.line + line - 1,
-        column: (toPos.line === 1)
-            ? toPos.column + column
-            : toPos.column
-    };
+  return {
+    line: toPos.line + line - 1,
+    column: (toPos.line === 1)
+      ? toPos.column + column
+      : toPos.column
+  };
 }
 
 Mp.subtract = function(line, column) {
-    return new Mapping(this.sourceLines, this.sourceLoc, {
-        start: subtractPos(this.targetLoc.start, line, column),
-        end: subtractPos(this.targetLoc.end, line, column)
-    });
+  return new Mapping(this.sourceLines, this.sourceLoc, {
+    start: subtractPos(this.targetLoc.start, line, column),
+    end: subtractPos(this.targetLoc.end, line, column)
+  });
 };
 
 function subtractPos(fromPos: any, line: number, column: number) {
-    return {
-        line: fromPos.line - line + 1,
-        column: (fromPos.line === line)
-            ? fromPos.column - column
-            : fromPos.column
-    };
+  return {
+    line: fromPos.line - line + 1,
+    column: (fromPos.line === line)
+      ? fromPos.column - column
+      : fromPos.column
+  };
 }
 
 Mp.indent = function(by, skipFirstLine, noNegativeColumns) {
-    if (by === 0) {
-        return this;
-    }
+  if (by === 0) {
+    return this;
+  }
 
-    var targetLoc = this.targetLoc;
-    var startLine = targetLoc.start.line;
-    var endLine = targetLoc.end.line;
+  var targetLoc = this.targetLoc;
+  var startLine = targetLoc.start.line;
+  var endLine = targetLoc.end.line;
 
-    if (skipFirstLine && startLine === 1 && endLine === 1) {
-        return this;
-    }
+  if (skipFirstLine && startLine === 1 && endLine === 1) {
+    return this;
+  }
 
-    targetLoc = {
-        start: targetLoc.start,
-        end: targetLoc.end
+  targetLoc = {
+    start: targetLoc.start,
+    end: targetLoc.end
+  };
+
+  if (!skipFirstLine || startLine > 1) {
+    var startColumn = targetLoc.start.column + by;
+    targetLoc.start = {
+      line: startLine,
+      column: noNegativeColumns
+        ? Math.max(0, startColumn)
+        : startColumn
     };
+  }
 
-    if (!skipFirstLine || startLine > 1) {
-        var startColumn = targetLoc.start.column + by;
-        targetLoc.start = {
-            line: startLine,
-            column: noNegativeColumns
-                ? Math.max(0, startColumn)
-                : startColumn
-        };
-    }
+  if (!skipFirstLine || endLine > 1) {
+    var endColumn = targetLoc.end.column + by;
+    targetLoc.end = {
+      line: endLine,
+      column: noNegativeColumns
+        ? Math.max(0, endColumn)
+        : endColumn
+    };
+  }
 
-    if (!skipFirstLine || endLine > 1) {
-        var endColumn = targetLoc.end.column + by;
-        targetLoc.end = {
-            line: endLine,
-            column: noNegativeColumns
-                ? Math.max(0, endColumn)
-                : endColumn
-        };
-    }
-
-    return new Mapping(this.sourceLines, this.sourceLoc, targetLoc);
+  return new Mapping(this.sourceLines, this.sourceLoc, targetLoc);
 };
 
 function skipChars(
-    sourceLines: any, sourceFromPos: any,
-    targetLines: any, targetFromPos: any, targetToPos: any
+  sourceLines: any, sourceFromPos: any,
+  targetLines: any, targetFromPos: any, targetToPos: any
 ) {
-    assert.ok(sourceLines instanceof linesModule.Lines);
-    assert.ok(targetLines instanceof linesModule.Lines);
-    Position.assert(sourceFromPos);
-    Position.assert(targetFromPos);
-    Position.assert(targetToPos);
+  assert.ok(sourceLines instanceof linesModule.Lines);
+  assert.ok(targetLines instanceof linesModule.Lines);
+  Position.assert(sourceFromPos);
+  Position.assert(targetFromPos);
+  Position.assert(targetToPos);
 
-    var targetComparison = comparePos(targetFromPos, targetToPos);
-    if (targetComparison === 0) {
-        // Trivial case: no characters to skip.
-        return sourceFromPos;
-    }
+  var targetComparison = comparePos(targetFromPos, targetToPos);
+  if (targetComparison === 0) {
+    // Trivial case: no characters to skip.
+    return sourceFromPos;
+  }
 
-    if (targetComparison < 0) {
-        // Skipping forward.
+  if (targetComparison < 0) {
+    // Skipping forward.
 
-        var sourceCursor = sourceLines.skipSpaces(sourceFromPos);
-        var targetCursor = targetLines.skipSpaces(targetFromPos);
+    var sourceCursor = sourceLines.skipSpaces(sourceFromPos);
+    var targetCursor = targetLines.skipSpaces(targetFromPos);
 
-        var lineDiff = targetToPos.line - targetCursor.line;
-        sourceCursor.line += lineDiff;
-        targetCursor.line += lineDiff;
+    var lineDiff = targetToPos.line - targetCursor.line;
+    sourceCursor.line += lineDiff;
+    targetCursor.line += lineDiff;
 
-        if (lineDiff > 0) {
-            // If jumping to later lines, reset columns to the beginnings
-            // of those lines.
-            sourceCursor.column = 0;
-            targetCursor.column = 0;
-        } else {
-            assert.strictEqual(lineDiff, 0);
-        }
-
-        while (comparePos(targetCursor, targetToPos) < 0 &&
-               targetLines.nextPos(targetCursor, true)) {
-            assert.ok(sourceLines.nextPos(sourceCursor, true));
-            assert.strictEqual(
-                sourceLines.charAt(sourceCursor),
-                targetLines.charAt(targetCursor)
-            );
-        }
-
+    if (lineDiff > 0) {
+      // If jumping to later lines, reset columns to the beginnings
+      // of those lines.
+      sourceCursor.column = 0;
+      targetCursor.column = 0;
     } else {
-        // Skipping backward.
-
-        var sourceCursor = sourceLines.skipSpaces(sourceFromPos, true);
-        var targetCursor = targetLines.skipSpaces(targetFromPos, true);
-
-        var lineDiff = targetToPos.line - targetCursor.line;
-        sourceCursor.line += lineDiff;
-        targetCursor.line += lineDiff;
-
-        if (lineDiff < 0) {
-            // If jumping to earlier lines, reset columns to the ends of
-            // those lines.
-            sourceCursor.column = sourceLines.getLineLength(sourceCursor.line);
-            targetCursor.column = targetLines.getLineLength(targetCursor.line);
-        } else {
-            assert.strictEqual(lineDiff, 0);
-        }
-
-        while (comparePos(targetToPos, targetCursor) < 0 &&
-               targetLines.prevPos(targetCursor, true)) {
-            assert.ok(sourceLines.prevPos(sourceCursor, true));
-            assert.strictEqual(
-                sourceLines.charAt(sourceCursor),
-                targetLines.charAt(targetCursor)
-            );
-        }
+      assert.strictEqual(lineDiff, 0);
     }
 
-    return sourceCursor;
+    while (comparePos(targetCursor, targetToPos) < 0 &&
+           targetLines.nextPos(targetCursor, true)) {
+      assert.ok(sourceLines.nextPos(sourceCursor, true));
+      assert.strictEqual(
+        sourceLines.charAt(sourceCursor),
+        targetLines.charAt(targetCursor)
+      );
+    }
+
+  } else {
+    // Skipping backward.
+
+    var sourceCursor = sourceLines.skipSpaces(sourceFromPos, true);
+    var targetCursor = targetLines.skipSpaces(targetFromPos, true);
+
+    var lineDiff = targetToPos.line - targetCursor.line;
+    sourceCursor.line += lineDiff;
+    targetCursor.line += lineDiff;
+
+    if (lineDiff < 0) {
+      // If jumping to earlier lines, reset columns to the ends of
+      // those lines.
+      sourceCursor.column = sourceLines.getLineLength(sourceCursor.line);
+      targetCursor.column = targetLines.getLineLength(targetCursor.line);
+    } else {
+      assert.strictEqual(lineDiff, 0);
+    }
+
+    while (comparePos(targetToPos, targetCursor) < 0 &&
+           targetLines.prevPos(targetCursor, true)) {
+      assert.ok(sourceLines.prevPos(sourceCursor, true));
+      assert.strictEqual(
+        sourceLines.charAt(sourceCursor),
+        targetLines.charAt(targetCursor)
+      );
+    }
+  }
+
+  return sourceCursor;
 }

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1,8 +1,6 @@
 import assert from "assert";
 import { printComments } from "./comments";
-import * as linesModule from "./lines";
-var fromString = linesModule.fromString;
-var concat = linesModule.concat;
+import { Lines, fromString, concat } from "./lines";
 import { normalize as normalizeOptions } from "./options";
 import { getReprinter } from "./patcher";
 import types from "./types";
@@ -235,7 +233,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
     namedTypes.Printable.assert(n);
 
-    var parts: any[] = [];
+    const parts: (string | Lines)[] = [];
 
     switch (n.type) {
     case "File":
@@ -646,7 +644,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
     case "CallExpression":
     case "OptionalCallExpression":
-        var parts = [path.call(print, "callee")];
+        parts.push(path.call(print, "callee"));
 
         if (n.type === "OptionalCallExpression" &&
             n.callee.type !== "OptionalMemberExpression") {
@@ -973,8 +971,8 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         ]);
 
     case "IfStatement":
-        var con = adjustClause(path.call(print, "consequent"), options),
-            parts = ["if (", path.call(print, "test"), ")", con];
+        var con = adjustClause(path.call(print, "consequent"), options);
+        parts.push("if (", path.call(print, "test"), ")", con);
 
         if (n.alternate)
             parts.push(
@@ -994,8 +992,9 @@ function genericPrintNoParens(path: any, options: any, print: any) {
                 path.call(print, "update")
             ]).indentTail(forParen.length),
             head = concat([forParen, indented, ")"]),
-            clause = adjustClause(path.call(print, "body"), options),
-            parts = [head];
+            clause = adjustClause(path.call(print, "body"), options);
+
+        parts.push(head);
 
         if (head.length > 1) {
             parts.push("\n");
@@ -1048,7 +1047,9 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         var doBody = concat([
             "do",
             adjustClause(path.call(print, "body"), options)
-        ]), parts = [doBody];
+        ]);
+
+        parts.push(doBody);
 
         if (endsWithBrace(doBody))
             parts.push(" while");
@@ -2090,7 +2091,6 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
     case "TSAsExpression": {
         var withParens = n.extra && n.extra.parenthesized === true;
-        parts = [];
         if (withParens) parts.push("(");
         parts.push(
             path.call(print, "expression"),
@@ -2748,7 +2748,7 @@ function printFunctionParams(path: any, options: any, print: any) {
 
 function printExportDeclaration(path: any, options: any, print: any) {
     var decl = path.getValue();
-    var parts = ["export "];
+    var parts: (string | Lines)[] = ["export "];
     if (decl.exportKind && decl.exportKind !== "value") {
         parts.push(decl.exportKind + " ");
     }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,3 +5,16 @@
 import astTypes from "ast-types";
 export default astTypes;
 export * from "ast-types";
+
+// TODO Get these types from ast-types.
+
+export type Position = {
+  line: number;
+  column: number;
+};
+
+export type SourceLocation = {
+  source?: string | null;
+  start: Position;
+  end: Position;
+};

--- a/test/lines.ts
+++ b/test/lines.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import fs from "fs";
 import path from "path";
-import { fromString, concat, countSpaces, LinesType } from "../lib/lines";
+import { fromString, concat, countSpaces, Lines } from "../lib/lines";
 import { EOL as eol } from "os";
 
 function check(a: any, b: any) {
@@ -403,7 +403,7 @@ describe("lines", function() {
             "}"
         ].join(eol);
 
-        function checkUnchanged(lines: LinesType, code: string) {
+        function checkUnchanged(lines: Lines, code: string) {
             check(lines.toString(tabOpts), code);
             check(lines.toString(noTabOpts), code);
             check(lines.indent(3).indent(-5).indent(2).toString(tabOpts), code);


### PR DESCRIPTION
When everything was converted to TypeScript, we intentionally held off on converting some existing constructor functions to proper classes.

This PR converts the `Mapping` and `Lines` types to classes.