### PR TITLE
Emit ClassProperty.access to specify field access

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1324,8 +1324,9 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         return concat(parts);
 
     case "ClassProperty":
-        if (typeof n.accessibility === "string") {
-            parts.push(n.accessibility, " ");
+        var access = n.accessibility || n.access;
+        if (typeof access === "string") {
+            parts.push(access, " ");
         }
 
         if (n.static) {


### PR DESCRIPTION
Update `printer.ts` to emit the access modifier for a field, as specified by [PR 323 for ast-types](https://github.com/benjamn/ast-types/pull/323).