### PR TITLE
Modernize and TypeScript-ify the main.ts entry point module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 matrix:
   include:
+  - node_js: "12"
   - node_js: "11"
   - node_js: "10"
   - node_js: "9"

--- a/README.md
+++ b/README.md
@@ -19,50 +19,71 @@ From GitHub:
     cd recast
     npm install .
 
+Import style
+---
+
+Recast is designed to be imported using **named** imports:
+```js
+import { parse, print } from "recast";
+console.log(print(parse(source)).code);
+
+import * as recast from "recast";
+console.log(recast.print(recast.parse(source)).code);
+```
+
+If you're using CommonJS:
+```js
+const { parse, print } = require("recast");
+console.log(print(parse(source)).code);
+
+const recast = require("recast");
+console.log(recast.print(recast.parse(source)).code);
+```
+
 Usage
 ---
 
-In less poetic terms, Recast exposes two essential interfaces, one for parsing JavaScript code (`require("recast").parse`) and the other for reprinting modified syntax trees (`require("recast").print`).
+Recast exposes two essential interfaces, one for parsing JavaScript code (`require("recast").parse`) and the other for reprinting modified syntax trees (`require("recast").print`).
 
 Here's a simple but non-trivial example of how you might use `.parse` and `.print`:
 ```js
-var recast = require("recast");
+import * as recast from "recast";
 
 // Let's turn this function declaration into a variable declaration.
-var code = [
-    "function add(a, b) {",
-    "  return a +",
-    "    // Weird formatting, huh?",
-    "    b;",
-    "}"
+const code = [
+  "function add(a, b) {",
+  "  return a +",
+  "    // Weird formatting, huh?",
+  "    b;",
+  "}"
 ].join("\n");
 
 // Parse the code using an interface similar to require("esprima").parse.
-var ast = recast.parse(code);
+const ast = recast.parse(code);
 ```
 Now do *whatever* you want to `ast`. Really, anything at all!
 
 See [ast-types](https://github.com/benjamn/ast-types) (especially the [def/core.ts](https://github.com/benjamn/ast-types/blob/master/def/core.ts)) module for a thorough overview of the `ast` API.
 ```js
 // Grab a reference to the function declaration we just parsed.
-var add = ast.program.body[0];
+const add = ast.program.body[0];
 
 // Make sure it's a FunctionDeclaration (optional).
-var n = recast.types.namedTypes;
+const n = recast.types.namedTypes;
 n.FunctionDeclaration.assert(add);
 
 // If you choose to use recast.builders to construct new AST nodes, all builder
 // arguments will be dynamically type-checked against the Mozilla Parser API.
-var b = recast.types.builders;
+const b = recast.types.builders;
 
 // This kind of manipulation should seem familiar if you've used Esprima or the
 // Mozilla Parser API before.
 ast.program.body[0] = b.variableDeclaration("var", [
-    b.variableDeclarator(add.id, b.functionExpression(
-        null, // Anonymize the function expression.
-        add.params,
-        add.body
-    ))
+  b.variableDeclarator(add.id, b.functionExpression(
+    null, // Anonymize the function expression.
+    add.params,
+    add.body
+  ))
 ]);
 
 // Just for fun, because addition is commutative:
@@ -70,7 +91,7 @@ add.params.push(add.params.shift());
 ```
 When you finish manipulating the AST, let `recast.print` work its magic:
 ```js
-var output = recast.print(ast).code;
+const output = recast.print(ast).code;
 ```
 The `output` string now looks exactly like this, weird formatting and all:
 ```js

--- a/lib/comments.ts
+++ b/lib/comments.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import types from "./types";
+import * as types from "ast-types";
 var n = types.namedTypes;
 var isArray = types.builtInTypes.array;
 var isObject = types.builtInTypes.object;

--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import types from "./types";
+import * as types from "ast-types";
 var n = types.namedTypes;
 var isArray = types.builtInTypes.array;
 var isNumber = types.builtInTypes.number;

--- a/lib/lines.ts
+++ b/lib/lines.ts
@@ -1,9 +1,11 @@
 import assert from "assert";
 import sourceMap from "source-map";
 import { normalize as normalizeOptions, Options } from "./options";
-import { Position as Pos } from "./types";
+import { namedTypes } from "ast-types";
 import { comparePos } from "./util";
 import Mapping from "./mapping";
+
+type Pos = namedTypes.Position;
 
 // Goals:
 // 1. Minimize new string creation.

--- a/lib/mapping.ts
+++ b/lib/mapping.ts
@@ -1,10 +1,10 @@
 import assert from "assert";
 import { comparePos } from "./util";
-import {
-  SourceLocation as Loc,
-  Position as Pos,
-} from "./types";
+import { namedTypes } from "ast-types";
 import { Lines } from "./lines";
+
+type Pos = namedTypes.Position;
+type Loc = namedTypes.SourceLocation;
 
 export default class Mapping {
   constructor(

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import types from "./types";
+import * as types from "ast-types";
 var b = types.builders;
 var isObject = types.builtInTypes.object;
 var isArray = types.builtInTypes.array;

--- a/lib/patcher.ts
+++ b/lib/patcher.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import * as linesModule from "./lines";
-import types from "./types";
+import * as types from "ast-types";
 var Printable = types.namedTypes.Printable;
 var Expression = types.namedTypes.Expression;
 var ReturnStatement = types.namedTypes.ReturnStatement;

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -3,7 +3,7 @@ import { printComments } from "./comments";
 import { Lines, fromString, concat } from "./lines";
 import { normalize as normalizeOptions } from "./options";
 import { getReprinter } from "./patcher";
-import types from "./types";
+import * as types from "ast-types";
 var namedTypes = types.namedTypes;
 var isString = types.builtInTypes.string;
 var isObject = types.builtInTypes.object;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,0 @@
-import * as types from "ast-types";
-export * from "ast-types";
-export default types;
-
-export type Position = types.namedTypes.Position;
-export type SourceLocation = types.namedTypes.SourceLocation;

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import types from "./types";
+import * as types from "ast-types";
 var n = types.namedTypes;
 import sourceMap from "source-map";
 var SourceMapConsumer = sourceMap.SourceMapConsumer;

--- a/main.ts
+++ b/main.ts
@@ -4,123 +4,89 @@ import { parse } from "./lib/parser";
 import { Printer } from "./lib/printer";
 import { Options } from "./lib/options";
 
-export interface Parser {
-    parse(source: string, options?: any): types.ASTNode;
+export {
+  /**
+   * Parse a string of code into an augmented syntax tree suitable for
+   * arbitrary modification and reprinting.
+   */
+  parse,
+
+  /**
+   * Convenient shorthand for the ast-types package.
+   */
+  types,
+};
+
+/**
+ * Traverse and potentially modify an abstract syntax tree using a
+ * convenient visitor syntax:
+ *
+ *   recast.visit(ast, {
+ *     names: [],
+ *     visitIdentifier: function(path) {
+ *       var node = path.value;
+ *       this.visitor.names.push(node.name);
+ *       this.traverse(path);
+ *     }
+ *   });
+ */
+export const visit = types.visit;
+
+/**
+ * Options shared between parsing and printing.
+ */
+export { Options } from "./lib/options";
+
+/**
+ * Reprint a modified syntax tree using as much of the original source
+ * code as possible.
+ */
+export function print(node: types.ASTNode, options?: Options) {
+  return new Printer(options).print(node);
 }
 
-function print(node: types.ASTNode, options?: Options) {
-    return new Printer(options).print(node);
+/**
+ * Print without attempting to reuse any original source code.
+ */
+export function prettyPrint(node: types.ASTNode, options?: Options) {
+  return new Printer(options).printGenerically(node);
 }
 
-function prettyPrint(node: types.ASTNode, options?: Options) {
-    return new Printer(options).printGenerically(node);
+/**
+ * Convenient command-line interface (see e.g. example/add-braces).
+ */
+export function run(transformer: Transformer, options?: RunOptions) {
+  return runFile(process.argv[2], transformer, options);
 }
 
-interface Transformer {
-    (ast: types.ASTNode, callback: (ast: types.ASTNode) => void): void;
+export interface Transformer {
+  (ast: types.ASTNode, callback: (ast: types.ASTNode) => void): void;
 }
 
-interface RunOptions extends Options {
-    writeback?(code: string): void;
-}
-
-function run(transformer: Transformer, options?: RunOptions) {
-    return runFile(process.argv[2], transformer, options);
+export interface RunOptions extends Options {
+  writeback?(code: string): void;
 }
 
 function runFile(path: any, transformer: Transformer, options?: RunOptions) {
-    fs.readFile(path, "utf-8", function(err, code) {
-        if (err) {
-            console.error(err);
-            return;
-        }
+  fs.readFile(path, "utf-8", function(err, code) {
+    if (err) {
+      console.error(err);
+      return;
+    }
 
-        runString(code, transformer, options);
-    });
+    runString(code, transformer, options);
+  });
 }
 
 function defaultWriteback(output: string) {
-    process.stdout.write(output);
+  process.stdout.write(output);
 }
 
 function runString(code: string, transformer: Transformer, options?: RunOptions) {
-    var writeback = options && options.writeback || defaultWriteback;
-    transformer(parse(code, options), function(node: any) {
-        writeback(print(node, options).code);
-    });
+  const writeback = options && options.writeback || defaultWriteback;
+  transformer(parse(code, options), function(node: any) {
+    writeback(print(node, options).code);
+  });
 }
 
-interface Main {
-    parse: typeof parse;
-    visit: typeof types.visit;
-    print: typeof print;
-    prettyPrint: typeof prettyPrint;
-    types: typeof types;
-    run: typeof run;
-}
-
-const main = exports as Main;
-Object.defineProperties(main, {
-    /**
-     * Parse a string of code into an augmented syntax tree suitable for
-     * arbitrary modification and reprinting.
-     */
-    parse: {
-        enumerable: true,
-        value: parse
-    },
-
-    /**
-     * Traverse and potentially modify an abstract syntax tree using a
-     * convenient visitor syntax:
-     *
-     *   recast.visit(ast, {
-     *     names: [],
-     *     visitIdentifier: function(path) {
-     *       var node = path.value;
-     *       this.visitor.names.push(node.name);
-     *       this.traverse(path);
-     *     }
-     *   });
-     */
-    visit: {
-        enumerable: true,
-        value: types.visit
-    },
-
-    /**
-     * Reprint a modified syntax tree using as much of the original source
-     * code as possible.
-     */
-    print: {
-        enumerable: true,
-        value: print
-    },
-
-    /**
-     * Print without attempting to reuse any original source code.
-     */
-    prettyPrint: {
-        enumerable: false,
-        value: prettyPrint
-    },
-
-    /**
-     * Customized version of require("ast-types").
-     */
-    types: {
-        enumerable: false,
-        value: types
-    },
-
-    /**
-     * Convenient command-line interface (see e.g. example/add-braces).
-     */
-    run: {
-        enumerable: false,
-        value: run
-    }
-});
-
-export default main;
-export { Options } from "./lib/options";
+export default exports;

--- a/main.ts
+++ b/main.ts
@@ -1,23 +1,23 @@
 import fs from "fs";
-import types, { ASTNode, NodePath, Type } from "./lib/types";
+import * as types from "ast-types";
 import { parse } from "./lib/parser";
 import { Printer } from "./lib/printer";
 import { Options } from "./lib/options";
 
 export interface Parser {
-    parse(source: string, options?: any): ASTNode;
+    parse(source: string, options?: any): types.ASTNode;
 }
 
-function print(node: ASTNode, options?: Options) {
+function print(node: types.ASTNode, options?: Options) {
     return new Printer(options).print(node);
 }
 
-function prettyPrint(node: ASTNode, options?: Options) {
+function prettyPrint(node: types.ASTNode, options?: Options) {
     return new Printer(options).printGenerically(node);
 }
 
 interface Transformer {
-    (ast: ASTNode, callback: (ast: ASTNode) => void): void;
+    (ast: types.ASTNode, callback: (ast: types.ASTNode) => void): void;
 }
 
 interface RunOptions extends Options {
@@ -123,5 +123,4 @@ Object.defineProperties(main, {
 });
 
 export default main;
-export { ASTNode, NodePath, Type }
 export { Options } from "./lib/options";

--- a/main.ts
+++ b/main.ts
@@ -30,7 +30,7 @@ export {
  *     }
  *   });
  */
-export const visit = types.visit;
+export { visit } from "ast-types";
 
 /**
  * Options shared between parsing and printing.
@@ -88,5 +88,3 @@ function runString(code: string, transformer: Transformer, options?: RunOptions)
     writeback(print(node, options).code);
   });
 }
-
-export default exports;

--- a/main.ts
+++ b/main.ts
@@ -59,7 +59,7 @@ interface Main {
     run: typeof run;
 }
 
-const main = {} as Main;
+const main = exports as Main;
 Object.defineProperties(main, {
     /**
      * Parse a string of code into an augmented syntax tree suitable for

--- a/package-lock.json
+++ b/package-lock.json
@@ -1710,26 +1710,6 @@
         "once": "^1.3.1"
       }
     },
-    "recast": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.16.2.tgz",
-      "integrity": "sha512-O/7qXi51DPjRVdbrpNzoBQH5dnAPQNbfoOFyRiUwreTMJfIHYOEBzwuH+c0+/BTSJ3CQyKs6ILSWXhESH6Op3A==",
-      "dev": true,
-      "requires": {
-        "ast-types": "0.11.7",
-        "esprima": "~4.0.0",
-        "private": "~0.1.5",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "ast-types": {
-          "version": "0.11.7",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.7.tgz",
-          "integrity": "sha512-2mP3TwtkY/aTv5X3ZsMpNAbOnyoC/aMJwJSoaELPkHId0nSQgFcnU4dRW3isxiz7+zBexk0ym3WNVjMiQBnJSw==",
-          "dev": true
-        }
-      }
-    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -1939,24 +1919,6 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
-    },
-    "ts-add-module-exports": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ts-add-module-exports/-/ts-add-module-exports-1.0.0.tgz",
-      "integrity": "sha512-oMRGz9WWbdTB7+d6aZDXvJK9N0NZkbi9+LQzn0siP8papRonpaCcT+Z6AuA9ira7QXwYBmXbJBK4x7CVKhFvZQ==",
-      "dev": true,
-      "requires": {
-        "ast-types": "^0.11.6",
-        "recast": "^0.16.1"
-      },
-      "dependencies": {
-        "ast-types": {
-          "version": "0.11.7",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.7.tgz",
-          "integrity": "sha512-2mP3TwtkY/aTv5X3ZsMpNAbOnyoC/aMJwJSoaELPkHId0nSQgFcnU4dRW3isxiz7+zBexk0ym3WNVjMiQBnJSw==",
-          "dev": true
-        }
-      }
     },
     "ts-emit-clean": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -849,12 +849,6 @@
         "color-convert": "^1.9.0"
       }
     },
-    "arg": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
-      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
-      "dev": true
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -863,6 +857,12 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
     },
     "ast-types": {
       "version": "0.13.0",
@@ -1965,16 +1965,19 @@
       "dev": true
     },
     "ts-node": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.1.0.tgz",
-      "integrity": "sha512-34jpuOrxDuf+O6iW1JpgTRDFynUZ1iEqtYruBqh35gICNjN8x+LpVcPAcwzLPi9VU6mdA3ym+x233nZmZp445A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
       "dev": true,
       "requires": {
-        "arg": "^4.1.0",
+        "arrify": "^1.0.0",
+        "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
-        "yn": "^3.0.0"
+        "yn": "^2.0.0"
       }
     },
     "typescript": {
@@ -2207,9 +2210,9 @@
       }
     },
     "yn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
-      "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,13 +22,12 @@
   "main": "main.js",
   "types": "main.d.ts",
   "scripts": {
-    "tsc": "tsc --noEmit",
     "mocha": "test/run.sh",
     "debug": "test/run.sh --inspect-brk",
-    "test": "npm run tsc && npm run mocha",
-    "build": "tsc",
+    "test": "npm run build && npm run mocha",
+    "build": "npm run clean && tsc",
     "clean": "ts-emit-clean",
-    "prepack": "npm run clean && npm run build",
+    "prepack": "npm run build",
     "postpack": "npm run clean"
   },
   "browser": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mocha": "test/run.sh",
     "debug": "test/run.sh --inspect-brk",
     "test": "npm run tsc && npm run mocha",
-    "build": "tsc && ts-add-module-exports",
+    "build": "tsc",
     "clean": "ts-emit-clean",
     "prepack": "npm run clean && npm run build",
     "postpack": "npm run clean"
@@ -53,7 +53,6 @@
     "glob": "7.1.4",
     "mocha": "6.1.4",
     "reify": "0.18.1",
-    "ts-add-module-exports": "1.0.0",
     "ts-emit-clean": "1.0.0",
     "ts-node": "7.0.1",
     "typescript": "3.4.5"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "reify": "0.18.1",
     "ts-add-module-exports": "1.0.0",
     "ts-emit-clean": "1.0.0",
-    "ts-node": "8.1.0",
+    "ts-node": "7.0.1",
     "typescript": "3.4.5"
   },
   "engines": {

--- a/test/babel.ts
+++ b/test/babel.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import recast from "../main";
+import * as recast from "../main";
 var n = recast.types.namedTypes;
 var b = recast.types.builders;
 import { EOL as eol } from "os";

--- a/test/comments.ts
+++ b/test/comments.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import recast from "../main";
+import * as recast from "../main";
 var n = recast.types.namedTypes;
 var b = recast.types.builders;
 import { Printer } from "../lib/printer";

--- a/test/es6tests.ts
+++ b/test/es6tests.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { parse } from "../lib/parser";
 import { Printer } from "../lib/printer";
-import types from "../lib/types";
+import * as types from "ast-types";
 var n = types.namedTypes;
 var b = types.builders;
 import { EOL as eol } from "os";

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { parse } from "../lib/parser";
 import { Printer } from "../lib/printer";
-import types from "../lib/types";
+import * as types from "ast-types";
 import { EOL as eol } from "os";
 
 describe("type syntax", function() {

--- a/test/identity.ts
+++ b/test/identity.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import fs from "fs";
 import path from "path";
 import * as types from "ast-types";
-import main from "../main";
+import * as recast from "../main";
 
 var nodeMajorVersion = parseInt(process.versions.node, 10);
 
@@ -11,9 +11,9 @@ function testFile(path: string, options: { parser?: any } = {}) {
         assert.equal(err, null);
         assert.strictEqual(typeof source, "string");
 
-        var ast = main.parse(source, options);
+        var ast = recast.parse(source, options);
         types.astNodesAreEquivalent.assert(ast.original, ast);
-        var code = main.print(ast).code;
+        var code = recast.print(ast).code;
         assert.strictEqual(source, code);
     });
 }

--- a/test/identity.ts
+++ b/test/identity.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import fs from "fs";
 import path from "path";
-import types from "../lib/types";
+import * as types from "ast-types";
 import main from "../main";
 
 var nodeMajorVersion = parseInt(process.versions.node, 10);

--- a/test/jsx.ts
+++ b/test/jsx.ts
@@ -2,7 +2,7 @@
 
 import { parse } from "../lib/parser";
 import { Printer } from "../lib/printer";
-import types from "../lib/types";
+import * as types from "ast-types";
 var nodeMajorVersion = parseInt(process.versions.node, 10);
 
 (nodeMajorVersion >= 6 ? describe : xdescribe)

--- a/test/mapping.ts
+++ b/test/mapping.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import sourceMap from "source-map";
 import recast from "../main";
-import types from "../lib/types";
+import * as types from "ast-types";
 var n = types.namedTypes;
 var b = types.builders;
 var NodePath = types.NodePath;

--- a/test/mapping.ts
+++ b/test/mapping.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import sourceMap from "source-map";
-import recast from "../main";
+import * as recast from "../main";
 import * as types from "ast-types";
 var n = types.namedTypes;
 var b = types.builders;

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import * as esprima from "esprima";
 import { parse } from "../lib/parser";
 import { Printer } from "../lib/printer";
-import types from "../lib/types";
+import * as types from "ast-types";
 import { EOL as eol } from "os";
 
 const printer = new Printer;

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -3,7 +3,7 @@ import { parse } from "../lib/parser";
 import { getReprinter } from "../lib/patcher";
 import { Printer } from "../lib/printer";
 import { fromString } from "../lib/lines";
-import types from "../lib/types";
+import * as types from "ast-types";
 var namedTypes = types.namedTypes;
 import FastPath from "../lib/fast-path";
 import { EOL as eol } from "os";
@@ -21,7 +21,6 @@ describe("parser", function() {
   ].forEach(runTestsForParser);
 
   it("AlternateParser", function() {
-    var types = require("../lib/types");
     var b = types.builders;
     var parser = {
       parse: function() {

--- a/test/patcher.ts
+++ b/test/patcher.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import recast from "../main";
-import types from "../lib/types";
+import * as types from "ast-types";
 var n = types.namedTypes;
 var b = types.builders;
 import { getReprinter, Patcher } from "../lib/patcher";

--- a/test/patcher.ts
+++ b/test/patcher.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import recast from "../main";
+import * as recast from "../main";
 import * as types from "ast-types";
 var n = types.namedTypes;
 var b = types.builders;

--- a/test/perf.ts
+++ b/test/perf.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import fs from "fs";
-import recast from "../main";
+import * as recast from "../main";
 
 var source = fs.readFileSync(
     path.join(__dirname, "data", "backbone.js"),

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import recast from "../main";
 import { parse } from "../lib/parser";
 import { Printer } from "../lib/printer";
-import types from "../lib/types";
+import * as types from "ast-types";
 var n = types.namedTypes;
 var b = types.builders;
 import { fromString } from "../lib/lines";

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import recast from "../main";
+import * as recast from "../main";
 import { parse } from "../lib/parser";
 import { Printer } from "../lib/printer";
 import * as types from "ast-types";

--- a/test/syntax.ts
+++ b/test/syntax.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import fs from "fs";
 import path from "path";
-import types from "../lib/types";
+import * as types from "ast-types";
 import { parse } from "../lib/parser";
 var hasOwn = Object.prototype.hasOwnProperty;
 

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import path from "path";
 import fs from "fs";
 import recast from "../main";
-import types from "../lib/types";
+import * as types from "ast-types";
 import {EOL as eol} from "os";
 import * as parser from "../parsers/typescript";
 

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import path from "path";
 import fs from "fs";
-import recast from "../main";
+import * as recast from "../main";
 import * as types from "ast-types";
 import {EOL as eol} from "os";
 import * as parser from "../parsers/typescript";

--- a/test/visit.ts
+++ b/test/visit.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import types, { Visitor } from "../lib/types";
+import * as types from "ast-types";
 var namedTypes = types.namedTypes;
 var builders = types.builders;
 import { parse } from "../lib/parser";
@@ -37,7 +37,7 @@ describe("types.visit", function() {
         );
 
         var propNames: any[] = [];
-        var methods: Visitor = {
+        var methods: types.Visitor = {
             visitProperty: function(path) {
                 var key: any = path.node.key;
                 propNames.push(key.value || key.name);


### PR DESCRIPTION
Using `Object.defineProperties` to populate the `exports` object in `main.ts` is an ancient holdover from CommonJS. Now that this repository uses TypeScript (#554), we should embrace TS/ESM syntax as fully as possible.

From an external perspective, the most important change here is that the `recast` package no longer has a `default` export, and now uses only named exports.

Some exported types (`ASTNode`, `NodePath`, and `Type`) are no longer exported directly from `main.ts`, but may instead be obtained via `recast.types.{ASTNode,NodePath,Type}`.

These changes definitely necessitate a minor version bump, at the very least.