### PR TITLE
Add ability to have shorthand destructuring for default function parameter objects

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -754,6 +754,10 @@ function genericPrintNoParens(path: any, options: any, print: any) {
             return printMethod(path, options, print);
         }
 
+        if (n.shorthand && n.value.type === "AssignmentPattern") {
+            return path.call(print, "value");
+        }
+
         var key = path.call(print, "key");
         if (n.computed) {
             parts.push("[", key, "]");

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -2059,4 +2059,55 @@ describe("printer", function() {
     var pretty = new Printer().printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
+
+  it("object destructuring for function parameters", function() {
+    var code = [
+      'function myFunction(',
+      '    {',
+      '        yes = "y",',
+      '        no: no = "n",',
+      '        short,',
+      '        long: longHand',
+      '    }',
+      ') {}',
+    ].join(eol);
+
+    const simplifiedDefaultArgProperty = b.property(
+      'init',
+      b.identifier('yes'),
+      b.assignmentPattern(b.identifier('yes'), b.literal('y')),
+    );
+    simplifiedDefaultArgProperty.shorthand = true;
+
+    const notSimplifiedDefaultArgProperty = b.property(
+      'init',
+      b.identifier('no'),
+      b.assignmentPattern(b.identifier('no'), b.literal('n')),
+    );
+
+    const simplifiedProperty = b.property(
+      'init',
+      b.identifier('short'),
+      b.identifier('short'),
+    );
+    simplifiedProperty.shorthand = true;
+
+    const notSimplifiedProperty = b.property('init', b.identifier('long'), b.identifier('longHand'));
+
+    var ast = b.program([
+      b.functionDeclaration(
+        b.identifier('myFunction'),
+        [b.objectPattern([
+          simplifiedDefaultArgProperty,
+          notSimplifiedDefaultArgProperty,
+          simplifiedProperty,
+          notSimplifiedProperty
+        ])],
+        b.blockStatement([]),
+      )
+    ]);
+
+    var pretty = new Printer().printGenerically(ast).code;
+    assert.strictEqual(pretty, code);
+  });
 });


### PR DESCRIPTION
Fixes [this](https://github.com/benjamn/ast-types/issues/348) issue