### PR TITLE
Fix printing expressions with type parameters

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -928,6 +928,9 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
     case "NewExpression":
         parts.push("new ", path.call(print, "callee"));
+        if (n.typeParameters) {
+            parts.push(path.call(print, "typeParameters"));
+        }
         var args = n.arguments;
         if (args) {
             parts.push(printArgumentsList(path, options, print));

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -651,6 +651,10 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     case "OptionalCallExpression":
         parts.push(path.call(print, "callee"));
 
+        if (n.typeParameters) {
+            parts.push(path.call(print, "typeParameters"));
+        }
+
         if (n.type === "OptionalCallExpression" &&
             n.callee.type !== "OptionalMemberExpression") {
             parts.push("?.");

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -359,6 +359,10 @@ function genericPrintNoParens(path: any, options: any, print: any) {
                 path.call(print, "id"),
                 path.call(print, "typeParameters")
             );
+        } else {
+            if (n.typeParameters) {
+                parts.push(path.call(print, "typeParameters"));
+            }
         }
 
         parts.push(

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -655,6 +655,10 @@ function genericPrintNoParens(path: any, options: any, print: any) {
             parts.push(path.call(print, "typeParameters"));
         }
 
+        if (n.typeArguments) {
+            parts.push(path.call(print, "typeArguments"));
+        }
+
         if (n.type === "OptionalCallExpression" &&
             n.callee.type !== "OptionalMemberExpression") {
             parts.push("?.");
@@ -934,6 +938,9 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         parts.push("new ", path.call(print, "callee"));
         if (n.typeParameters) {
             parts.push(path.call(print, "typeParameters"));
+        }
+        if (n.typeArguments) {
+            parts.push(path.call(print, "typeArguments"));
         }
         var args = n.arguments;
         if (args) {

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -138,5 +138,9 @@ describe("type syntax", function() {
       "  ...",
       "};"
     ].join(eol), flowParserParseOptions);
+
+    // typeArguments
+    check('new A<string>();', flowParserParseOptions);
+    check('createPlugin<number>();', flowParserParseOptions);
   });
 });

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -306,6 +306,10 @@ var nodeMajorVersion = parseInt(process.versions.node, 10);
     check([
       'const a = function<T>(a: T): void {};'
     ]);
+
+    check([
+      'new A<number>();',
+    ]);
   });
 });
 

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -310,6 +310,10 @@ var nodeMajorVersion = parseInt(process.versions.node, 10);
     check([
       'new A<number>();',
     ]);
+
+    check([
+      'createPlugin<number>();',
+    ]);
   });
 });
 

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -302,6 +302,10 @@ var nodeMajorVersion = parseInt(process.versions.node, 10);
       'const qualifiedWithParams: import("package").ns.foo<T, U> = 4;',
       'const justParameterized: import("package")<T> = 5;',
     ]);
+
+    check([
+      'const a = function<T>(a: T): void {};'
+    ]);
   });
 });
 


### PR DESCRIPTION
added code to print `typeParamentes` for:
 - FunctionExpression (case when it is anonymous function)
 - NewExpression
 - CallExpression