### PR TITLE
fix TSConstructorType printing

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1993,9 +1993,18 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         ]);
 
     case "TSFunctionType":
-    case "TSConstructorType":
         return concat([
             path.call(print, "typeParameters"),
+            "(",
+            printFunctionParams(path, options, print),
+            ")",
+            path.call(print, "typeAnnotation")
+        ]);
+
+    case "TSConstructorType":
+        return concat([
+            "new ",
+            path.call(print, 'typeParameters'),
             "(",
             printFunctionParams(path, options, print),
             ")",
@@ -2149,7 +2158,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         // in a type predicate, it takes the for u is U
         var parent = path.getParentNode(0);
         var prefix = ": ";
-        if (namedTypes.TSFunctionType.check(parent)) {
+        if (namedTypes.TSFunctionType.check(parent) || namedTypes.TSConstructorType.check(parent)) {
             prefix = " => ";
         }
 

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -314,6 +314,10 @@ var nodeMajorVersion = parseInt(process.versions.node, 10);
     check([
       'createPlugin<number>();',
     ]);
+
+    check([
+      'type Class<T> = new (...args: any) => T;',
+    ]);
   });
 });
 


### PR DESCRIPTION
fix for the case when printing:

```ts
type Class<T> = new (...args: any) => T;
```