### PR TITLE
Add semicolons after directives only as needed.

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -608,10 +608,8 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         if (n.directives) {
             path.each(function(childPath: any) {
                 parts.push(
-                    print(childPath).indent(options.tabWidth),
-                    ";",
-                    n.directives.length > 1 || !naked.isEmpty() ? "\n" : ""
-                );
+                    maybeAddSemicolon(print(childPath).indent(options.tabWidth)),
+                    n.directives.length > 1 || !naked.isEmpty() ? "\n" : "");
             }, "directives");
         }
         parts.push(naked.indent(options.tabWidth));

--- a/test/babel.ts
+++ b/test/babel.ts
@@ -452,4 +452,27 @@ describe("Babel", function () {
         ].join(eol)
     );
   });
+
+  // https://github.com/codemod-js/codemod/issues/157
+  it("avoids extra semicolons on mutated blocks containing a 'use strict' directive", function() {
+    var code = [
+      '(function () {',
+      '  "use strict";',
+      '  hello;',
+      '})();'
+    ].join(eol);
+    var ast = recast.parse(code, parseOptions);
+
+    // delete "hello;"
+    ast.program.body[0].expression.callee.body.body.splice(0);
+
+    assert.strictEqual(
+        recast.print(ast).code,
+        [
+          '(function () {',
+          '  "use strict";',
+          '})();'
+        ].join(eol)
+    );
+  });
 });


### PR DESCRIPTION
This description will use the following code for illustration:

```js
(function () {
  "use strict";
  hello;
})();
```

In the situation where the containing `BlockStatement` changed but the directive itself did not, recast would simply print the directive as-is while generically printing the block. Since the `Directive` node `loc` includes the trailing semicolon, that part gets printed as `"use strict";`. Subsequently, the `BlockStatement` printer would unconditionally add a semicolon part after each directive string. This caused recast to print a double semicolon in such circumstances, i.e. `"use strict";;`.

Originally reported in https://github.com/codemod-js/codemod/issues/157.