### PR TITLE
parenthesis around arrow function body when returning object literal

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -474,6 +474,14 @@ FPp.needsParens = function(assumeExpressionContext) {
 
     break;
 
+  case 'TSAsExpression':
+    if (parent.type === 'ArrowFunctionExpression' &&
+      name === 'body' &&
+      node.expression.type === 'ObjectExpression') {
+      return true;
+    }
+    break;
+
   case "CallExpression":
     if (name === "declaration" &&
         n.ExportDefaultDeclaration.check(parent) &&

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1173,6 +1173,27 @@ describe("printer", function() {
     assert.strictEqual(pretty, code);
   });
 
+  it("adds parenthesis around arrow function body when returning object literal with typescript typecast", function() {
+    var code = "() => ({} as object);";
+
+    var fn = b.arrowFunctionExpression(
+      [],
+      b.tsAsExpression(
+      b.objectExpression([]),
+        b.tsObjectKeyword()
+      ),
+      false
+    );
+
+    var ast = b.program([
+      b.expressionStatement(fn)
+    ]);
+
+    var printer = new Printer();
+    var pretty = printer.printGenerically(ast).code;
+    assert.strictEqual(pretty, code);
+  });
+
   it("prints class property initializers with type annotations correctly", function() {
     var code = [
       "class A {",


### PR DESCRIPTION
Add parenthesis around arrow function body when returning object literal with typescript typecast

```ts
() => ({} as object);
```