### PR TITLE
refactor: use block scoping

### DIFF
--- a/lib/comments.ts
+++ b/lib/comments.ts
@@ -1,12 +1,12 @@
 import assert from "assert";
 import * as types from "ast-types";
-var n = types.namedTypes;
-var isArray = types.builtInTypes.array;
-var isObject = types.builtInTypes.object;
+const n = types.namedTypes;
+const isArray = types.builtInTypes.array;
+const isObject = types.builtInTypes.object;
 import { Lines, concat } from "./lines";
 import { comparePos, fixFaultyLocations } from "./util";
 import { makeUniqueKey } from "private";
-var childNodesCacheKey = makeUniqueKey();
+const childNodesCacheKey = makeUniqueKey();
 
 // TODO Move a non-caching implementation of this function into ast-types,
 // and implement a caching wrapper function here.
@@ -40,7 +40,7 @@ function getSortedChildNodes(node: any, lines: any, resultArray?: any) {
     return node[childNodesCacheKey];
   }
 
-  var names;
+  let names;
   if (isArray.check(node)) {
     names = Object.keys(node);
   } else if (isObject.check(node)) {
@@ -67,13 +67,13 @@ function getSortedChildNodes(node: any, lines: any, resultArray?: any) {
 // .precedingNode, .enclosingNode, and/or .followingNode properties, at
 // least one of which is guaranteed to be defined.
 function decorateComment(node: any, comment: any, lines: any) {
-  var childNodes = getSortedChildNodes(node, lines);
+  const childNodes = getSortedChildNodes(node, lines);
 
   // Time to dust off the old binary search robes and wizard hat.
-  var left = 0, right = childNodes.length;
+  let left = 0, right = childNodes.length;
   while (left < right) {
-    var middle = (left + right) >> 1;
-    var child = childNodes[middle];
+    const middle = (left + right) >> 1;
+    const child = childNodes[middle];
 
     if (comparePos(child.loc.start, comment.loc.start) <= 0 &&
         comparePos(comment.loc.end, child.loc.end) <= 0) {
@@ -119,20 +119,20 @@ export function attach(comments: any[], ast: any, lines: any) {
     return;
   }
 
-  var tiesToBreak: any[] = [];
+  const tiesToBreak: any[] = [];
 
   comments.forEach(function(comment) {
     comment.loc.lines = lines;
     decorateComment(ast, comment, lines);
 
-    var pn = comment.precedingNode;
-    var en = comment.enclosingNode;
-    var fn = comment.followingNode;
+    const pn = comment.precedingNode;
+    const en = comment.enclosingNode;
+    const fn = comment.followingNode;
 
     if (pn && fn) {
-      var tieCount = tiesToBreak.length;
+      const tieCount = tiesToBreak.length;
       if (tieCount > 0) {
-        var lastTie = tiesToBreak[tieCount - 1];
+        const lastTie = tiesToBreak[tieCount - 1];
 
         assert.strictEqual(
           lastTie.precedingNode === comment.precedingNode,
@@ -180,14 +180,14 @@ export function attach(comments: any[], ast: any, lines: any) {
 };
 
 function breakTies(tiesToBreak: any[], lines: any) {
-  var tieCount = tiesToBreak.length;
+  const tieCount = tiesToBreak.length;
   if (tieCount === 0) {
     return;
   }
 
-  var pn = tiesToBreak[0].precedingNode;
-  var fn = tiesToBreak[0].followingNode;
-  var gapEndPos = fn.loc.start;
+  const pn = tiesToBreak[0].precedingNode;
+  const fn = tiesToBreak[0].followingNode;
+  let gapEndPos = fn.loc.start;
 
   // Iterate backwards through tiesToBreak, examining the gaps
   // between the tied comments. In order to qualify as leading, a
@@ -200,7 +200,7 @@ function breakTies(tiesToBreak: any[], lines: any) {
     assert.strictEqual(comment.precedingNode, pn);
     assert.strictEqual(comment.followingNode, fn);
 
-    var gap = lines.sliceString(comment.loc.end, gapEndPos);
+    const gap = lines.sliceString(comment.loc.end, gapEndPos);
     if (/\S/.test(gap)) {
       // The gap string contained something other than whitespace.
       break;
@@ -230,7 +230,7 @@ function breakTies(tiesToBreak: any[], lines: any) {
 }
 
 function addCommentHelper(node: any, comment: any) {
-  var comments = node.comments || (node.comments = []);
+  const comments = node.comments || (node.comments = []);
   comments.push(comment);
 }
 
@@ -253,12 +253,12 @@ function addTrailingComment(node: any, comment: any) {
 }
 
 function printLeadingComment(commentPath: any, print: any) {
-  var comment = commentPath.getValue();
+  const comment = commentPath.getValue();
   n.Comment.assert(comment);
 
-  var loc = comment.loc;
-  var lines = loc && loc.lines;
-  var parts = [print(commentPath)];
+  const loc = comment.loc;
+  const lines = loc && loc.lines;
+  const parts = [print(commentPath)];
 
   if (comment.trailing) {
     // When we print trailing comments as leading comments, we don't
@@ -266,7 +266,7 @@ function printLeadingComment(commentPath: any, print: any) {
     parts.push("\n");
 
   } else if (lines instanceof Lines) {
-    var trailingSpace = lines.slice(
+    const trailingSpace = lines.slice(
       loc.end,
       lines.skipSpaces(loc.end) || lines.lastPos(),
     );
@@ -289,16 +289,16 @@ function printLeadingComment(commentPath: any, print: any) {
 }
 
 function printTrailingComment(commentPath: any, print: any) {
-  var comment = commentPath.getValue(commentPath);
+  const comment = commentPath.getValue(commentPath);
   n.Comment.assert(comment);
 
-  var loc = comment.loc;
-  var lines = loc && loc.lines;
-  var parts = [];
+  const loc = comment.loc;
+  const lines = loc && loc.lines;
+  const parts = [];
 
   if (lines instanceof Lines) {
-    var fromPos = lines.skipSpaces(loc.start, true) || lines.firstPos();
-    var leadingSpace = lines.slice(fromPos, loc.start);
+    const fromPos = lines.skipSpaces(loc.start, true) || lines.firstPos();
+    const leadingSpace = lines.slice(fromPos, loc.start);
 
     if (leadingSpace.length === 1) {
       // If the leading space contains no newlines, then we want to
@@ -317,22 +317,22 @@ function printTrailingComment(commentPath: any, print: any) {
 }
 
 export function printComments(path: any, print: any) {
-  var value = path.getValue();
-  var innerLines = print(path);
-  var comments = n.Node.check(value) &&
+  const value = path.getValue();
+  const innerLines = print(path);
+  const comments = n.Node.check(value) &&
     types.getFieldValue(value, "comments");
 
   if (!comments || comments.length === 0) {
     return innerLines;
   }
 
-  var leadingParts: any[] = [];
-  var trailingParts = [innerLines];
+  const leadingParts: any[] = [];
+  const trailingParts = [innerLines];
 
   path.each(function(commentPath: any) {
-    var comment = commentPath.getValue();
-    var leading = types.getFieldValue(comment, "leading");
-    var trailing = types.getFieldValue(comment, "trailing");
+    const comment = commentPath.getValue();
+    const leading = types.getFieldValue(comment, "leading");
+    const trailing = types.getFieldValue(comment, "trailing");
 
     if (leading || (trailing && !(n.Statement.check(value) ||
                                   comment.type === "Block" ||

--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -1,8 +1,8 @@
 import assert from "assert";
 import * as types from "ast-types";
-var n = types.namedTypes;
-var isArray = types.builtInTypes.array;
-var isNumber = types.builtInTypes.number;
+const n = types.namedTypes;
+const isArray = types.builtInTypes.array;
+const isNumber = types.builtInTypes.number;
 import * as util from "./util";
 
 interface FastPathType {
@@ -35,7 +35,7 @@ const FastPath = function FastPath(this: FastPathType, value: any) {
   this.stack = [value];
 } as any as FastPathConstructor;
 
-var FPp: FastPathType = FastPath.prototype;
+const FPp: FastPathType = FastPath.prototype;
 
 // Static convenience function for coercing a value to a FastPath.
 FastPath.from = function(obj) {
@@ -47,8 +47,8 @@ FastPath.from = function(obj) {
   if (obj instanceof types.NodePath) {
     // For backwards compatibility, unroll NodePath instances into
     // lightweight FastPath [..., name, value] stacks.
-    var copy = Object.create(FastPath.prototype);
-    var stack = [obj.value];
+    const copy = Object.create(FastPath.prototype);
+    const stack = [obj.value];
     for (var pp; (pp = obj.parentPath); obj = pp)
       stack.push(obj.name, pp.value);
     copy.stack = stack.reverse();
@@ -68,8 +68,8 @@ FPp.copy = function copy() {
 // The name of the current property is always the penultimate element of
 // this.stack, and always a String.
 FPp.getName = function getName() {
-  var s = this.stack;
-  var len = s.length;
+  const s = this.stack;
+  const len = s.length;
   if (len > 1) {
     return s[len - 2];
   }
@@ -81,21 +81,21 @@ FPp.getName = function getName() {
 // The value of the current property is always the final element of
 // this.stack.
 FPp.getValue = function getValue() {
-  var s = this.stack;
+  const s = this.stack;
   return s[s.length - 1];
 };
 
 FPp.valueIsDuplicate = function () {
-  var s = this.stack;
-  var valueIndex = s.length - 1;
+  const s = this.stack;
+  const valueIndex = s.length - 1;
   return s.lastIndexOf(s[valueIndex], valueIndex - 1) >= 0;
 };
 
 function getNodeHelper(path: any, count: number) {
-  var s = path.stack;
+  const s = path.stack;
 
-  for (var i = s.length - 1; i >= 0; i -= 2) {
-    var value = s[i];
+  for (let i = s.length - 1; i >= 0; i -= 2) {
+    const value = s[i];
     if (n.Node.check(value) && --count < 0) {
       return value;
     }
@@ -118,7 +118,7 @@ FPp.getParentNode = function getParentNode(count = 0) {
 // even, though, which allows us to return the root value in constant time
 // (i.e. without iterating backwards through the stack).
 FPp.getRootValue = function getRootValue() {
-  var s = this.stack;
+  const s = this.stack;
   if (s.length % 2 === 0) {
     return s[1];
   }
@@ -131,16 +131,16 @@ FPp.getRootValue = function getRootValue() {
 // be restored to its original state after the callback is finished, so it
 // is probably a mistake to retain a reference to the path.
 FPp.call = function call(callback/*, name1, name2, ... */) {
-  var s = this.stack;
-  var origLen = s.length;
-  var value = s[origLen - 1];
-  var argc = arguments.length;
-  for (var i = 1; i < argc; ++i) {
-    var name = arguments[i];
+  const s = this.stack;
+  const origLen = s.length;
+  let value = s[origLen - 1];
+  const argc = arguments.length;
+  for (let i = 1; i < argc; ++i) {
+    const name = arguments[i];
     value = value[name];
     s.push(name, value);
   }
-  var result = callback(this);
+  const result = callback(this);
   s.length = origLen;
   return result;
 };
@@ -150,13 +150,13 @@ FPp.call = function call(callback/*, name1, name2, ... */) {
 // callback will be called with a reference to this path object for each
 // element of the array.
 FPp.each = function each(callback/*, name1, name2, ... */) {
-  var s = this.stack;
-  var origLen = s.length;
-  var value = s[origLen - 1];
-  var argc = arguments.length;
+  const s = this.stack;
+  const origLen = s.length;
+  let value = s[origLen - 1];
+  const argc = arguments.length;
 
   for (var i = 1; i < argc; ++i) {
-    var name = arguments[i];
+    const name = arguments[i];
     value = value[name];
     s.push(name, value);
   }
@@ -178,18 +178,18 @@ FPp.each = function each(callback/*, name1, name2, ... */) {
 // callback function invocations are stored in an array and returned at
 // the end of the iteration.
 FPp.map = function map(callback/*, name1, name2, ... */) {
-  var s = this.stack;
-  var origLen = s.length;
-  var value = s[origLen - 1];
-  var argc = arguments.length;
+  const s = this.stack;
+  const origLen = s.length;
+  let value = s[origLen - 1];
+  const argc = arguments.length;
 
   for (var i = 1; i < argc; ++i) {
-    var name = arguments[i];
+    const name = arguments[i];
     value = value[name];
     s.push(name, value);
   }
 
-  var result = new Array(value.length);
+  const result = new Array(value.length);
 
   for (var i = 0; i < value.length; ++i) {
     if (i in value) {
@@ -291,7 +291,7 @@ FPp.getNextToken = function (node) {
 // Inspired by require("ast-types").NodePath.prototype.needsParens, but
 // more efficient because we're iterating backwards through a stack.
 FPp.needsParens = function(assumeExpressionContext) {
-  var node = this.getNode();
+  const node = this.getNode();
 
   // This needs to come before `if (!parent) { return false }` because
   // an object destructuring assignment requires parens for
@@ -300,12 +300,12 @@ FPp.needsParens = function(assumeExpressionContext) {
     return true;
   }
 
-  var parent = this.getParentNode();
+  const parent = this.getParentNode();
   if (!parent) {
     return false;
   }
 
-  var name = this.getName();
+  const name = this.getName();
 
   // If the value of this path is some child of a Node and not a Node
   // itself, then it doesn't need parentheses. Only Node objects (in fact,
@@ -555,7 +555,7 @@ function containsCallExpression(node: any): any {
 }
 
 FPp.canBeFirstInStatement = function() {
-  var node = this.getNode();
+  const node = this.getNode();
 
   if (n.FunctionExpression.check(node)) {
     return false;
@@ -573,11 +573,11 @@ FPp.canBeFirstInStatement = function() {
 };
 
 FPp.firstInStatement = function() {
-  var s = this.stack;
-  var parentName, parent;
-  var childName, child;
+  const s = this.stack;
+  let parentName, parent;
+  let childName, child;
 
-  for (var i = s.length - 1; i >= 0; i -= 2) {
+  for (let i = s.length - 1; i >= 0; i -= 2) {
     if (n.Node.check(s[i])) {
       childName = parentName;
       child = parent;

--- a/lib/lines.ts
+++ b/lib/lines.ts
@@ -57,7 +57,7 @@ export class Lines {
       return null;
     }
 
-    var targetLines = this;
+    const targetLines = this;
 
     function updateJSON(json?: any) {
       json = json || {};
@@ -79,26 +79,26 @@ export class Lines {
       return updateJSON(targetLines.cachedSourceMap.toJSON());
     }
 
-    var smg = new sourceMap.SourceMapGenerator(updateJSON());
-    var sourcesToContents: any = {};
+    const smg = new sourceMap.SourceMapGenerator(updateJSON());
+    const sourcesToContents: any = {};
 
     targetLines.mappings.forEach(function(mapping: any) {
-      var sourceCursor = mapping.sourceLines.skipSpaces(
+      const sourceCursor = mapping.sourceLines.skipSpaces(
         mapping.sourceLoc.start
       ) || mapping.sourceLines.lastPos();
 
-      var targetCursor = targetLines.skipSpaces(
+      const targetCursor = targetLines.skipSpaces(
         mapping.targetLoc.start
       ) || targetLines.lastPos();
 
       while (comparePos(sourceCursor, mapping.sourceLoc.end) < 0 &&
              comparePos(targetCursor, mapping.targetLoc.end) < 0) {
 
-        var sourceChar = mapping.sourceLines.charAt(sourceCursor);
-        var targetChar = targetLines.charAt(targetCursor);
+        const sourceChar = mapping.sourceLines.charAt(sourceCursor);
+        const targetChar = targetLines.charAt(targetCursor);
         assert.strictEqual(sourceChar, targetChar);
 
-        var sourceName = mapping.sourceLines.name;
+        const sourceName = mapping.sourceLines.name;
 
         // Add mappings one character at a time for maximum resolution.
         smg.addMapping({
@@ -110,7 +110,7 @@ export class Lines {
         });
 
         if (!hasOwn.call(sourcesToContents, sourceName)) {
-          var sourceContent = mapping.sourceLines.toString();
+          const sourceContent = mapping.sourceLines.toString();
           smg.setSourceContent(sourceName, sourceContent);
           sourcesToContents[sourceName] = sourceContent;
         }
@@ -130,10 +130,7 @@ export class Lines {
     assert.strictEqual(typeof pos.line, "number");
     assert.strictEqual(typeof pos.column, "number");
 
-    var line = pos.line,
-    column = pos.column,
-    strings = this.toString().split(lineTerminatorSeqExp),
-    string = strings[line - 1];
+    const line = pos.line, column = pos.column, strings = this.toString().split(lineTerminatorSeqExp), string = strings[line - 1];
 
     if (typeof string === "undefined")
       return "";
@@ -153,17 +150,12 @@ export class Lines {
     assert.strictEqual(typeof pos.line, "number");
     assert.strictEqual(typeof pos.column, "number");
 
-    var line = pos.line,
-    column = pos.column,
-    secret = this,
-    infos = secret.infos,
-    info = infos[line - 1],
-    c = column;
+    let line = pos.line, column = pos.column, secret = this, infos = secret.infos, info = infos[line - 1], c = column;
 
     if (typeof info === "undefined" || c < 0)
       return "";
 
-    var indent = this.getIndentAt(line);
+    const indent = this.getIndentAt(line);
     if (c < indent)
       return " ";
 
@@ -188,7 +180,7 @@ export class Lines {
     if (skipFirstLine && this.length === 1)
       return this;
 
-    var lines = new Lines(this.infos.map(function(info: any, i: any) {
+    const lines = new Lines(this.infos.map(function(info: any, i: any) {
       if (info.line && (i > 0 || !skipFirstLine)) {
         info = {
           ...info,
@@ -199,7 +191,7 @@ export class Lines {
     }));
 
     if (this.mappings.length > 0) {
-      var newMappings = lines.mappings;
+      const newMappings = lines.mappings;
       assert.strictEqual(newMappings.length, 0);
       this.mappings.forEach(function(mapping: any) {
         newMappings.push(mapping.indent(width, skipFirstLine, true));
@@ -214,7 +206,7 @@ export class Lines {
       return this;
     }
 
-    var lines = new Lines(this.infos.map(function(info: any) {
+    const lines = new Lines(this.infos.map(function(info: any) {
       if (info.line && ! info.locked) {
         info = {
           ...info,
@@ -225,7 +217,7 @@ export class Lines {
     }));
 
     if (this.mappings.length > 0) {
-      var newMappings = lines.mappings;
+      const newMappings = lines.mappings;
       assert.strictEqual(newMappings.length, 0);
       this.mappings.forEach(function(mapping: any) {
         newMappings.push(mapping.indent(by));
@@ -244,7 +236,7 @@ export class Lines {
       return this;
     }
 
-    var lines = new Lines(this.infos.map(function(info: any, i: any) {
+    const lines = new Lines(this.infos.map(function(info: any, i: any) {
       if (i > 0 && info.line && ! info.locked) {
         info = {
           ...info,
@@ -256,7 +248,7 @@ export class Lines {
     }));
 
     if (this.mappings.length > 0) {
-      var newMappings = lines.mappings;
+      const newMappings = lines.mappings;
       assert.strictEqual(newMappings.length, 0);
       this.mappings.forEach(function(mapping: any) {
         newMappings.push(mapping.indent(by, true));
@@ -289,12 +281,12 @@ export class Lines {
       return this.cachedTabWidth;
     }
 
-    var counts: any[] = []; // Sparse array.
-    var lastIndent = 0;
+    const counts: any[] = []; // Sparse array.
+    let lastIndent = 0;
 
-    for (var line = 1, last = this.length; line <= last; ++line) {
-      var info = this.infos[line - 1];
-      var sliced = info.line.slice(info.sliceStart, info.sliceEnd);
+    for (let line = 1, last = this.length; line <= last; ++line) {
+      const info = this.infos[line - 1];
+      const sliced = info.line.slice(info.sliceStart, info.sliceEnd);
 
       // Whitespace-only lines don't tell us much about the likely tab
       // width of this code.
@@ -302,15 +294,15 @@ export class Lines {
         continue;
       }
 
-      var diff = Math.abs(info.indent - lastIndent);
+      const diff = Math.abs(info.indent - lastIndent);
       counts[diff] = ~~counts[diff] + 1;
       lastIndent = info.indent;
     }
 
-    var maxCount = -1;
-    var result = 2;
+    let maxCount = -1;
+    let result = 2;
 
-    for (var tabWidth = 1;
+    for (let tabWidth = 1;
          tabWidth < counts.length;
          tabWidth += 1) {
       if (hasOwn.call(counts, tabWidth) &&
@@ -330,10 +322,7 @@ export class Lines {
     if (this.infos.length === 0) {
       return false;
     }
-    var firstLineInfo = this.infos[0],
-    sliceStart = firstLineInfo.sliceStart,
-    sliceEnd = firstLineInfo.sliceEnd,
-    firstLine = firstLineInfo.line.slice(sliceStart, sliceEnd).trim();
+    const firstLineInfo = this.infos[0], sliceStart = firstLineInfo.sliceStart, sliceEnd = firstLineInfo.sliceEnd, firstLine = firstLineInfo.line.slice(sliceStart, sliceEnd).trim();
     return firstLine.length === 0 ||
       firstLine.slice(0, 2) === "//" ||
       firstLine.slice(0, 2) === "/*";
@@ -344,19 +333,19 @@ export class Lines {
   }
 
   isPrecededOnlyByWhitespace(pos: Pos) {
-    var info = this.infos[pos.line - 1];
-    var indent = Math.max(info.indent, 0);
+    const info = this.infos[pos.line - 1];
+    const indent = Math.max(info.indent, 0);
 
-    var diff = pos.column - indent;
+    const diff = pos.column - indent;
     if (diff <= 0) {
       // If pos.column does not exceed the indentation amount, then
       // there must be only whitespace before it.
       return true;
     }
 
-    var start = info.sliceStart;
-    var end = Math.min(start + diff, info.sliceEnd);
-    var prefix = info.line.slice(start, end);
+    const start = info.sliceStart;
+    const end = Math.min(start + diff, info.sliceEnd);
+    const prefix = info.line.slice(start, end);
 
     return isOnlyWhitespace(prefix);
   }
@@ -367,8 +356,7 @@ export class Lines {
   }
 
   nextPos(pos: Pos, skipSpaces: boolean = false) {
-    var l = Math.max(pos.line, 0),
-    c = Math.max(pos.column, 0);
+    const l = Math.max(pos.line, 0), c = Math.max(pos.column, 0);
 
     if (c < this.getLineLength(l)) {
       pos.column += 1;
@@ -391,8 +379,7 @@ export class Lines {
   }
 
   prevPos(pos: Pos, skipSpaces: boolean = false) {
-    var l = pos.line,
-    c = pos.column;
+    let l = pos.line, c = pos.column;
 
     if (c < 1) {
       l -= 1;
@@ -464,12 +451,12 @@ export class Lines {
   }
 
   trimLeft() {
-    var pos = this.skipSpaces(this.firstPos(), false, true);
+    const pos = this.skipSpaces(this.firstPos(), false, true);
     return pos ? this.slice(pos) : emptyLines;
   }
 
   trimRight() {
-    var pos = this.skipSpaces(this.lastPos(), true, true);
+    const pos = this.skipSpaces(this.lastPos(), true, true);
     return pos ? this.slice(this.firstPos(), pos) : emptyLines;
   }
 
@@ -508,7 +495,7 @@ export class Lines {
   }
 
   bootstrapSlice(start: Pos, end: Pos) {
-    var strings = this.toString().split(
+    const strings = this.toString().split(
       lineTerminatorSeqExp
     ).slice(
       start.line - 1,
@@ -550,13 +537,13 @@ export class Lines {
       sliced.push(sliceInfo(sliced.pop(), 0, end.column));
     }
 
-    var lines = new Lines(sliced);
+    const lines = new Lines(sliced);
 
     if (this.mappings.length > 0) {
-      var newMappings = lines.mappings;
+      const newMappings = lines.mappings;
       assert.strictEqual(newMappings.length, 0);
       this.mappings.forEach(function(this: any, mapping: any) {
-        var sliced = mapping.slice(this, start, end);
+        const sliced = mapping.slice(this, start, end);
         if (sliced) {
           newMappings.push(sliced);
         }
@@ -580,8 +567,8 @@ export class Lines {
     const parts = [];
     const { tabWidth = 2 } = options;
 
-    for (var line = start.line; line <= end.line; ++line) {
-      var info = this.infos[line - 1];
+    for (let line = start.line; line <= end.line; ++line) {
+      let info = this.infos[line - 1];
 
       if (line === start.line) {
         if (line === end.line) {
@@ -593,9 +580,9 @@ export class Lines {
         info = sliceInfo(info, 0, end.column);
       }
 
-      var indent = Math.max(info.indent, 0);
+      const indent = Math.max(info.indent, 0);
 
-      var before = info.line.slice(0, info.sliceStart);
+      const before = info.line.slice(0, info.sliceStart);
       if (options.reuseWhitespace &&
           isOnlyWhitespace(before) &&
           countSpaces(before, options.tabWidth) === indent) {
@@ -604,15 +591,15 @@ export class Lines {
         continue;
       }
 
-      var tabs = 0;
-      var spaces = indent;
+      let tabs = 0;
+      let spaces = indent;
 
       if (options.useTabs) {
         tabs = Math.floor(indent / tabWidth);
         spaces -= tabs * tabWidth;
       }
 
-      var result = "";
+      let result = "";
 
       if (tabs > 0) {
         result += new Array(tabs + 1).join("\t");
@@ -635,10 +622,10 @@ export class Lines {
   }
 
   join(elements: (string | Lines)[]) {
-    var separator = this;
-    var infos: any[] = [];
-    var mappings: any[] = [];
-    var prevInfo: any;
+    const separator = this;
+    const infos: any[] = [];
+    const mappings: any[] = [];
+    let prevInfo: any;
 
     function appendLines(linesOrNull: Lines | null) {
       if (linesOrNull === null) {
@@ -646,10 +633,10 @@ export class Lines {
       }
 
       if (prevInfo) {
-        var info = linesOrNull.infos[0];
-        var indent = new Array(info.indent + 1).join(" ");
-        var prevLine = infos.length;
-        var prevColumn = Math.max(prevInfo.indent, 0) +
+        const info = linesOrNull.infos[0];
+        const indent = new Array(info.indent + 1).join(" ");
+        const prevLine = infos.length;
+        const prevColumn = Math.max(prevInfo.indent, 0) +
           prevInfo.sliceEnd - prevInfo.sliceStart;
 
         prevInfo.line = prevInfo.line.slice(
@@ -687,7 +674,7 @@ export class Lines {
     }
 
     elements.map(function(elem: any) {
-      var lines = fromString(elem);
+      const lines = fromString(elem);
       if (lines.isEmpty())
         return null;
       return lines;
@@ -702,7 +689,7 @@ export class Lines {
     if (infos.length < 1)
       return emptyLines;
 
-    var lines = new Lines(infos);
+    const lines = new Lines(infos);
 
     lines.mappings = mappings;
 
@@ -710,22 +697,22 @@ export class Lines {
   }
 
   concat(...args: (string | Lines)[]) {
-    var list: typeof args = [this];
+    const list: typeof args = [this];
     list.push.apply(list, args);
     assert.strictEqual(list.length, args.length + 1);
     return emptyLines.join(list);
   }
 }
 
-var fromStringCache: any = {};
+const fromStringCache: any = {};
 var hasOwn = fromStringCache.hasOwnProperty;
-var maxCacheKeyLen = 10;
+const maxCacheKeyLen = 10;
 
 export function countSpaces(spaces: any, tabWidth?: number) {
-  var count = 0;
-  var len = spaces.length;
+  let count = 0;
+  const len = spaces.length;
 
-  for (var i = 0; i < len; ++i) {
+  for (let i = 0; i < len; ++i) {
     switch (spaces.charCodeAt(i)) {
     case 9: // '\t'
       assert.strictEqual(typeof tabWidth, "number");
@@ -757,7 +744,7 @@ export function countSpaces(spaces: any, tabWidth?: number) {
   return count;
 }
 
-var leadingSpaceExp = /^\s*/;
+const leadingSpaceExp = /^\s*/;
 
 // As specified here: http://www.ecma-international.org/ecma-262/6.0/#sec-line-terminators
 var lineTerminatorSeqExp =
@@ -775,18 +762,18 @@ export function fromString(
 
   string += "";
 
-  var tabWidth = options && options.tabWidth;
-  var tabless = string.indexOf("\t") < 0;
-  var cacheable = !options && tabless && (string.length <= maxCacheKeyLen);
+  const tabWidth = options && options.tabWidth;
+  const tabless = string.indexOf("\t") < 0;
+  const cacheable = !options && tabless && (string.length <= maxCacheKeyLen);
 
   assert.ok(tabWidth || tabless, "No tab width specified but encountered tabs in string\n" + string);
 
   if (cacheable && hasOwn.call(fromStringCache, string))
     return fromStringCache[string];
 
-  var lines = new Lines(string.split(lineTerminatorSeqExp).map(function(line) {
+  const lines = new Lines(string.split(lineTerminatorSeqExp).map(function(line) {
     // TODO: handle null exec result
-    var spaces = leadingSpaceExp.exec(line)![0];
+    const spaces = leadingSpaceExp.exec(line)![0];
     return {
       line: line,
       indent: countSpaces(spaces, tabWidth),
@@ -808,10 +795,10 @@ function isOnlyWhitespace(string: string) {
 }
 
 function sliceInfo(info: any, startCol: number, endCol?: number) {
-  var sliceStart = info.sliceStart;
-  var sliceEnd = info.sliceEnd;
-  var indent = Math.max(info.indent, 0);
-  var lineLength = indent + sliceEnd - sliceStart;
+  let sliceStart = info.sliceStart;
+  let sliceEnd = info.sliceEnd;
+  let indent = Math.max(info.indent, 0);
+  let lineLength = indent + sliceEnd - sliceStart;
 
   if (typeof endCol === "undefined") {
     endCol = lineLength;

--- a/lib/mapping.ts
+++ b/lib/mapping.ts
@@ -18,14 +18,14 @@ export default class Mapping {
     start: Pos,
     end: Pos = lines.lastPos(),
   ) {
-    var sourceLines = this.sourceLines;
-    var sourceLoc = this.sourceLoc;
-    var targetLoc = this.targetLoc;
+    const sourceLines = this.sourceLines;
+    let sourceLoc = this.sourceLoc;
+    let targetLoc = this.targetLoc;
 
     function skip(name: "start" | "end") {
-      var sourceFromPos = sourceLoc[name];
-      var targetFromPos = targetLoc[name];
-      var targetToPos = start;
+      const sourceFromPos = sourceLoc[name];
+      const targetFromPos = targetLoc[name];
+      let targetToPos = start;
 
       if (name === "end") {
         targetToPos = end;
@@ -121,9 +121,9 @@ export default class Mapping {
       return this;
     }
 
-    var targetLoc = this.targetLoc;
-    var startLine = targetLoc.start.line;
-    var endLine = targetLoc.end.line;
+    let targetLoc = this.targetLoc;
+    const startLine = targetLoc.start.line;
+    const endLine = targetLoc.end.line;
 
     if (skipFirstLine && startLine === 1 && endLine === 1) {
       return this;
@@ -135,7 +135,7 @@ export default class Mapping {
     };
 
     if (!skipFirstLine || startLine > 1) {
-      var startColumn = targetLoc.start.column + by;
+      const startColumn = targetLoc.start.column + by;
       targetLoc.start = {
         line: startLine,
         column: noNegativeColumns
@@ -145,7 +145,7 @@ export default class Mapping {
     }
 
     if (!skipFirstLine || endLine > 1) {
-      var endColumn = targetLoc.end.column + by;
+      const endColumn = targetLoc.end.column + by;
       targetLoc.end = {
         line: endLine,
         column: noNegativeColumns
@@ -183,7 +183,7 @@ function skipChars(
   targetFromPos: Pos,
   targetToPos: Pos,
 ) {
-  var targetComparison = comparePos(targetFromPos, targetToPos);
+  const targetComparison = comparePos(targetFromPos, targetToPos);
   if (targetComparison === 0) {
     // Trivial case: no characters to skip.
     return sourceFromPos;

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -164,7 +164,7 @@ interface DeprecatedOptions {
   esprima?: any;
 }
 
-var defaults: Options = {
+const defaults: Options = {
   parser: require("../parsers/esprima"),
   tabWidth: 4,
   useTabs: false,
@@ -184,13 +184,14 @@ var defaults: Options = {
   arrowParensAlways: false,
   flowObjectCommas: true,
   tokens: true
-}, hasOwn = defaults.hasOwnProperty;
+};
+const hasOwn = defaults.hasOwnProperty;
 
 export type NormalizedOptions = Required<Omit<Options, keyof DeprecatedOptions>>;
 
 // Copy options and fill in default values.
 export function normalize(opts?: Options): NormalizedOptions {
-  var options = opts || defaults;
+  const options = opts || defaults;
 
   function get(key: keyof Options) {
     return hasOwn.call(options, key)

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -1,8 +1,8 @@
 import assert from "assert";
 import * as types from "ast-types";
-var b = types.builders;
-var isObject = types.builtInTypes.object;
-var isArray = types.builtInTypes.array;
+const b = types.builders;
+const isObject = types.builtInTypes.object;
+const isArray = types.builtInTypes.array;
 import { normalize as normalizeOptions } from "./options";
 import { fromString } from "./lines";
 import { attach as attachComments } from "./comments";
@@ -102,7 +102,7 @@ export function parse(source: string, options?: Partial<Options>) {
   // well), since sometimes program.loc.{start,end} will coincide with the
   // .loc.{start,end} of the first and last *statements*, mistakenly
   // excluding comments that fall outside that region.
-  var trueProgramLoc: any = util.getTrueLoc({
+  const trueProgramLoc: any = util.getTrueLoc({
     type: program.type,
     loc: program.loc,
     body: [],
@@ -149,7 +149,7 @@ const TreeCopier = function TreeCopier(this: TreeCopierType, lines: any, tokens:
   this.seen = new Map;
 } as any as TreeCopierConstructor;
 
-var TCp: TreeCopierType = TreeCopier.prototype;
+const TCp: TreeCopierType = TreeCopier.prototype;
 
 TCp.copy = function(node) {
   if (this.seen.has(node)) {
@@ -182,9 +182,9 @@ TCp.copy = function(node) {
 
   this.seen.set(node, copy);
 
-  var loc = node.loc;
-  var oldIndent = this.indent;
-  var newIndent = oldIndent;
+  const loc = node.loc;
+  const oldIndent = this.indent;
+  let newIndent = oldIndent;
 
   const oldStartTokenIndex = this.startTokenIndex;
   const oldEndTokenIndex = this.endTokenIndex;
@@ -213,10 +213,10 @@ TCp.copy = function(node) {
     this.findTokenRange(loc);
   }
 
-  var keys = Object.keys(node);
-  var keyCount = keys.length;
-  for (var i = 0; i < keyCount; ++i) {
-    var key = keys[i];
+  const keys = Object.keys(node);
+  const keyCount = keys.length;
+  for (let i = 0; i < keyCount; ++i) {
+    const key = keys[i];
     if (key === "loc") {
       copy[key] = node[key];
     } else if (key === "tokens" &&

--- a/lib/patcher.ts
+++ b/lib/patcher.ts
@@ -1,16 +1,16 @@
 import assert from "assert";
 import * as linesModule from "./lines";
 import * as types from "ast-types";
-var Printable = types.namedTypes.Printable;
-var Expression = types.namedTypes.Expression;
-var ReturnStatement = types.namedTypes.ReturnStatement;
-var SourceLocation = types.namedTypes.SourceLocation;
+const Printable = types.namedTypes.Printable;
+const Expression = types.namedTypes.Expression;
+const ReturnStatement = types.namedTypes.ReturnStatement;
+const SourceLocation = types.namedTypes.SourceLocation;
 import { comparePos, copyPos, getUnionOfKeys } from "./util";
 import FastPath from "./fast-path";
-var isObject = types.builtInTypes.object;
-var isArray = types.builtInTypes.array;
-var isString = types.builtInTypes.string;
-var riskyAdjoiningCharExp = /[0-9a-z_$]/i;
+const isObject = types.builtInTypes.object;
+const isArray = types.builtInTypes.array;
+const isString = types.builtInTypes.string;
+const riskyAdjoiningCharExp = /[0-9a-z_$]/i;
 
 interface PatcherType {
   replace(loc: any, lines: any): any;
@@ -27,8 +27,7 @@ const Patcher = function Patcher(this: PatcherType, lines: any) {
   assert.ok(this instanceof Patcher);
   assert.ok(lines instanceof linesModule.Lines);
 
-  var self = this,
-  replacements: any[] = [];
+  const self = this, replacements: any[] = [];
 
   self.replace = function(loc, lines) {
     if (isString.check(lines))
@@ -49,8 +48,7 @@ const Patcher = function Patcher(this: PatcherType, lines: any) {
              column: lines.getLineLength(lines.length) }
     };
 
-    var sliceFrom = loc.start,
-    toConcat: any[] = [];
+    let sliceFrom = loc.start, toConcat: any[] = [];
 
     function pushSlice(from: any, to: any) {
       assert.ok(comparePos(from, to) <= 0);
@@ -76,10 +74,10 @@ const Patcher = function Patcher(this: PatcherType, lines: any) {
 } as any as PatcherConstructor;
 export { Patcher };
 
-var Pp: PatcherType = Patcher.prototype;
+const Pp: PatcherType = Patcher.prototype;
 
 Pp.tryToReprintComments = function(newNode, oldNode, print) {
-  var patcher = this;
+  const patcher = this;
 
   if (!newNode.comments &&
       !oldNode.comments) {
@@ -87,14 +85,14 @@ Pp.tryToReprintComments = function(newNode, oldNode, print) {
     return true;
   }
 
-  var newPath = FastPath.from(newNode);
-  var oldPath = FastPath.from(oldNode);
+  const newPath = FastPath.from(newNode);
+  const oldPath = FastPath.from(oldNode);
 
   newPath.stack.push("comments", getSurroundingComments(newNode));
   oldPath.stack.push("comments", getSurroundingComments(oldNode));
 
-  var reprints: any[] = [];
-  var ableToReprintComments =
+  const reprints: any[] = [];
+  const ableToReprintComments =
     findArrayReprints(newPath, oldPath, reprints);
 
   // No need to pop anything from newPath.stack or oldPath.stack, since
@@ -102,7 +100,7 @@ Pp.tryToReprintComments = function(newNode, oldNode, print) {
 
   if (ableToReprintComments && reprints.length > 0) {
     reprints.forEach(function(reprint) {
-      var oldComment = reprint.oldPath.getValue();
+      const oldComment = reprint.oldPath.getValue();
       assert.ok(oldComment.leading || oldComment.trailing);
       patcher.replace(
         oldComment.loc,
@@ -120,7 +118,7 @@ Pp.tryToReprintComments = function(newNode, oldNode, print) {
 // comments that occur inside node.loc. Returns an empty array for nodes
 // with no leading or trailing comments.
 function getSurroundingComments(node: any) {
-  var result: any[] = [];
+  const result: any[] = [];
   if (node.comments &&
       node.comments.length > 0) {
     node.comments.forEach(function(comment: any) {
@@ -137,7 +135,7 @@ Pp.deleteComments = function(node) {
     return;
   }
 
-  var patcher = this;
+  const patcher = this;
 
   node.comments.forEach(function(comment: any) {
     if (comment.leading) {
@@ -166,29 +164,29 @@ export function getReprinter(path: any) {
 
   // Make sure that this path refers specifically to a Node, rather than
   // some non-Node subproperty of a Node.
-  var node = path.getValue();
+  const node = path.getValue();
   if (!Printable.check(node))
     return;
 
-  var orig = (node as any).original;
-  var origLoc = orig && orig.loc;
-  var lines = origLoc && origLoc.lines;
-  var reprints: any[] = [];
+  const orig = (node as any).original;
+  const origLoc = orig && orig.loc;
+  const lines = origLoc && origLoc.lines;
+  const reprints: any[] = [];
 
   if (!lines || !findReprints(path, reprints))
     return;
 
   return function(print: any) {
-    var patcher = new Patcher(lines);
+    const patcher = new Patcher(lines);
 
     reprints.forEach(function(reprint) {
-      var newNode = reprint.newPath.getValue();
-      var oldNode = reprint.oldPath.getValue();
+      const newNode = reprint.newPath.getValue();
+      const oldNode = reprint.oldPath.getValue();
 
       SourceLocation.assert(oldNode.loc, true);
 
-      var needToPrintNewPathWithComments =
-        !patcher.tryToReprintComments(newNode, oldNode, print)
+      const needToPrintNewPathWithComments =
+        !patcher.tryToReprintComments(newNode, oldNode, print);
 
       if (needToPrintNewPathWithComments) {
         // Since we were not able to preserve all leading/trailing
@@ -198,7 +196,7 @@ export function getReprinter(path: any) {
         patcher.deleteComments(oldNode);
       }
 
-      var newLines = print(reprint.newPath, {
+      let newLines = print(reprint.newPath, {
         includeComments: needToPrintNewPathWithComments,
         // If the oldNode we're replacing already had parentheses, we may
         // not need to print the new node with any extra parentheses,
@@ -209,8 +207,8 @@ export function getReprinter(path: any) {
                           reprint.oldPath.hasParens())
       }).indentTail(oldNode.loc.indent);
 
-      var nls = needsLeadingSpace(lines, oldNode.loc, newLines);
-      var nts = needsTrailingSpace(lines, oldNode.loc, newLines);
+      const nls = needsLeadingSpace(lines, oldNode.loc, newLines);
+      const nts = needsTrailingSpace(lines, oldNode.loc, newLines);
 
       // If we try to replace the argument of a ReturnStatement like
       // return"asdf" with e.g. a literal null expression, we run the risk
@@ -218,7 +216,7 @@ export function getReprinter(path: any) {
       // space in situations where that might happen. Likewise for
       // "asdf"in obj. See #170.
       if (nls || nts) {
-        var newParts = [];
+        const newParts = [];
         nls && newParts.push(" ");
         newParts.push(newLines);
         nts && newParts.push(" ");
@@ -244,15 +242,15 @@ export function getReprinter(path: any) {
 // are both identifier characters, they must be separated by a space,
 // otherwise they will most likely get fused together into a single token.
 function needsLeadingSpace(oldLines: any, oldLoc: any, newLines: any) {
-  var posBeforeOldLoc = copyPos(oldLoc.start);
+  const posBeforeOldLoc = copyPos(oldLoc.start);
 
   // The character just before the location occupied by oldNode.
-  var charBeforeOldLoc =
+  const charBeforeOldLoc =
     oldLines.prevPos(posBeforeOldLoc) &&
     oldLines.charAt(posBeforeOldLoc);
 
   // First character of the reprinted node.
-  var newFirstChar = newLines.charAt(newLines.firstPos());
+  const newFirstChar = newLines.charAt(newLines.firstPos());
 
   return charBeforeOldLoc &&
     riskyAdjoiningCharExp.test(charBeforeOldLoc) &&
@@ -265,12 +263,12 @@ function needsLeadingSpace(oldLines: any, oldLoc: any, newLines: any) {
 // otherwise they will most likely get fused together into a single token.
 function needsTrailingSpace(oldLines: any, oldLoc: any, newLines: any) {
   // The character just after the location occupied by oldNode.
-  var charAfterOldLoc = oldLines.charAt(oldLoc.end);
+  const charAfterOldLoc = oldLines.charAt(oldLoc.end);
 
-  var newLastPos = newLines.lastPos();
+  const newLastPos = newLines.lastPos();
 
   // Last character of the reprinted node.
-  var newLastChar = newLines.prevPos(newLastPos) &&
+  const newLastChar = newLines.prevPos(newLastPos) &&
     newLines.charAt(newLastPos);
 
   return newLastChar &&
@@ -280,10 +278,10 @@ function needsTrailingSpace(oldLines: any, oldLoc: any, newLines: any) {
 }
 
 function findReprints(newPath: any, reprints: any) {
-  var newNode = newPath.getValue();
+  const newNode = newPath.getValue();
   Printable.assert(newNode);
 
-  var oldNode = newNode.original;
+  const oldNode = newNode.original;
   Printable.assert(oldNode);
 
   assert.deepEqual(reprints, []);
@@ -292,8 +290,8 @@ function findReprints(newPath: any, reprints: any) {
     return false;
   }
 
-  var oldPath = new FastPath(oldNode);
-  var canReprint = findChildReprints(newPath, oldPath, reprints);
+  const oldPath = new FastPath(oldNode);
+  const canReprint = findChildReprints(newPath, oldPath, reprints);
 
   if (!canReprint) {
     // Make absolutely sure the calling code does not attempt to reprint
@@ -305,8 +303,8 @@ function findReprints(newPath: any, reprints: any) {
 }
 
 function findAnyReprints(newPath: any, oldPath: any, reprints: any) {
-  var newNode = newPath.getValue();
-  var oldNode = oldPath.getValue();
+  const newNode = newPath.getValue();
+  const oldNode = oldPath.getValue();
 
   if (newNode === oldNode)
     return true;
@@ -321,8 +319,8 @@ function findAnyReprints(newPath: any, oldPath: any, reprints: any) {
 }
 
 function findArrayReprints(newPath: any, oldPath: any, reprints: any) {
-  var newNode = newPath.getValue();
-  var oldNode = oldPath.getValue();
+  const newNode = newPath.getValue();
+  const oldNode = oldPath.getValue();
 
   if (newNode === oldNode ||
       newPath.valueIsDuplicate() ||
@@ -331,16 +329,16 @@ function findArrayReprints(newPath: any, oldPath: any, reprints: any) {
   }
 
   isArray.assert(newNode);
-  var len = newNode.length;
+  const len = newNode.length;
 
   if (!(isArray.check(oldNode) &&
         oldNode.length === len))
     return false;
 
-  for (var i = 0; i < len; ++i) {
+  for (let i = 0; i < len; ++i) {
     newPath.stack.push(i, newNode[i]);
     oldPath.stack.push(i, oldNode[i]);
-    var canReprint = findAnyReprints(newPath, oldPath, reprints);
+    const canReprint = findAnyReprints(newPath, oldPath, reprints);
     newPath.stack.length -= 2;
     oldPath.stack.length -= 2;
     if (!canReprint) {
@@ -352,7 +350,7 @@ function findArrayReprints(newPath: any, oldPath: any, reprints: any) {
 }
 
 function findObjectReprints(newPath: any, oldPath: any, reprints: any) {
-  var newNode = newPath.getValue();
+  const newNode = newPath.getValue();
   isObject.assert(newNode);
 
   if (newNode.original === null) {
@@ -360,7 +358,7 @@ function findObjectReprints(newPath: any, oldPath: any, reprints: any) {
     return false;
   }
 
-  var oldNode = oldPath.getValue();
+  const oldNode = oldPath.getValue();
   if (!isObject.check(oldNode))
     return false;
 
@@ -379,7 +377,7 @@ function findObjectReprints(newPath: any, oldPath: any, reprints: any) {
     // appropriate for patching into the location of oldNode.
 
     if ((newNode as any).type === (oldNode as any).type) {
-      var childReprints: any[] = [];
+      const childReprints: any[] = [];
 
       if (findChildReprints(newPath, oldPath, childReprints)) {
         reprints.push.apply(reprints, childReprints);
@@ -424,8 +422,8 @@ function findObjectReprints(newPath: any, oldPath: any, reprints: any) {
 }
 
 function findChildReprints(newPath: any, oldPath: any, reprints: any) {
-  var newNode = newPath.getValue();
-  var oldNode = oldPath.getValue();
+  const newNode = newPath.getValue();
+  const oldNode = oldPath.getValue();
 
   isObject.assert(newNode);
   isObject.assert(oldNode);
@@ -443,7 +441,7 @@ function findChildReprints(newPath: any, oldPath: any, reprints: any) {
     return false;
   }
 
-  var keys = getUnionOfKeys(oldNode, newNode);
+  const keys = getUnionOfKeys(oldNode, newNode);
 
   if (oldNode.type === "File" ||
       newNode.type === "File") {
@@ -455,9 +453,9 @@ function findChildReprints(newPath: any, oldPath: any, reprints: any) {
   // Don't bother traversing .loc objects looking for reprintable nodes.
   delete keys.loc;
 
-  var originalReprintCount = reprints.length;
+  const originalReprintCount = reprints.length;
 
-  for (var k in keys) {
+  for (let k in keys) {
     if (k.charAt(0) === "_") {
       // Ignore "private" AST properties added by e.g. Babel plugins and
       // parsers like Babylon.
@@ -466,7 +464,7 @@ function findChildReprints(newPath: any, oldPath: any, reprints: any) {
 
     newPath.stack.push(k, types.getFieldValue(newNode, k));
     oldPath.stack.push(k, types.getFieldValue(oldNode, k));
-    var canReprint = findAnyReprints(newPath, oldPath, reprints);
+    const canReprint = findAnyReprints(newPath, oldPath, reprints);
     newPath.stack.length -= 2;
     oldPath.stack.length -= 2;
 

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -4,9 +4,9 @@ import { Lines, fromString, concat } from "./lines";
 import { normalize as normalizeOptions } from "./options";
 import { getReprinter } from "./patcher";
 import * as types from "ast-types";
-var namedTypes = types.namedTypes;
-var isString = types.builtInTypes.string;
-var isObject = types.builtInTypes.object;
+const namedTypes = types.namedTypes;
+const isString = types.builtInTypes.string;
+const isObject = types.builtInTypes.object;
 import FastPath from "./fast-path";
 import * as util from "./util";
 
@@ -32,8 +32,8 @@ const PrintResult = function PrintResult(this: PrintResultType, code: any, sourc
     }
 } as any as PrintResultConstructor;
 
-var PRp: PrintResultType = PrintResult.prototype;
-var warnedAboutToString = false;
+const PRp: PrintResultType = PrintResult.prototype;
+let warnedAboutToString = false;
 
 PRp.toString = function() {
     if (!warnedAboutToString) {
@@ -49,7 +49,7 @@ PRp.toString = function() {
     return this.code;
 };
 
-var emptyPrintResult = new PrintResult("");
+const emptyPrintResult = new PrintResult("");
 
 interface PrinterType {
     print(ast: any): PrintResultType;
@@ -221,7 +221,7 @@ function genericPrint(path: any, config: any, options: any, printPath: any) {
 // configuration object originally passed into the Printer constructor).
 // Its properties are documented in lib/options.js.
 function genericPrintNoParens(path: any, options: any, print: any) {
-    var n = path.getValue();
+    const n = path.getValue();
 
     if (!n) {
         return fromString("");
@@ -625,7 +625,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         parts.push("return");
 
         if (n.argument) {
-            var argLines = path.call(print, "argument");
+            const argLines = path.call(print, "argument");
             if (argLines.startsWithComment() ||
                 (argLines.length > 1 &&
                     namedTypes.JSXElement &&
@@ -697,13 +697,13 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         var i = 0;
         fields.forEach(function(field) {
             path.each(function(childPath: any) {
-                var lines = print(childPath);
+                let lines = print(childPath);
 
                 if (!oneLine) {
                     lines = lines.indent(options.tabWidth);
                 }
 
-                var multiLine = !isTypeAnnotation && lines.length > 1;
+                const multiLine = !isTypeAnnotation && lines.length > 1;
                 if (multiLine && allowBreak) {
                     // Similar to the logic for BlockStatement.
                     parts.push("\n");
@@ -812,8 +812,8 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         }
 
         path.each(function(elemPath: any) {
-            var i = elemPath.getName();
-            var elem = elemPath.getValue();
+            const i = elemPath.getName();
+            const elem = elemPath.getValue();
             if (!elem) {
                 // If the array expression ends with a hole, that hole
                 // will be ignored by the interpreter, but if it ends with
@@ -822,7 +822,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
                 // both (all) of the holes.
                 parts.push(",");
             } else {
-                var lines = printed[i];
+                let lines = printed[i];
                 if (oneLine) {
                     if (i > 0)
                         parts.push(" ");
@@ -964,7 +964,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
         var maxLen = 0;
         var printed = path.map(function(childPath: any) {
-            var lines = print(childPath);
+            const lines = print(childPath);
             maxLen = Math.max(lines.length, maxLen);
             return lines;
         }, "declarations");
@@ -1253,7 +1253,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
         var childLines = concat(
             path.map(function(childPath: any) {
-                var child = childPath.getValue();
+                const child = childPath.getValue();
 
                 if (namedTypes.Literal.check(child) &&
                     typeof child.value === "string") {
@@ -1460,7 +1460,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         parts.push("`");
 
         path.each(function(childPath: any) {
-            var i = childPath.getName();
+            const i = childPath.getName();
             parts.push(print(childPath));
             if (i < expressions.length) {
                 parts.push("${", expressions[i], "}");
@@ -1556,8 +1556,8 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         }
 
         path.each(function(elemPath: any) {
-            var i = elemPath.getName();
-            var elem = elemPath.getValue();
+            const i = elemPath.getName();
+            const elem = elemPath.getValue();
             if (!elem) {
                 // If the array expression ends with a hole, that hole
                 // will be ignored by the interpreter, but if it ends with
@@ -1566,7 +1566,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
                 // both (all) of the holes.
                 parts.push(",");
             } else {
-                var lines = printed[i];
+                let lines = printed[i];
                 if (oneLine) {
                     if (i > 0)
                         parts.push(" ");
@@ -2165,7 +2165,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         // ambiguous: it can be prefixed by => or :
         // in a type predicate, it takes the for u is U
         var parent = path.getParentNode(0);
-        var prefix = ": ";
+        let prefix = ": ";
         if (namedTypes.TSFunctionType.check(parent) || namedTypes.TSConstructorType.check(parent)) {
             prefix = " => ";
         }
@@ -2534,12 +2534,12 @@ function printDecorators(path: any, printPath: any) {
 }
 
 function printStatementSequence(path: any, options: any, print: any) {
-    var filtered: any[] = [];
-    var sawComment = false;
-    var sawStatement = false;
+    const filtered: any[] = [];
+    let sawComment = false;
+    let sawStatement = false;
 
     path.each(function(stmtPath: any) {
-        var stmt = stmtPath.getValue();
+        const stmt = stmtPath.getValue();
 
         // Just in case the AST has been modified to contain falsy
         // "statements," it's safer simply to skip them.
@@ -2586,27 +2586,27 @@ function printStatementSequence(path: any, options: any, print: any) {
         );
     }
 
-    var prevTrailingSpace: any = null;
-    var len = filtered.length;
-    var parts: any[] = [];
+    let prevTrailingSpace: any = null;
+    const len = filtered.length;
+    const parts: any[] = [];
 
     filtered.forEach(function(info, i) {
-        var printed = info.printed;
-        var stmt = info.node;
-        var multiLine = printed.length > 1;
-        var notFirst = i > 0;
-        var notLast = i < len - 1;
-        var leadingSpace;
-        var trailingSpace;
-        var lines = stmt && stmt.loc && stmt.loc.lines;
-        var trueLoc = lines && options.reuseWhitespace &&
+        const printed = info.printed;
+        const stmt = info.node;
+        const multiLine = printed.length > 1;
+        const notFirst = i > 0;
+        const notLast = i < len - 1;
+        let leadingSpace;
+        let trailingSpace;
+        const lines = stmt && stmt.loc && stmt.loc.lines;
+        const trueLoc = lines && options.reuseWhitespace &&
             util.getTrueLoc(stmt, lines);
 
         if (notFirst) {
             if (trueLoc) {
-                var beforeStart = lines.skipSpaces(trueLoc.start, true);
-                var beforeStartLine = beforeStart ? beforeStart.line : 1;
-                var leadingGap = trueLoc.start.line - beforeStartLine;
+                const beforeStart = lines.skipSpaces(trueLoc.start, true);
+                const beforeStartLine = beforeStart ? beforeStart.line : 1;
+                const leadingGap = trueLoc.start.line - beforeStartLine;
                 leadingSpace = Array(leadingGap + 1).join("\n");
             } else {
                 leadingSpace = multiLine ? "\n\n" : "\n";
@@ -2617,9 +2617,9 @@ function printStatementSequence(path: any, options: any, print: any) {
 
         if (notLast) {
             if (trueLoc) {
-                var afterEnd = lines.skipSpaces(trueLoc.end);
-                var afterEndLine = afterEnd ? afterEnd.line : lines.length;
-                var trailingGap = afterEndLine - trueLoc.end.line;
+                const afterEnd = lines.skipSpaces(trueLoc.end);
+                const afterEndLine = afterEnd ? afterEnd.line : lines.length;
+                const trailingGap = afterEndLine - trueLoc.end.line;
                 trailingSpace = Array(trailingGap + 1).join("\n");
             } else {
                 trailingSpace = multiLine ? "\n\n" : "\n";
@@ -2656,8 +2656,8 @@ function maxSpace(s1: any, s2: any) {
         return fromString(s1);
     }
 
-    var spaceLines1 = fromString(s1);
-    var spaceLines2 = fromString(s2);
+    const spaceLines1 = fromString(s1);
+    const spaceLines2 = fromString(s2);
 
     if (spaceLines2.length > spaceLines1.length) {
         return spaceLines2;
@@ -2667,16 +2667,16 @@ function maxSpace(s1: any, s2: any) {
 }
 
 function printMethod(path: any, options: any, print: any) {
-    var node = path.getNode();
-    var kind = node.kind;
-    var parts = [];
+    const node = path.getNode();
+    const kind = node.kind;
+    const parts = [];
 
-    var nodeValue = node.value;
+    let nodeValue = node.value;
     if (! namedTypes.FunctionExpression.check(nodeValue)) {
         nodeValue = node;
     }
 
-    var access = node.accessibility || node.access;
+    const access = node.accessibility || node.access;
     if (typeof access === "string") {
         parts.push(access, " ");
     }
@@ -2705,7 +2705,7 @@ function printMethod(path: any, options: any, print: any) {
         parts.push(kind, " ");
     }
 
-    var key = path.call(print, "key");
+    let key = path.call(print, "key");
     if (node.computed) {
         key = concat(["[", key, "]"]);
     }
@@ -2753,10 +2753,10 @@ function printMethod(path: any, options: any, print: any) {
 }
 
 function printArgumentsList(path: any, options: any, print: any) {
-    var printed = path.map(print, "arguments");
-    var trailingComma = util.isTrailingCommaEnabled(options, "parameters");
+    const printed = path.map(print, "arguments");
+    const trailingComma = util.isTrailingCommaEnabled(options, "parameters");
 
-    var joined = fromString(", ").join(printed);
+    let joined = fromString(", ").join(printed);
     if (joined.getLineLength(1) > options.wrapColumn) {
         joined = fromString(",\n").join(printed);
         return concat([
@@ -2770,7 +2770,7 @@ function printArgumentsList(path: any, options: any, print: any) {
 }
 
 function printFunctionParams(path: any, options: any, print: any) {
-    var fun = path.getValue();
+    const fun = path.getValue();
 
     if (fun.params) {
         var params = fun.params;
@@ -2782,8 +2782,8 @@ function printFunctionParams(path: any, options: any, print: any) {
 
     if (fun.defaults) {
         path.each(function(defExprPath: any) {
-            var i = defExprPath.getName();
-            var p = printed[i];
+            const i = defExprPath.getName();
+            const p = printed[i];
             if (p && defExprPath.getValue()) {
                 printed[i] = concat([p, " = ", print(defExprPath)]);
             }
@@ -2794,7 +2794,7 @@ function printFunctionParams(path: any, options: any, print: any) {
         printed.push(concat(["...", path.call(print, "rest")]));
     }
 
-    var joined = fromString(", ").join(printed);
+    let joined = fromString(", ").join(printed);
     if (joined.length > 1 ||
         joined.getLineLength(1) > options.wrapColumn) {
         joined = fromString(",\n").join(printed);
@@ -2812,12 +2812,12 @@ function printFunctionParams(path: any, options: any, print: any) {
 }
 
 function printExportDeclaration(path: any, options: any, print: any) {
-    var decl = path.getValue();
-    var parts: (string | Lines)[] = ["export "];
+    const decl = path.getValue();
+    const parts: (string | Lines)[] = ["export "];
     if (decl.exportKind && decl.exportKind !== "value") {
         parts.push(decl.exportKind + " ");
     }
-    var shouldPrintSpaces = options.objectCurlySpacing;
+    const shouldPrintSpaces = options.objectCurlySpacing;
 
     namedTypes.Declaration.assert(decl);
 
@@ -2895,7 +2895,7 @@ function printExportDeclaration(path: any, options: any, print: any) {
         }
     }
 
-    var lines = concat(parts);
+    let lines = concat(parts);
     if (lastNonSpaceCharacter(lines) !== ";" &&
         ! (decl.declaration &&
            (decl.declaration.type === "FunctionDeclaration" ||
@@ -2909,7 +2909,7 @@ function printExportDeclaration(path: any, options: any, print: any) {
 }
 
 function printFlowDeclaration(path: any, parts: any) {
-    var parentExportDecl = util.getParentExportDeclaration(path);
+    const parentExportDecl = util.getParentExportDeclaration(path);
 
     if (parentExportDecl) {
         assert.strictEqual(
@@ -2928,7 +2928,7 @@ function printFlowDeclaration(path: any, parts: any) {
 
 function printVariance(path: any, print: any) {
     return path.call(function (variancePath: any) {
-        var value = variancePath.getValue();
+        const value = variancePath.getValue();
 
         if (value) {
             if (value === "plus") {
@@ -2957,9 +2957,9 @@ function adjustClause(clause: any, options: any) {
 }
 
 function lastNonSpaceCharacter(lines: any) {
-    var pos = lines.lastPos();
+    const pos = lines.lastPos();
     do {
-        var ch = lines.charAt(pos);
+        const ch = lines.charAt(pos);
         if (/\S/.test(ch))
             return ch;
     } while (lines.prevPos(pos));
@@ -2991,7 +2991,7 @@ function nodeStr(str: string, options: any) {
 }
 
 function maybeAddSemicolon(lines: any) {
-    var eoc = lastNonSpaceCharacter(lines);
+    const eoc = lastNonSpaceCharacter(lines);
     if (!eoc || "\n};".indexOf(eoc) < 0)
         return concat([lines, ";"]);
     return lines;

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,10 +1,10 @@
 import assert from "assert";
 import * as types from "ast-types";
-var n = types.namedTypes;
+const n = types.namedTypes;
 import sourceMap from "source-map";
-var SourceMapConsumer = sourceMap.SourceMapConsumer;
-var SourceMapGenerator = sourceMap.SourceMapGenerator;
-var hasOwn = Object.prototype.hasOwnProperty;
+const SourceMapConsumer = sourceMap.SourceMapConsumer;
+const SourceMapGenerator = sourceMap.SourceMapGenerator;
+const hasOwn = Object.prototype.hasOwnProperty;
 
 export function getOption(options: any, key: any, defaultValue: any) {
   if (options && hasOwn.call(options, key)) {
@@ -14,12 +14,12 @@ export function getOption(options: any, key: any, defaultValue: any) {
 }
 
 export function getUnionOfKeys(...args: any[]) {
-  var result: any = {};
-  var argc = args.length;
-  for (var i = 0; i < argc; ++i) {
-    var keys = Object.keys(args[i]);
-    var keyCount = keys.length;
-    for (var j = 0; j < keyCount; ++j) {
+  const result: any = {};
+  const argc = args.length;
+  for (let i = 0; i < argc; ++i) {
+    const keys = Object.keys(args[i]);
+    const keyCount = keys.length;
+    for (let j = 0; j < keyCount; ++j) {
       result[keys[j]] = true;
     }
   }
@@ -46,22 +46,22 @@ export function composeSourceMaps(formerMap: any, latterMap: any) {
     return latterMap || null;
   }
 
-  var smcFormer = new SourceMapConsumer(formerMap);
-  var smcLatter = new SourceMapConsumer(latterMap);
-  var smg = new SourceMapGenerator({
+  const smcFormer = new SourceMapConsumer(formerMap);
+  const smcLatter = new SourceMapConsumer(latterMap);
+  const smg = new SourceMapGenerator({
     file: latterMap.file,
     sourceRoot: latterMap.sourceRoot
   });
 
-  var sourcesToContents: any = {};
+  const sourcesToContents: any = {};
 
   smcLatter.eachMapping(function(mapping) {
-    var origPos = smcFormer.originalPositionFor({
+    const origPos = smcFormer.originalPositionFor({
       line: mapping.originalLine,
       column: mapping.originalColumn
     });
 
-    var sourceName = origPos.source;
+    const sourceName = origPos.source;
     if (sourceName === null) {
       return;
     }
@@ -76,7 +76,7 @@ export function composeSourceMaps(formerMap: any, latterMap: any) {
       name: mapping.name
     });
 
-    var sourceContent = smcFormer.sourceContentFor(sourceName);
+    const sourceContent = smcFormer.sourceContentFor(sourceName);
     if (sourceContent && !hasOwn.call(sourcesToContents, sourceName)) {
       sourcesToContents[sourceName] = sourceContent;
       smg.setSourceContent(sourceName, sourceContent);
@@ -95,7 +95,7 @@ export function getTrueLoc(node: any, lines: any) {
     return null;
   }
 
-  var result = {
+  const result = {
     start: node.loc.start,
     end: node.loc.end
   };
@@ -183,7 +183,7 @@ export function fixFaultyLocations(node: any, lines: any) {
 
     // Expand the .loc of the node responsible for printing the decorators
     // (here, the export declaration) so that it includes node.decorators.
-    var decorators = node.declaration.decorators;
+    const decorators = node.declaration.decorators;
     if (decorators) {
       decorators.forEach(function (decorator: any) {
         expandLoc(loc, decorator.loc);
@@ -208,7 +208,7 @@ export function fixFaultyLocations(node: any, lines: any) {
 
   } else if (node.type === "ObjectTypeProperty") {
     var loc = node.loc;
-    var end = loc && loc.end;
+    let end = loc && loc.end;
     if (end) {
       end = copyPos(end);
       if (lines.prevPos(end) &&
@@ -229,9 +229,9 @@ function fixForLoopHead(node: any, lines: any) {
   }
 
   function fix(child: any) {
-    var loc = child && child.loc;
-    var start = loc && loc.start;
-    var end = loc && copyPos(loc.end);
+    const loc = child && child.loc;
+    const start = loc && loc.start;
+    const end = loc && copyPos(loc.end);
 
     while (start && end && comparePos(start, end) < 0) {
       lines.prevPos(end);
@@ -264,20 +264,20 @@ function fixTemplateLiteral(node: any, lines: any) {
   if (node.loc) {
     // First we need to exclude the opening ` from the .loc of the first
     // quasi element, in case the parser accidentally decided to include it.
-    var afterLeftBackTickPos = copyPos(node.loc.start);
+    const afterLeftBackTickPos = copyPos(node.loc.start);
     assert.strictEqual(lines.charAt(afterLeftBackTickPos), "`");
     assert.ok(lines.nextPos(afterLeftBackTickPos));
-    var firstQuasi = node.quasis[0];
+    const firstQuasi = node.quasis[0];
     if (comparePos(firstQuasi.loc.start, afterLeftBackTickPos) < 0) {
       firstQuasi.loc.start = afterLeftBackTickPos;
     }
 
     // Next we need to exclude the closing ` from the .loc of the last quasi
     // element, in case the parser accidentally decided to include it.
-    var rightBackTickPos = copyPos(node.loc.end);
+    const rightBackTickPos = copyPos(node.loc.end);
     assert.ok(lines.prevPos(rightBackTickPos));
     assert.strictEqual(lines.charAt(rightBackTickPos), "`");
-    var lastQuasi = node.quasis[node.quasis.length - 1];
+    const lastQuasi = node.quasis[node.quasis.length - 1];
     if (comparePos(rightBackTickPos, lastQuasi.loc.end) < 0) {
       lastQuasi.loc.end = rightBackTickPos;
     }
@@ -290,12 +290,12 @@ function fixTemplateLiteral(node: any, lines: any) {
     // precedes the expression. The position of the $ should be the same
     // as the .loc.end of the preceding quasi element, but some parsers
     // accidentally include the ${ in the .loc of the quasi element.
-    var dollarCurlyPos = lines.skipSpaces(expr.loc.start, true, false);
+    const dollarCurlyPos = lines.skipSpaces(expr.loc.start, true, false);
     if (lines.prevPos(dollarCurlyPos) &&
         lines.charAt(dollarCurlyPos) === "{" &&
         lines.prevPos(dollarCurlyPos) &&
         lines.charAt(dollarCurlyPos) === "$") {
-      var quasiBefore = node.quasis[i];
+      const quasiBefore = node.quasis[i];
       if (comparePos(dollarCurlyPos, quasiBefore.loc.end) < 0) {
         quasiBefore.loc.end = dollarCurlyPos;
       }
@@ -303,11 +303,11 @@ function fixTemplateLiteral(node: any, lines: any) {
 
     // Likewise, some parsers accidentally include the } that follows
     // the expression in the .loc of the following quasi element.
-    var rightCurlyPos = lines.skipSpaces(expr.loc.end, false, false);
+    const rightCurlyPos = lines.skipSpaces(expr.loc.end, false, false);
     if (lines.charAt(rightCurlyPos) === "}") {
       assert.ok(lines.nextPos(rightCurlyPos));
       // Now rightCurlyPos is technically the position just after the }.
-      var quasiAfter = node.quasis[i + 1];
+      const quasiAfter = node.quasis[i + 1];
       if (comparePos(quasiAfter.loc.start, rightCurlyPos) < 0) {
         quasiAfter.loc.start = rightCurlyPos;
       }
@@ -330,7 +330,7 @@ export function isExportDeclaration(node: any) {
 };
 
 export function getParentExportDeclaration(path: any) {
-  var parentNode = path.getParentNode();
+  const parentNode = path.getParentNode();
   if (path.getName() === "declaration" &&
       isExportDeclaration(parentNode)) {
     return parentNode;
@@ -340,7 +340,7 @@ export function getParentExportDeclaration(path: any) {
 };
 
 export function isTrailingCommaEnabled(options: any, context: any) {
-  var trailingComma = options.trailingComma;
+  const trailingComma = options.trailingComma;
   if (typeof trailingComma === "object") {
     return !!trailingComma[context];
   }

--- a/test/babel.ts
+++ b/test/babel.ts
@@ -1,9 +1,9 @@
 import assert from "assert";
 import * as recast from "../main";
-var n = recast.types.namedTypes;
-var b = recast.types.builders;
+const n = recast.types.namedTypes;
+const b = recast.types.builders;
 import { EOL as eol } from "os";
-var nodeMajorVersion = parseInt(process.versions.node, 10);
+const nodeMajorVersion = parseInt(process.versions.node, 10);
 
 describe("Babel", function () {
   // Babel no longer supports Node 4 or 5.
@@ -11,17 +11,17 @@ describe("Babel", function () {
     return;
   }
 
-  var babelTransform = require("@babel/core").transform;
-  var babelPresetEnv = require("@babel/preset-env");
-  var parseOptions = {
+  const babelTransform = require("@babel/core").transform;
+  const babelPresetEnv = require("@babel/preset-env");
+  const parseOptions = {
     parser: require("../parsers/babel")
   };
 
   it("basic printing", function () {
     function check(lines: any) {
-      var code = lines.join(eol);
-      var ast = recast.parse(code, parseOptions);
-      var output = recast.prettyPrint(ast, { tabWidth: 2 }).code;
+      const code = lines.join(eol);
+      const ast = recast.parse(code, parseOptions);
+      const output = recast.prettyPrint(ast, { tabWidth: 2 }).code;
       assert.strictEqual(output, code);
     }
 
@@ -167,19 +167,19 @@ describe("Babel", function () {
   });
 
   it("babel 6: should not wrap IIFE when reusing nodes", function () {
-    var code = [
+    const code = [
       '(function(...c) {',
       '  c();',
       '})();',
     ].join(eol);
 
-    var ast = recast.parse(code, parseOptions);
-    var output = recast.print(ast, { tabWidth: 2 }).code;
+    const ast = recast.parse(code, parseOptions);
+    const output = recast.print(ast, { tabWidth: 2 }).code;
     assert.strictEqual(output, code);
   });
 
   it("should not disappear when surrounding code changes", function () {
-    var code = [
+    const code = [
       'import foo from "foo";',
       'import React from "react";',
       '',
@@ -196,18 +196,18 @@ describe("Babel", function () {
       'export default DebugPanel;',
     ].join(eol);
 
-    var ast = recast.parse(code, parseOptions);
+    const ast = recast.parse(code, parseOptions);
 
     assert.strictEqual(recast.print(ast).code, code);
 
-    var root = new recast.types.NodePath(ast);
-    var reactImportPath = root.get("program", "body", 1);
+    const root = new recast.types.NodePath(ast);
+    const reactImportPath = root.get("program", "body", 1);
     n.ImportDeclaration.assert(reactImportPath.value);
 
     // Remove the second import statement.
     reactImportPath.prune();
 
-    var reprinted = recast.print(ast).code;
+    const reprinted = recast.print(ast).code;
 
     assert.ok(reprinted.match(/@component/));
     assert.ok(reprinted.match(/@callExpression/));
@@ -221,7 +221,7 @@ describe("Babel", function () {
   });
 
   it("should not disappear when an import is added and `export` is used inline", function () {
-    var code = [
+    const code = [
       'import foo from "foo";',
       'import React from "react";',
       '',
@@ -239,19 +239,19 @@ describe("Babel", function () {
       '}',
     ].join(eol);
 
-    var ast = recast.parse(code, parseOptions);
+    const ast = recast.parse(code, parseOptions);
 
     assert.strictEqual(recast.print(ast).code, code);
 
-    var root = new recast.types.NodePath(ast);
-    var body = root.get("program", "body");
+    const root = new recast.types.NodePath(ast);
+    const body = root.get("program", "body");
 
     // add a new import statement
     body.unshift(b.importDeclaration([
       b.importDefaultSpecifier(b.identifier('x')),
     ], b.literal('x')));
 
-    var reprinted = recast.print(ast).code;
+    const reprinted = recast.print(ast).code;
 
     assert.ok(reprinted.match(/@component/));
     assert.ok(reprinted.match(/@callExpression/));
@@ -263,7 +263,7 @@ describe("Babel", function () {
   });
 
   it("should not disappear when an import is added and `export default` is used inline", function () {
-    var code = [
+    const code = [
       'import foo from "foo";',
       'import React from "react";',
       '',
@@ -281,19 +281,19 @@ describe("Babel", function () {
       '}',
     ].join(eol);
 
-    var ast = recast.parse(code, parseOptions);
+    const ast = recast.parse(code, parseOptions);
 
     assert.strictEqual(recast.print(ast).code, code);
 
-    var root = new recast.types.NodePath(ast);
-    var body = root.get("program", "body");
+    const root = new recast.types.NodePath(ast);
+    const body = root.get("program", "body");
 
     // add a new import statement
     body.unshift(b.importDeclaration([
       b.importDefaultSpecifier(b.identifier('x')),
     ], b.literal('x')));
 
-    var reprinted = recast.print(ast).code;
+    const reprinted = recast.print(ast).code;
 
     assert.ok(reprinted.match(/@component/));
     assert.ok(reprinted.match(/@callExpression/));
@@ -305,15 +305,15 @@ describe("Babel", function () {
   });
 
   it("should not print delimiters with type annotations", function () {
-    var code = [
+    const code = [
       'type X = {',
       '  a: number,',
       '  b: number,',
       '};',
     ].join('\n');
 
-    var ast = recast.parse(code, parseOptions)
-    var root = new recast.types.NodePath(ast);
+    const ast = recast.parse(code, parseOptions);
+    const root = new recast.types.NodePath(ast);
 
     root.get('program', 'body', 0, 'right', 'properties', 0).prune();
 
@@ -328,7 +328,7 @@ describe("Babel", function () {
   }
 
   it("should parenthesize ** operator arguments when lower precedence", function () {
-    var ast = recast.parse('a ** b;', parseOptions);
+    const ast = recast.parse('a ** b;', parseOptions);
 
     ast.program.body[0].expression.left = parseExpression('x + y');
     ast.program.body[0].expression.right = parseExpression('x || y');
@@ -340,7 +340,7 @@ describe("Babel", function () {
   });
 
   it("should parenthesize ** operator arguments as needed when same precedence", function () {
-    var ast = recast.parse('a ** b;', parseOptions);
+    const ast = recast.parse('a ** b;', parseOptions);
 
     ast.program.body[0].expression.left = parseExpression('x * y');
     ast.program.body[0].expression.right = parseExpression('x / y');
@@ -352,16 +352,16 @@ describe("Babel", function () {
   });
 
   it("should be able to replace top-level statements with leading empty lines", function () {
-    var code = [
+    const code = [
       '',
       'if (test) {',
       '  console.log(test);',
       '}',
     ].join('\n');
 
-    var ast = recast.parse(code, parseOptions);
+    const ast = recast.parse(code, parseOptions);
 
-    var replacement = b.expressionStatement(
+    const replacement = b.expressionStatement(
       b.callExpression(
         b.identifier('fn'),
         [b.identifier('test'), b.literal(true)]
@@ -389,8 +389,8 @@ describe("Babel", function () {
   });
 
   it("should parse and print dynamic import(...)", function () {
-    var code = 'wait(import("oyez"));';
-  var ast = recast.parse(code, parseOptions);
+    const code = 'wait(import("oyez"));';
+  const ast = recast.parse(code, parseOptions);
     assert.strictEqual(
       recast.prettyPrint(ast).code,
       code
@@ -398,7 +398,7 @@ describe("Babel", function () {
   });
 
   it("tolerates circular references", function () {
-    var code = "function foo(bar = true) {}";
+    const code = "function foo(bar = true) {}";
     recast.parse(code, {
       parser: {
         parse: function (source: any) {
@@ -414,27 +414,27 @@ describe("Babel", function () {
   });
 
   it("prints numbers in bases other than 10 without converting them", function() {
-    var code = [
+    const code = [
       'let decimal = 6;',
       'let hex = 0xf00d;',
       'let binary = 0b1010;',
       'let octal = 0o744;'
     ].join(eol);
 
-    var ast = recast.parse(code, parseOptions);
-    var output = recast.print(ast, { tabWidth: 2 }).code;
+    const ast = recast.parse(code, parseOptions);
+    const output = recast.print(ast, { tabWidth: 2 }).code;
     assert.strictEqual(output, code);
   });
 
   it("prints the export-default-from syntax", function () {
-    var code = [
+    const code = [
       'export { default as foo, bar } from "foo";',
       'export { default as veryLongIdentifier1, veryLongIdentifier2, veryLongIdentifier3, veryLongIdentifier4, veryLongIdentifier5 } from "long-identifiers";'
     ].join(eol);
-    var ast = recast.parse(code, parseOptions);
+    const ast = recast.parse(code, parseOptions);
 
-    var replacement1 = b.exportDefaultSpecifier(b.identifier('foo'));
-    var replacement2 = b.exportDefaultSpecifier(
+    const replacement1 = b.exportDefaultSpecifier(b.identifier('foo'));
+    const replacement2 = b.exportDefaultSpecifier(
       b.identifier('veryLongIdentifier1')
     );
     ast.program.body[0].specifiers[0] = replacement1;
@@ -455,13 +455,13 @@ describe("Babel", function () {
 
   // https://github.com/codemod-js/codemod/issues/157
   it("avoids extra semicolons on mutated blocks containing a 'use strict' directive", function() {
-    var code = [
+    const code = [
       '(function () {',
       '  "use strict";',
       '  hello;',
       '})();'
     ].join(eol);
-    var ast = recast.parse(code, parseOptions);
+    const ast = recast.parse(code, parseOptions);
 
     // delete "hello;"
     ast.program.body[0].expression.callee.body.body.splice(0);

--- a/test/comments.ts
+++ b/test/comments.ts
@@ -1,14 +1,14 @@
 "use strict";
 
 import * as recast from "../main";
-var n = recast.types.namedTypes;
-var b = recast.types.builders;
+const n = recast.types.namedTypes;
+const b = recast.types.builders;
 import { Printer } from "../lib/printer";
 import { fromString } from "../lib/lines";
 import assert from "assert";
 import { EOL as eol } from "os";
 
-var annotated = [
+const annotated = [
   "function dup(/* string */ s,",
   "             /* int */ n) /* string */",
   "{",
@@ -18,7 +18,7 @@ var annotated = [
   "}"
 ];
 
-var nodeMajorVersion = parseInt(process.versions.node, 10);
+const nodeMajorVersion = parseInt(process.versions.node, 10);
 
 describe("comments", function() {
   ["../parsers/acorn",
@@ -48,10 +48,10 @@ function runTestsForParser(parserId: any) {
   }
 
   pit("attachment and reprinting", function() {
-    var code = annotated.join(eol);
-    var ast = recast.parse(code, { parser });
+    const code = annotated.join(eol);
+    const ast = recast.parse(code, { parser });
 
-    var dup = ast.program.body[0];
+    const dup = ast.program.body[0];
     n.FunctionDeclaration.assert(dup);
     assert.strictEqual(dup.id.name, "dup");
 
@@ -75,21 +75,21 @@ function runTestsForParser(parserId: any) {
       ["/* string */"].concat(annotated.slice(2)).join(eol)
     );
 
-    var retStmt = dup.body.body[0];
+    const retStmt = dup.body.body[0];
     n.ReturnStatement.assert(retStmt);
 
-    var indented = annotated.slice(3, 6).join(eol);
-    var flush = fromString(indented).indent(-2);
+    const indented = annotated.slice(3, 6).join(eol);
+    const flush = fromString(indented).indent(-2);
 
     assert.strictEqual(
       recast.print(retStmt).code,
       flush.toString()
     );
 
-    var join = retStmt.argument;
+    const join = retStmt.argument;
     n.CallExpression.assert(join);
 
-    var one = join.callee.object.arguments[0].right;
+    const one = join.callee.object.arguments[0].right;
     n.Literal.assert(one);
     assert.strictEqual(one.value, 1);
     assert.strictEqual(recast.print(one).code, [
@@ -98,7 +98,7 @@ function runTestsForParser(parserId: any) {
     ].join(eol));
   });
 
-  var trailing = [
+  const trailing = [
     "Foo.prototype = {",
     "// Copyright (c) 2013 Ben Newman <bn@cs.stanford.edu>",
     "",
@@ -117,7 +117,7 @@ function runTestsForParser(parserId: any) {
     "};"
   ];
 
-  var trailingExpected = [
+  const trailingExpected = [
     "Foo.prototype = {",
     "  // Copyright (c) 2013 Ben Newman <bn@cs.stanford.edu>",
     "",
@@ -146,8 +146,8 @@ function runTestsForParser(parserId: any) {
   ];
 
   pit("TrailingComments", function() {
-    var code = trailing.join(eol);
-    var ast = recast.parse(code, { parser });
+    const code = trailing.join(eol);
+    const ast = recast.parse(code, { parser });
     assert.strictEqual(recast.print(ast).code, code);
 
     // Drop all original source information to force reprinting.
@@ -158,7 +158,7 @@ function runTestsForParser(parserId: any) {
       }
     });
 
-    var assign = ast.program.body[0].expression;
+    const assign = ast.program.body[0].expression;
     n.AssignmentExpression.assert(assign);
 
     const esprimaInfo = {
@@ -195,7 +195,7 @@ function runTestsForParser(parserId: any) {
       typescript: babelInfo
     } as any)[parserName];
 
-    var props = assign.right.properties;
+    const props = assign.right.properties;
     info.Property.arrayOf().assert(props);
 
     props.push(info.propBuilder(
@@ -203,15 +203,15 @@ function runTestsForParser(parserId: any) {
       info.literalBuilder("property")
     ));
 
-    var quxVal = props[2].value;
+    const quxVal = props[2].value;
     n.ObjectExpression.assert(quxVal);
     quxVal.properties.push(info.propBuilder(
       b.identifier("asdf"),
       info.literalBuilder(43)
     ));
 
-    var actual = recast.print(ast, { tabWidth: 2 }).code;
-    var expected = trailingExpected.join(eol);
+    const actual = recast.print(ast, { tabWidth: 2 }).code;
+    const expected = trailingExpected.join(eol);
 
     // Check semantic equivalence:
     recast.types.astNodesAreEquivalent.assert(
@@ -222,14 +222,14 @@ function runTestsForParser(parserId: any) {
     assert.strictEqual(actual, expected);
   });
 
-  var bodyTrailing = [
+  const bodyTrailing = [
     "module.exports = {};",
     "/**",
     " * Trailing comment.",
     " */"
   ];
 
-  var bodyTrailingExpected = [
+  const bodyTrailingExpected = [
     "module.exports = {};",
     "/**",
     " * Trailing comment.",
@@ -237,8 +237,8 @@ function runTestsForParser(parserId: any) {
   ];
 
   pit("BodyTrailingComments", function() {
-    var code = bodyTrailing.join(eol);
-    var ast = recast.parse(code, { parser });
+    const code = bodyTrailing.join(eol);
+    const ast = recast.parse(code, { parser });
 
     // Drop all original source information to force reprinting.
     recast.visit(ast, {
@@ -248,40 +248,40 @@ function runTestsForParser(parserId: any) {
       }
     });
 
-    var actual = recast.print(ast, { tabWidth: 2 }).code;
-    var expected = bodyTrailingExpected.join(eol);
+    const actual = recast.print(ast, { tabWidth: 2 }).code;
+    const expected = bodyTrailingExpected.join(eol);
 
     assert.strictEqual(actual, expected);
   });
 
-  var paramTrailing = [
+  const paramTrailing = [
     "function foo(bar, baz /* = null */) {",
     "  assert.strictEqual(baz, null);",
     "}"
   ];
 
-  var paramTrailingExpected = [
+  const paramTrailingExpected = [
     "function foo(zxcv, bar, baz /* = null */) {",
     "  assert.strictEqual(baz, null);",
     "}"
   ];
 
   pit("ParamTrailingComments", function() {
-    var code = paramTrailing.join(eol);
-    var ast = recast.parse(code, { parser });
+    const code = paramTrailing.join(eol);
+    const ast = recast.parse(code, { parser });
 
-    var func = ast.program.body[0];
+    const func = ast.program.body[0];
     n.FunctionDeclaration.assert(func);
 
     func.params.unshift(b.identifier("zxcv"));
 
-    var actual = recast.print(ast, { tabWidth: 2 }).code;
-    var expected = paramTrailingExpected.join(eol);
+    const actual = recast.print(ast, { tabWidth: 2 }).code;
+    const expected = paramTrailingExpected.join(eol);
 
     assert.strictEqual(actual, expected);
   });
 
-  var statementTrailing = [
+  const statementTrailing = [
     "if (true) {",
     "  f();",
     "  // trailing 1",
@@ -291,7 +291,7 @@ function runTestsForParser(parserId: any) {
     "}"
   ];
 
-  var statementTrailingExpected = [
+  const statementTrailingExpected = [
     "if (true) {",
     "  e();",
     "  f();",
@@ -303,22 +303,22 @@ function runTestsForParser(parserId: any) {
   ];
 
   pit("StatementTrailingComments", function() {
-    var code = statementTrailing.join(eol);
-    var ast = recast.parse(code, { parser });
+    const code = statementTrailing.join(eol);
+    const ast = recast.parse(code, { parser });
 
-    var block = ast.program.body[0].consequent;
+    const block = ast.program.body[0].consequent;
     n.BlockStatement.assert(block);
 
     block.body.unshift(b.expressionStatement(
       b.callExpression(b.identifier("e"), [])));
 
-    var actual = recast.print(ast, { tabWidth: 2 }).code;
-    var expected = statementTrailingExpected.join(eol);
+    const actual = recast.print(ast, { tabWidth: 2 }).code;
+    const expected = statementTrailingExpected.join(eol);
 
     assert.strictEqual(actual, expected);
   });
 
-  var protoAssign = [
+  const protoAssign = [
     "A.prototype.foo = function() {",
     "  return this.bar();",
     "}", // Lack of semicolon screws up location info.
@@ -330,11 +330,11 @@ function runTestsForParser(parserId: any) {
   ];
 
   pit("ProtoAssignComment", function() {
-    var code = protoAssign.join(eol);
-    var ast = recast.parse(code, { parser });
+    const code = protoAssign.join(eol);
+    const ast = recast.parse(code, { parser });
 
-    var foo = ast.program.body[0];
-    var bar = ast.program.body[1];
+    const foo = ast.program.body[0];
+    const bar = ast.program.body[1];
 
     n.ExpressionStatement.assert(foo);
     n.ExpressionStatement.assert(bar);
@@ -346,7 +346,7 @@ function runTestsForParser(parserId: any) {
     assert.ok(bar.comments);
     assert.strictEqual(bar.comments.length, 1);
 
-    var barComment = bar.comments[0];
+    const barComment = bar.comments[0];
     assert.strictEqual(barComment.leading, true);
     assert.strictEqual(barComment.trailing, false);
 
@@ -356,7 +356,7 @@ function runTestsForParser(parserId: any) {
     );
   });
 
-  var conciseMethods = [
+  const conciseMethods = [
     "var obj = {",
     "  a(/*before*/ param) {},",
     "  b(param /*after*/) {},",
@@ -365,20 +365,20 @@ function runTestsForParser(parserId: any) {
   ];
 
   pit("should correctly attach to concise methods", function() {
-    var code = conciseMethods.join(eol);
-    var ast = recast.parse(code, { parser });
+    const code = conciseMethods.join(eol);
+    const ast = recast.parse(code, { parser });
 
-    var objExpr = ast.program.body[0].declarations[0].init;
+    const objExpr = ast.program.body[0].declarations[0].init;
     n.ObjectExpression.assert(objExpr);
 
-    var a = objExpr.properties[0];
+    const a = objExpr.properties[0];
     n.Identifier.assert(a.key);
     assert.strictEqual(a.key.name, "a");
 
-    var aComments = (a.value || a).params[0].comments;
+    const aComments = (a.value || a).params[0].comments;
     assert.strictEqual(aComments.length, 1);
 
-    var aComment = aComments[0];
+    const aComment = aComments[0];
     assert.strictEqual(aComment.leading, true);
     assert.strictEqual(aComment.trailing, false);
     assert.ok(aComment.type.endsWith("Block"));
@@ -389,14 +389,14 @@ function runTestsForParser(parserId: any) {
       "a(/*before*/ param) {}"
     );
 
-    var b = objExpr.properties[1];
+    const b = objExpr.properties[1];
     n.Identifier.assert(b.key);
     assert.strictEqual(b.key.name, "b");
 
-    var bComments = (b.value || b).params[0].comments;
+    const bComments = (b.value || b).params[0].comments;
     assert.strictEqual(bComments.length, 1);
 
-    var bComment = bComments[0];
+    const bComment = bComments[0];
     assert.strictEqual(bComment.leading, false);
     assert.strictEqual(bComment.trailing, true);
     assert.ok(bComment.type.endsWith("Block"));
@@ -407,14 +407,14 @@ function runTestsForParser(parserId: any) {
       "b(param /*after*/) {}"
     );
 
-    var c = objExpr.properties[2];
+    const c = objExpr.properties[2];
     n.Identifier.assert(c.key);
     assert.strictEqual(c.key.name, "c");
 
-    var cComments = (c.value || c).body.comments;
+    const cComments = (c.value || c).body.comments;
     assert.strictEqual(cComments.length, 1);
 
-    var cComment = cComments[0];
+    const cComment = cComments[0];
     assert.strictEqual(cComment.leading, true);
     assert.strictEqual(cComment.trailing, false);
     assert.ok(cComment.type.endsWith("Block"));
@@ -428,13 +428,13 @@ function runTestsForParser(parserId: any) {
 
   pit("should attach comments as configurable", function() {
     // Given
-    var simpleCommentedCode = [
+    const simpleCommentedCode = [
       "// A comment",
       "var obj = {",
       "};",
     ];
-    var code = simpleCommentedCode.join(eol);
-    var ast = recast.parse(code, { parser });
+    const code = simpleCommentedCode.join(eol);
+    const ast = recast.parse(code, { parser });
 
     // When
     Object.defineProperty(ast.program, 'comments', {
@@ -447,15 +447,15 @@ function runTestsForParser(parserId: any) {
   });
 
   pit("should be reprinted when modified", function() {
-    var code = [
+    const code = [
       "foo;",
       "// bar",
       "bar;"
     ].join(eol);
 
-    var ast = recast.parse(code, { parser });
+    const ast = recast.parse(code, { parser });
 
-    var comments = ast.program.body[1].comments;
+    const comments = ast.program.body[1].comments;
     assert.strictEqual(comments.length, 1);
     var comment = comments[0];
     assert.ok(comment.type.endsWith("Line"));
@@ -577,7 +577,7 @@ function runTestsForParser(parserId: any) {
   });
 
   pit("should preserve stray non-comment syntax", function() {
-    var code = [
+    const code = [
       "[",
       "  foo",
       "  , /* comma */",
@@ -587,10 +587,10 @@ function runTestsForParser(parserId: any) {
       "]"
     ].join(eol);
 
-    var ast = recast.parse(code, { parser });
+    const ast = recast.parse(code, { parser });
     assert.strictEqual(recast.print(ast).code, code);
 
-    var elems = ast.program.body[0].expression.elements;
+    const elems = ast.program.body[0].expression.elements;
     elems[0].comments.push(b.line(" line comment", true, false));
     assert.strictEqual(recast.print(ast).code, [
       "[",
@@ -649,7 +649,7 @@ function runTestsForParser(parserId: any) {
   });
 
   pit("should attach to program.body[0] instead of program", function() {
-    var code = [
+    const code = [
       "// comment 1",
       "var a;",
       "// comment 2",
@@ -660,25 +660,25 @@ function runTestsForParser(parserId: any) {
       "}"
     ].join('\n');
 
-    var ast = recast.parse(code, { parser });
+    const ast = recast.parse(code, { parser });
 
     assert.ok(!ast.program.comments);
 
-    var aDecl = ast.program.body[0];
+    const aDecl = ast.program.body[0];
     n.VariableDeclaration.assert(aDecl);
     assert.strictEqual(aDecl.comments.length, 1);
     assert.strictEqual(aDecl.comments[0].leading, true);
     assert.strictEqual(aDecl.comments[0].trailing, false);
     assert.strictEqual(aDecl.comments[0].value, " comment 1");
 
-    var bDecl = ast.program.body[1];
+    const bDecl = ast.program.body[1];
     n.VariableDeclaration.assert(bDecl);
     assert.strictEqual(bDecl.comments.length, 1);
     assert.strictEqual(bDecl.comments[0].leading, true);
     assert.strictEqual(bDecl.comments[0].trailing, false);
     assert.strictEqual(bDecl.comments[0].value, " comment 2");
 
-    var cDecl = ast.program.body[2].consequent.body[0];
+    const cDecl = ast.program.body[2].consequent.body[0];
     n.VariableDeclaration.assert(cDecl);
     assert.strictEqual(cDecl.comments.length, 1);
     assert.strictEqual(cDecl.comments[0].leading, true);
@@ -687,7 +687,7 @@ function runTestsForParser(parserId: any) {
   });
 
   pit("should not collapse multi line function definitions", function() {
-    var code = [
+    const code = [
       "var obj = {",
       "  a(",
       "    /*before*/ param",
@@ -696,8 +696,8 @@ function runTestsForParser(parserId: any) {
       "};",
     ].join(eol);
 
-    var ast = recast.parse(code, { parser });
-    var printer = new Printer({
+    const ast = recast.parse(code, { parser });
+    const printer = new Printer({
       tabWidth: 2
     });
 
@@ -708,19 +708,19 @@ function runTestsForParser(parserId: any) {
   });
 
   pit("should be pretty-printable in illegal positions", function() {
-    var code = [
+    const code = [
       "var sum = function /*anonymous*/(/*...args*/) /*int*/ {",
       "  // TODO",
       "};"
     ].join(eol);
 
-    var ast = recast.parse(code, { parser });
-    var funExp = ast.program.body[0].declarations[0].init;
+    const ast = recast.parse(code, { parser });
+    const funExp = ast.program.body[0].declarations[0].init;
     n.FunctionExpression.assert(funExp);
 
     funExp.original = null;
 
-    var comments = funExp.body.comments;
+    const comments = funExp.body.comments;
     assert.strictEqual(comments.length, 4);
     funExp.id = comments.shift();
     funExp.params.push(comments.shift());
@@ -733,13 +733,13 @@ function runTestsForParser(parserId: any) {
   });
 
   pit("should preserve correctness when a return expression has a comment", function () {
-    var code = [
+    const code = [
       "function f() {",
       "  return 3;",
       "}"
     ].join(eol);
 
-    var ast = recast.parse(code, { parser });
+    const ast = recast.parse(code, { parser });
     ast.program.body[0].body.body[0].argument.comments = [b.line('Foo')];
 
     assert.strictEqual(recast.print(ast).code, [
@@ -753,13 +753,13 @@ function runTestsForParser(parserId: any) {
   });
 
   pit("should wrap in parens when the return expression has nested leftmost comment", function () {
-    var code = [
+    const code = [
       "function f() {",
       "  return 1 + 2;",
       "}"
     ].join(eol);
 
-    var ast = recast.parse(code, { parser });
+    const ast = recast.parse(code, { parser });
     ast.program.body[0].body.body[0].argument.left.comments = [b.line('Foo')];
 
     assert.strictEqual(recast.print(ast).code, [
@@ -773,13 +773,13 @@ function runTestsForParser(parserId: any) {
   });
 
   pit("should not wrap in parens when the return expression has an interior comment", function () {
-    var code = [
+    const code = [
       "function f() {",
       "  return 1 + 2;",
       "}"
     ].join(eol);
 
-    var ast = recast.parse(code, { parser });
+    const ast = recast.parse(code, { parser });
     ast.program.body[0].body.body[0].argument.right.comments = [b.line('Foo')];
 
     assert.strictEqual(recast.print(ast).code, [
@@ -791,17 +791,17 @@ function runTestsForParser(parserId: any) {
   });
 
   pit("should correctly handle a lonesome comment (alt 1)", function() {
-    var code = ["", "// boo", ""].join(eol);
+    const code = ["", "// boo", ""].join(eol);
 
-    var ast = recast.parse(code);
+    const ast = recast.parse(code);
 
     assert.strictEqual(recast.print(ast).code, ["", "// boo", ""].join(eol));
   });
 
   pit("should correctly handle a not-so-lonesome comment (alt 2 - trailing whitespace)", function() {
-    var code = ["", "// boo ", ";"].join(eol);
+    const code = ["", "// boo ", ";"].join(eol);
 
-    var ast = recast.parse(code);
+    const ast = recast.parse(code);
 
     assert.strictEqual(
       recast.print(ast).code,
@@ -810,15 +810,15 @@ function runTestsForParser(parserId: any) {
   });
 
   pit("should correctly handle a lonesome comment (alt 3 - trailing whitespace)", function() {
-    var code = ["", "// boo ", ""].join(eol);
+    const code = ["", "// boo ", ""].join(eol);
 
-    var ast = recast.parse(code);
+    const ast = recast.parse(code);
 
     assert.strictEqual(recast.print(ast).code, ["", "// boo ", ""].join(eol));
   });
 
   pit("should not reformat a return statement that is not modified", function () {
-    var code = [
+    const code = [
       "function f() {",
       "  return      {",
       "    a:     1,",
@@ -827,19 +827,19 @@ function runTestsForParser(parserId: any) {
       "}"
     ].join(eol);
 
-    var ast = recast.parse(code, { parser });
+    const ast = recast.parse(code, { parser });
 
     assert.strictEqual(recast.print(ast).code, code);
   });
 
   pit("should correctly handle a removing the argument from a return", function () {
-    var code = [
+    const code = [
       "function f() {",
       "  return 'foo';",
       "}"
     ].join(eol);
 
-    var ast = recast.parse(code, { parser });
+    const ast = recast.parse(code, { parser });
     ast.program.body[0].body.body[0].argument = null;
 
     assert.strictEqual(recast.print(ast).code, [
@@ -850,13 +850,13 @@ function runTestsForParser(parserId: any) {
   });
 
   pit("should preserve comments attached to EmptyStatement", function() {
-    var code = [
+    const code = [
       "removeThisStatement;",
       "// comment",
       ";(function() {})();"
     ].join(eol);
 
-    var ast = recast.parse(code, { parser });
+    const ast = recast.parse(code, { parser });
     ast.program.body.shift();
 
     assert.strictEqual(recast.print(ast).code, [

--- a/test/es6tests.ts
+++ b/test/es6tests.ts
@@ -2,15 +2,15 @@ import assert from "assert";
 import { parse } from "../lib/parser";
 import { Printer } from "../lib/printer";
 import * as types from "ast-types";
-var n = types.namedTypes;
-var b = types.builders;
+const n = types.namedTypes;
+const b = types.builders;
 import { EOL as eol } from "os";
 
 describe("ES6 Compatability", function() {
   function convertShorthandMethod() {
-    var printer = new Printer({ tabWidth: 2 });
+    const printer = new Printer({ tabWidth: 2 });
 
-    var code = [
+    const code = [
       "var name='test-name';",
       "var shorthandObj = {",
       "  name,",
@@ -18,18 +18,18 @@ describe("ES6 Compatability", function() {
       "};"
     ].join(eol);
 
-    var ast = parse(code);
+    const ast = parse(code);
     n.VariableDeclaration.assert(ast.program.body[1]);
 
-    var shorthandObjDec = ast.program.body[1].declarations[0].init;
-    var methodDecProperty = shorthandObjDec.properties[1];
-    var newES5MethodProperty = b.property(
+    const shorthandObjDec = ast.program.body[1].declarations[0].init;
+    const methodDecProperty = shorthandObjDec.properties[1];
+    const newES5MethodProperty = b.property(
       methodDecProperty.kind,
       methodDecProperty.key,
       methodDecProperty.value,
     );
 
-    var correctMethodProperty = b.property(
+    const correctMethodProperty = b.property(
       methodDecProperty.kind,
       methodDecProperty.key,
       b.functionExpression(
@@ -51,9 +51,9 @@ describe("ES6 Compatability", function() {
      convertShorthandMethod);
 
   function respectDestructuringAssignment() {
-    var printer = new Printer({ tabWidth: 2 });
-    var code = 'var {a} = {};';
-    var ast = parse(code);
+    const printer = new Printer({ tabWidth: 2 });
+    const code = 'var {a} = {};';
+    const ast = parse(code);
     n.VariableDeclaration.assert(ast.program.body[0]);
     assert.strictEqual(printer.print(ast).code, code);
   }
@@ -63,11 +63,11 @@ describe("ES6 Compatability", function() {
 });
 
 describe("import/export syntax", function() {
-  var printer = new Printer({ tabWidth: 2 });
+  const printer = new Printer({ tabWidth: 2 });
 
   function check(source: string) {
-    var ast1 = parse(source);
-    var ast2 = parse(printer.printGenerically(ast1).code);
+    const ast1 = parse(source);
+    const ast2 = parse(printer.printGenerically(ast1).code);
     types.astNodesAreEquivalent.assert(ast1, ast2);
   }
 
@@ -274,13 +274,13 @@ describe("import/export syntax", function() {
   });
 
   it("should pretty-print template strings with backticks", function() {
-    var code = [
+    const code = [
       'var noun = "fool";',
       'var s = `I am a ${noun}`;',
       'var t = tag`You said: ${s}!`;'
     ].join(eol);
 
-    var ast = parse(code);
+    const ast = parse(code);
 
     assert.strictEqual(
       new Printer({

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -5,19 +5,19 @@ import * as types from "ast-types";
 import { EOL as eol } from "os";
 
 describe("type syntax", function() {
-  var printer = new Printer({ tabWidth: 2, quote: 'single', flowObjectCommas: false });
-  var esprimaParserParseOptions = {
+  const printer = new Printer({ tabWidth: 2, quote: 'single', flowObjectCommas: false });
+  const esprimaParserParseOptions = {
     parser: require("esprima-fb")
   };
-  var flowParserParseOptions = {
+  const flowParserParseOptions = {
     parser: require("flow-parser")
   };
 
   function check(source: string, parseOptions?: any) {
     parseOptions = parseOptions || esprimaParserParseOptions;
-    var ast1 = parse(source, parseOptions);
-    var code = printer.printGenerically(ast1).code;
-    var ast2 = parse(code, parseOptions);
+    const ast1 = parse(source, parseOptions);
+    const code = printer.printGenerically(ast1).code;
+    const ast2 = parse(code, parseOptions);
     types.astNodesAreEquivalent.assert(ast1, ast2);
     assert.strictEqual(source, code);
   }

--- a/test/identity.ts
+++ b/test/identity.ts
@@ -4,23 +4,23 @@ import path from "path";
 import * as types from "ast-types";
 import * as recast from "../main";
 
-var nodeMajorVersion = parseInt(process.versions.node, 10);
+const nodeMajorVersion = parseInt(process.versions.node, 10);
 
 function testFile(path: string, options: { parser?: any } = {}) {
     fs.readFile(path, "utf-8", function(err, source) {
         assert.equal(err, null);
         assert.strictEqual(typeof source, "string");
 
-        var ast = recast.parse(source, options);
+        const ast = recast.parse(source, options);
         types.astNodesAreEquivalent.assert(ast.original, ast);
-        var code = recast.print(ast).code;
+        const code = recast.print(ast).code;
         assert.strictEqual(source, code);
     });
 }
 
 function addTest(name: string) {
     it(name, function() {
-        var filename = path.join(__dirname, "..", name);
+        const filename = path.join(__dirname, "..", name);
 
         if (path.extname(filename) === ".ts") {
             // Babel 7 no longer supports Node 4 and 5.

--- a/test/jsx.ts
+++ b/test/jsx.ts
@@ -3,18 +3,18 @@
 import { parse } from "../lib/parser";
 import { Printer } from "../lib/printer";
 import * as types from "ast-types";
-var nodeMajorVersion = parseInt(process.versions.node, 10);
+const nodeMajorVersion = parseInt(process.versions.node, 10);
 
 (nodeMajorVersion >= 6 ? describe : xdescribe)
 ("JSX Compatability", function() {
-  var printer = new Printer({ tabWidth: 2 });
-  var parseOptions = {
+  const printer = new Printer({ tabWidth: 2 });
+  const parseOptions = {
     parser: require("../parsers/babel")
   };
 
   function check(source: string) {
-    var ast1 = parse(source, parseOptions);
-    var ast2 = parse(
+    const ast1 = parse(source, parseOptions);
+    const ast2 = parse(
       printer.printGenerically(ast1).code,
       parseOptions
     );

--- a/test/lines.ts
+++ b/test/lines.ts
@@ -14,12 +14,12 @@ function check(a: any, b: any) {
 
 describe("lines", function() {
     describe('line terminators', function() {
-        var source = [
+        const source = [
             'foo;',
             'bar;',
         ];
 
-        var terminators = [
+        const terminators = [
             '\u000A',
             '\u000D',
             '\u2028',
@@ -29,7 +29,7 @@ describe("lines", function() {
 
         terminators.forEach(function(t) {
             it('can handle ' + escape(t) + ' as line terminator', function() {
-                var lines = fromString(source.join(t));
+                const lines = fromString(source.join(t));
                 assert.strictEqual(lines.length, 2);
                 assert.strictEqual(lines.getLineLength(1), 4);
             });
@@ -49,20 +49,20 @@ describe("lines", function() {
         checkIsCached(", ");
         checkIsCached(": ");
 
-        var longer = "This is a somewhat longer string that we do not want to cache.";
+        const longer = "This is a somewhat longer string that we do not want to cache.";
         assert.notStrictEqual(
             fromString(longer),
             fromString(longer));
 
         // Since Lines objects are immutable, if one is passed to fromString,
         // we can return it as-is without having to make a defensive copy.
-        var longerLines = fromString(longer);
+        const longerLines = fromString(longer);
         assert.strictEqual(fromString(longerLines), longerLines);
     });
 
     it("ToString", function ToStringTest() {
-        var code = String(ToStringTest);
-        var lines = fromString(code);
+        const code = String(ToStringTest);
+        const lines = fromString(code);
         check(lines, code);
         check(lines.indentTail(5)
                    .indentTail(-7)
@@ -73,11 +73,11 @@ describe("lines", function() {
     function testEachPosHelper(lines: any, code: any) {
         check(lines, code);
 
-        var chars: any[] = [];
-        var emptyCount = 0;
+        const chars: any[] = [];
+        let emptyCount = 0;
 
         function iterator(pos: any) {
-            var ch = lines.charAt(pos);
+            const ch = lines.charAt(pos);
             if (ch === "")
                 emptyCount += 1;
             chars.push(ch);
@@ -93,11 +93,11 @@ describe("lines", function() {
         // systems, so normalize those to \n characters.
         code = code.replace(/\r\n/g, "\n");
 
-        var joined = chars.join("");
+        let joined = chars.join("");
         assert.strictEqual(joined.length, code.length);
         assert.strictEqual(joined, code);
 
-        var withoutSpaces = code.replace(/\s+/g, "");
+        const withoutSpaces = code.replace(/\s+/g, "");
         chars.length = emptyCount = 0;
         lines.eachPos(iterator, null, true); // Skip spaces this time.
         assert.strictEqual(emptyCount, 0);
@@ -107,8 +107,8 @@ describe("lines", function() {
     }
 
     it("EachPos", function EachPosTest() {
-        var code = String(EachPosTest);
-        var lines = fromString(code);
+        const code = String(EachPosTest);
+        let lines = fromString(code);
 
         testEachPosHelper(lines, code);
 
@@ -125,8 +125,8 @@ describe("lines", function() {
     it("CharAt", function CharAtTest() {
         // Function.prototype.toString uses \r\n line endings on non-*NIX
         // systems, so normalize those to \n characters.
-        var code = String(CharAtTest).replace(/\r\n/g, "\n");
-        var lines = fromString(code);
+        const code = String(CharAtTest).replace(/\r\n/g, "\n");
+        const lines = fromString(code);
 
         function compare(pos: any) {
             assert.strictEqual(
@@ -140,12 +140,10 @@ describe("lines", function() {
         // out-of-bounds input positions.
         fromString(exports.testBasic).eachPos(compare);
 
-        var original = fromString("  ab" + eol + "  c"),
-            indented = original.indentTail(4),
-            reference = fromString("  ab" + eol + "      c");
+        let original = fromString("  ab" + eol + "  c"), indented = original.indentTail(4), reference = fromString("  ab" + eol + "      c");
 
         function compareIndented(pos: any) {
-            var c = indented.charAt(pos);
+            const c = indented.charAt(pos);
             check(c, reference.charAt(pos));
             check(c, indented.bootstrapCharAt(pos));
             check(c, reference.bootstrapCharAt(pos));
@@ -160,9 +158,7 @@ describe("lines", function() {
     });
 
     it("Concat", function() {
-        var strings = ["asdf", "zcxv", "qwer"],
-            lines = fromString(strings.join(eol)),
-            indented = lines.indentTail(4);
+        const strings = ["asdf", "zcxv", "qwer"], lines = fromString(strings.join(eol)), indented = lines.indentTail(4);
 
         assert.strictEqual(lines.length, 3);
 
@@ -214,7 +210,7 @@ describe("lines", function() {
 
     it("Empty", function() {
         function c(s: any) {
-            var lines = fromString(s);
+            const lines = fromString(s);
             check(lines, s);
             assert.strictEqual(
                 lines.isEmpty(),
@@ -238,8 +234,7 @@ describe("lines", function() {
     });
 
     it("SingleLine", function() {
-        var string = "asdf",
-            line = fromString(string);
+        const string = "asdf", line = fromString(string);
 
         check(line, string);
         check(line.indentTail(4), string);
@@ -250,7 +245,7 @@ describe("lines", function() {
 
         // Multi-line Lines objects are altered by indentTail, but only if the
         // amount of the indentation is non-zero.
-        var twice = line.concat(eol, line);
+        const twice = line.concat(eol, line);
         assert.notStrictEqual(twice.indentTail(10), twice);
         assert.strictEqual(twice.indentTail(0), twice);
 
@@ -268,8 +263,7 @@ describe("lines", function() {
     });
 
     it("Slice", function SliceTest() {
-        var code = String(SliceTest),
-            lines = fromString(code);
+        const code = String(SliceTest), lines = fromString(code);
         checkAllSlices(lines);
     });
 
@@ -290,15 +284,10 @@ describe("lines", function() {
     }
 
     it("GetSourceLocation", function GetSourceLocationTest() {
-        var code = String(GetSourceLocationTest),
-            lines = fromString(code);
+        const code = String(GetSourceLocationTest), lines = fromString(code);
 
         function verify(indent: any) {
-            var indented = lines.indentTail(indent),
-                loc = getSourceLocation(indented),
-                string = indented.toString(),
-                strings = string.split(eol),
-                lastLine = strings[strings.length - 1];
+            const indented = lines.indentTail(indent), loc = getSourceLocation(indented), string = indented.toString(), strings = string.split(eol), lastLine = strings[strings.length - 1];
 
             assert.strictEqual(loc.end.line, strings.length);
             assert.strictEqual(loc.end.column, lastLine.length);
@@ -313,12 +302,12 @@ describe("lines", function() {
     });
 
     it("Trim", function() {
-        var string = "  xxx " + eol + " ";
-        var options = { tabWidth: 4 };
+        const string = "  xxx " + eol + " ";
+        const options = { tabWidth: 4 };
         fromString(string);
 
         function test(string: string) {
-            var lines = fromString(string, options);
+            const lines = fromString(string, options);
             check(lines.trimLeft(), fromString(string.replace(/^\s+/, ""), options));
             check(lines.trimRight(), fromString(string.replace(/\s+$/, ""), options));
             check(lines.trim(), fromString(string.replace(/^\s+|\s+$/g, ""), options));
@@ -335,9 +324,7 @@ describe("lines", function() {
     });
 
     it("NoIndentEmptyLines", function() {
-        var lines = fromString("a" + eol + eol + "b"),
-            indented = lines.indent(4),
-            tailIndented = lines.indentTail(5);
+        const lines = fromString("a" + eol + eol + "b"), indented = lines.indent(4), tailIndented = lines.indentTail(5);
 
         check(indented, fromString("    a" + eol + eol + "    b"));
         check(tailIndented, fromString("a" + eol + eol + "     b"));
@@ -347,7 +334,7 @@ describe("lines", function() {
     });
 
     it("CountSpaces", function() {
-        var count = countSpaces;
+        const count = countSpaces;
 
         assert.strictEqual(count(""), 0);
         assert.strictEqual(count(" "), 1);
@@ -393,11 +380,11 @@ describe("lines", function() {
     });
 
     it("IndentWithTabs", function() {
-        var tabWidth = 4;
-        var tabOpts = { tabWidth: tabWidth, useTabs: true };
-        var noTabOpts = { tabWidth: tabWidth, useTabs: false };
+        const tabWidth = 4;
+        const tabOpts = { tabWidth: tabWidth, useTabs: true };
+        const noTabOpts = { tabWidth: tabWidth, useTabs: false };
 
-        var code = [
+        let code = [
             "function f() {",
             "\treturn this;",
             "}"
@@ -410,7 +397,7 @@ describe("lines", function() {
             check(lines.indent(-3).indent(4).indent(-1).toString(noTabOpts), code);
         }
 
-        var lines = fromString(code, tabOpts);
+        let lines = fromString(code, tabOpts);
         checkUnchanged(lines, code);
 
         check(lines.indent(1).toString(tabOpts), [
@@ -437,13 +424,13 @@ describe("lines", function() {
             "    }"
         ].join(eol));
 
-        var funkyCode = [
+        const funkyCode = [
             " function g() { \t ",
             " \t\t  return this;  ",
             "\t} "
         ].join(eol);
 
-        var funky = fromString(funkyCode, tabOpts);
+        const funky = fromString(funkyCode, tabOpts);
         checkUnchanged(funky, funkyCode);
 
         check(funky.indent(1).toString(tabOpts), [
@@ -496,7 +483,7 @@ describe("lines", function() {
     });
 
     it("GuessTabWidth", function GuessTabWidthTest(done) {
-        var lines;
+        let lines;
         lines = fromString([
             "function identity(x) {",
             "    return x;",
@@ -531,11 +518,11 @@ describe("lines", function() {
     });
 
     it("ExoticWhitespace", function() {
-        var source = "";
-        var spacePattern = /^\s+$/;
+        let source = "";
+        const spacePattern = /^\s+$/;
 
-        for (var i = 0; i < 0xffff; ++i) {
-            var ch = String.fromCharCode(i);
+        for (let i = 0; i < 0xffff; ++i) {
+            const ch = String.fromCharCode(i);
             if (spacePattern.test(ch)) {
                 source += ch;
             }
@@ -543,8 +530,8 @@ describe("lines", function() {
 
         source += "x";
 
-        var options = { tabWidth: 4 };
-        var lines = fromString(source, options);
+        const options = { tabWidth: 4 };
+        const lines = fromString(source, options);
 
         assert.strictEqual(lines.length, 5);
         assert.strictEqual(lines.getLineLength(1), options.tabWidth);

--- a/test/mapping.ts
+++ b/test/mapping.ts
@@ -2,9 +2,9 @@ import assert from "assert";
 import sourceMap from "source-map";
 import * as recast from "../main";
 import * as types from "ast-types";
-var n = types.namedTypes;
-var b = types.builders;
-var NodePath = types.NodePath;
+const n = types.namedTypes;
+const b = types.builders;
+const NodePath = types.NodePath;
 import { fromString } from "../lib/lines";
 import { parse } from "../lib/parser";
 import { Printer } from "../lib/printer";
@@ -12,30 +12,30 @@ import { EOL as eol } from "os";
 
 describe("source maps", function() {
     it("should generate correct mappings", function() {
-        var code = [
+        const code = [
             "function foo(bar) {",
             "  return 1 + bar;",
             "}"
         ].join(eol);
 
         fromString(code);
-        var ast = parse(code, {
+        const ast = parse(code, {
             sourceFileName: "source.js"
         });
 
-        var path = new NodePath(ast);
-        var returnPath = path.get("program", "body", 0, "body", "body", 0);
+        const path = new NodePath(ast);
+        const returnPath = path.get("program", "body", 0, "body", "body", 0);
         n.ReturnStatement.assert(returnPath.value);
 
-        var leftPath = returnPath.get("argument", "left");
-        var leftValue = leftPath.value;
-        var rightPath = returnPath.get("argument", "right");
+        const leftPath = returnPath.get("argument", "left");
+        const leftValue = leftPath.value;
+        const rightPath = returnPath.get("argument", "right");
 
         leftPath.replace(rightPath.value);
         rightPath.replace(leftValue);
 
-        var sourceRoot = "path/to/source/root";
-        var printed = new Printer({
+        const sourceRoot = "path/to/source/root";
+        const printed = new Printer({
             sourceMapName: "source.map.json",
             sourceRoot: sourceRoot
         }).print(ast);
@@ -52,7 +52,7 @@ describe("source maps", function() {
             sourceRoot
         );
 
-        var smc = new sourceMap.SourceMapConsumer(printed.map);
+        const smc = new sourceMap.SourceMapConsumer(printed.map);
 
         function check(origLine: any, origCol: any, genLine: any, genCol: any, lastColumn: any) {
             assert.deepEqual(smc.originalPositionFor({
@@ -98,7 +98,7 @@ describe("source maps", function() {
         function stripConsole(ast: any) {
             return recast.visit(ast, {
                 visitCallExpression: function(path) {
-                    var node = path.value;
+                    const node = path.value;
                     if (n.MemberExpression.check(node.callee) &&
                         n.Identifier.check(node.callee.object) &&
                         node.callee.object.name === "console") {
@@ -111,7 +111,7 @@ describe("source maps", function() {
             });
         }
 
-        var code = [
+        const code = [
             "function add(a, b) {",
             "  var sum = a + b;",
             "  console.log(a, b);",
@@ -119,23 +119,23 @@ describe("source maps", function() {
             "}"
         ].join(eol);
 
-        var ast = parse(code, {
+        const ast = parse(code, {
             sourceFileName: "original.js"
         });
 
-        var useStrictResult = new Printer({
+        const useStrictResult = new Printer({
             sourceMapName: "useStrict.map.json"
         }).print(addUseStrict(ast));
 
-        var useStrictAst = parse(useStrictResult.code, {
+        const useStrictAst = parse(useStrictResult.code, {
             sourceFileName: "useStrict.js"
         });
 
-        var oneStepResult = new Printer({
+        const oneStepResult = new Printer({
             sourceMapName: "oneStep.map.json"
         }).print(stripConsole(ast));
 
-        var twoStepResult = new Printer({
+        const twoStepResult = new Printer({
             sourceMapName: "twoStep.map.json",
             inputSourceMap: useStrictResult.map
         }).print(stripConsole(useStrictAst));
@@ -145,17 +145,17 @@ describe("source maps", function() {
             twoStepResult.code
         );
 
-        var smc1 = new sourceMap.SourceMapConsumer(oneStepResult.map);
-        var smc2 = new sourceMap.SourceMapConsumer(twoStepResult.map);
+        const smc1 = new sourceMap.SourceMapConsumer(oneStepResult.map);
+        const smc2 = new sourceMap.SourceMapConsumer(twoStepResult.map);
 
         smc1.eachMapping(function(mapping) {
-            var pos = {
+            const pos = {
                 line: mapping.generatedLine,
                 column: mapping.generatedColumn
             };
 
-            var orig1 = smc1.originalPositionFor(pos);
-            var orig2 = smc2.originalPositionFor(pos);
+            const orig1 = smc1.originalPositionFor(pos);
+            const orig2 = smc2.originalPositionFor(pos);
 
             // The composition of the source maps generated separately from
             // the two transforms should be equivalent to the source map
@@ -170,19 +170,19 @@ describe("source maps", function() {
 
     it("should work when a child node becomes null", function() {
         // https://github.com/facebook/regenerator/issues/103
-        var code = [
+        const code = [
             "for (var i = 0; false; i++)",
             "  log(i);"
         ].join(eol);
-        var ast = parse(code);
-        var path = new NodePath(ast);
+        const ast = parse(code);
+        const path = new NodePath(ast);
 
-        var updatePath = path.get("program", "body", 0, "update");
+        const updatePath = path.get("program", "body", 0, "update");
         n.UpdateExpression.assert(updatePath.value);
 
         updatePath.replace(null);
 
-        var printed = new Printer().print(ast);
+        const printed = new Printer().print(ast);
         assert.strictEqual(printed.code, [
             "for (var i = 0; false; )",
             "  log(i);"
@@ -190,15 +190,15 @@ describe("source maps", function() {
     });
 
     it("should tolerate programs that become empty", function() {
-        var source = "foo();";
-        var ast = recast.parse(source, {
+        const source = "foo();";
+        const ast = recast.parse(source, {
             sourceFileName: "foo.js"
         });
 
         assert.strictEqual(ast.program.body.length, 1);
         ast.program.body.length = 0;
 
-        var result = recast.print(ast, {
+        const result = recast.print(ast, {
             sourceMapName: "foo.map.json"
         });
 

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -13,7 +13,7 @@ const {
 } = types;
 
 function parseExpression(expr: any) {
-  var ast: any = esprima.parse(expr);
+  let ast: any = esprima.parse(expr);
   n.Program.assert(ast);
   ast = ast.body[0];
   return n.ExpressionStatement.check(ast) ? ast.expression : ast;
@@ -32,7 +32,7 @@ function check(expr: any) {
   );
 }
 
-var operators = [
+const operators = [
   "==", "!=", "===", "!==",
   "<", "<=", ">", ">=",
   "<<", ">>", ">>>",
@@ -132,41 +132,41 @@ describe("parens", function () {
   });
 
   it("ReprintedParens", function () {
-    var code = "a(function g(){}.call(this));";
-    var ast1 = parse(code);
-    var body = ast1.program.body;
+    const code = "a(function g(){}.call(this));";
+    const ast1 = parse(code);
+    const body = ast1.program.body;
 
     // Copy the function from a position where it does not need
     // parentheses to a position where it does need parentheses.
     body.push(b.expressionStatement(
       body[0].expression.arguments[0]));
 
-    var generic = printer.printGenerically(ast1).code;
-    var ast2 = parse(generic);
+    const generic = printer.printGenerically(ast1).code;
+    const ast2 = parse(generic);
     types.astNodesAreEquivalent.assert(ast1, ast2);
 
-    var reprint = printer.print(ast1).code;
-    var ast3 = parse(reprint);
+    let reprint = printer.print(ast1).code;
+    const ast3 = parse(reprint);
     types.astNodesAreEquivalent.assert(ast1, ast3);
 
     body.shift();
     reprint = printer.print(ast1).code;
-    var ast4 = parse(reprint);
+    const ast4 = parse(reprint);
     assert.strictEqual(ast4.program.body.length, 1);
-    var callExp = ast4.program.body[0].expression;
+    const callExp = ast4.program.body[0].expression;
     n.CallExpression.assert(callExp);
     n.MemberExpression.assert(callExp.callee);
     n.FunctionExpression.assert(callExp.callee.object);
     types.astNodesAreEquivalent.assert(ast1, ast4);
 
-    var objCode = "({ foo: 42 }.foo);";
-    var objAst = parse(objCode);
-    var memExp = objAst.program.body[0].expression;
+    const objCode = "({ foo: 42 }.foo);";
+    const objAst = parse(objCode);
+    const memExp = objAst.program.body[0].expression;
     n.MemberExpression.assert(memExp);
     n.ObjectExpression.assert(memExp.object);
     n.Identifier.assert(memExp.property);
     assert.strictEqual(memExp.property.name, "foo");
-    var blockStmt = b.blockStatement([b.expressionStatement(memExp)]);
+    const blockStmt = b.blockStatement([b.expressionStatement(memExp)]);
     reprint = printer.print(blockStmt).code;
     types.astNodesAreEquivalent.assert(
       blockStmt,
@@ -175,36 +175,36 @@ describe("parens", function () {
   });
 
   it("don't reparenthesize valid IIFEs", function () {
-    var iifeCode = "(function     spaces   () {        }.call()  )  ;";
-    var iifeAst = parse(iifeCode);
-    var iifeReprint = printer.print(iifeAst).code;
+    const iifeCode = "(function     spaces   () {        }.call()  )  ;";
+    const iifeAst = parse(iifeCode);
+    const iifeReprint = printer.print(iifeAst).code;
     assert.strictEqual(iifeReprint, iifeCode);
   });
 
   it("don't reparenthesize valid object literals", function () {
-    var objCode = "(  {    foo   :  42}.  foo )  ;";
-    var objAst = parse(objCode);
-    var objReprint = printer.print(objAst).code;
+    const objCode = "(  {    foo   :  42}.  foo )  ;";
+    const objAst = parse(objCode);
+    const objReprint = printer.print(objAst).code;
     assert.strictEqual(objReprint, objCode);
   });
 
   it("don't parenthesize return statements with sequence expressions", function () {
-    var objCode = "function foo() { return 1, 2; }";
-    var objAst = parse(objCode);
-    var objReprint = printer.print(objAst).code;
+    const objCode = "function foo() { return 1, 2; }";
+    const objAst = parse(objCode);
+    const objReprint = printer.print(objAst).code;
     assert.strictEqual(objReprint, objCode);
   });
 
   it("NegatedLoopCondition", function () {
-    var ast = parse([
+    const ast = parse([
       "for (var i = 0; i < 10; ++i) {",
       "  console.log(i);",
       "}"
-    ].join(eol))
+    ].join(eol));
 
-    var loop = ast.program.body[0];
-    var test = loop.test;
-    var negation = b.unaryExpression("!", test);
+    const loop = ast.program.body[0];
+    const test = loop.test;
+    const negation = b.unaryExpression("!", test);
 
     assert.strictEqual(
       printer.print(negation).code,
@@ -221,7 +221,7 @@ describe("parens", function () {
   });
 
   it("MisleadingExistingParens", function () {
-    var ast = parse([
+    const ast = parse([
       // The key === "oyez" expression appears to have parentheses
       // already, but those parentheses won't help us when we negate the
       // condition with a !.
@@ -230,10 +230,10 @@ describe("parens", function () {
       "}"
     ].join(eol));
 
-    var ifStmt = ast.program.body[0];
+    const ifStmt = ast.program.body[0];
     ifStmt.test = b.unaryExpression("!", ifStmt.test);
 
-    var binaryPath = new NodePath(ast).get(
+    const binaryPath = new NodePath(ast).get(
       "program", "body", 0, "test", "argument");
 
     assert.ok(binaryPath.needsParens());
@@ -246,15 +246,15 @@ describe("parens", function () {
   });
 
   it("DiscretionaryParens", function () {
-    var code = [
+    const code = [
       "if (info.line && (i > 0 || !skipFirstLine)) {",
       "  info = copyLineInfo(info);",
       "}"
     ].join(eol);
 
-    var ast = parse(code);
+    const ast = parse(code);
 
-    var rightPath = new NodePath(ast).get(
+    const rightPath = new NodePath(ast).get(
       "program", "body", 0, "test", "right");
 
     assert.ok(rightPath.needsParens());
@@ -262,7 +262,7 @@ describe("parens", function () {
   });
 
   it("should not be added to multiline boolean expressions", function () {
-    var code = [
+    const code = [
       "function foo() {",
       "  return !(",
       "    a &&",
@@ -272,8 +272,8 @@ describe("parens", function () {
       "}"
     ].join(eol);
 
-    var ast = parse(code);
-    var printer = new Printer({
+    const ast = parse(code);
+    const printer = new Printer({
       tabWidth: 2
     });
 

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -4,10 +4,10 @@ import { getReprinter } from "../lib/patcher";
 import { Printer } from "../lib/printer";
 import { fromString } from "../lib/lines";
 import * as types from "ast-types";
-var namedTypes = types.namedTypes;
+const namedTypes = types.namedTypes;
 import FastPath from "../lib/fast-path";
 import { EOL as eol } from "os";
-var nodeMajorVersion = parseInt(process.versions.node, 10);
+const nodeMajorVersion = parseInt(process.versions.node, 10);
 
 // Esprima seems unable to handle unnamed top-level functions, so declare
 // test functions with names and then export them later.
@@ -21,10 +21,10 @@ describe("parser", function() {
   ].forEach(runTestsForParser);
 
   it("AlternateParser", function() {
-    var b = types.builders;
-    var parser = {
+    const b = types.builders;
+    const parser = {
       parse: function() {
-        var program = b.program([
+        const program = b.program([
           b.expressionStatement(b.identifier("surprise"))
         ]);
         program.comments = [];
@@ -33,8 +33,8 @@ describe("parser", function() {
     };
 
     function check(options?: any) {
-      var ast = parse("ignored", options);
-      var printer = new Printer;
+      const ast = parse("ignored", options);
+      const printer = new Printer;
 
       types.namedTypes.File.assert(ast, true);
       assert.strictEqual(
@@ -66,10 +66,10 @@ function runTestsForParser(parserId: string) {
   const parser = require(parserId);
 
   it("[" + parserName + "] empty source", function () {
-    var printer = new Printer;
+    const printer = new Printer;
 
     function check(code: string) {
-      var ast = parse(code, { parser });
+      const ast = parse(code, { parser });
       assert.strictEqual(printer.print(ast).code, code);
     }
 
@@ -91,21 +91,21 @@ function runTestsForParser(parserId: string) {
   };
 
   it("[" + parserName + "] parser basics", function testParser(done) {
-    var code = testParser + "";
-    var ast = parse(code, { parser });
+    const code = testParser + "";
+    const ast = parse(code, { parser });
 
     namedTypes.File.assert(ast);
     assert.ok(getReprinter(FastPath.from(ast)));
 
-    var funDecl = ast.program.body[0];
-    var funBody = funDecl.body;
+    const funDecl = ast.program.body[0];
+    const funBody = funDecl.body;
 
     namedTypes.FunctionDeclaration.assert(funDecl);
     namedTypes.BlockStatement.assert(funBody);
     assert.ok(getReprinter(FastPath.from(funBody)));
 
-    var lastStatement = funBody.body.pop();
-    var doneCall = lastStatement.expression;
+    const lastStatement = funBody.body.pop();
+    const doneCall = lastStatement.expression;
 
     assert.ok(!getReprinter(FastPath.from(funBody)));
     assert.ok(getReprinter(FastPath.from(ast)));
@@ -117,7 +117,7 @@ function runTestsForParser(parserId: string) {
 
     assert.strictEqual(lastStatement.comments.length, 2);
 
-    var firstComment = lastStatement.comments[0];
+    const firstComment = lastStatement.comments[0];
 
     assert.strictEqual(
       firstComment.type,
@@ -131,7 +131,7 @@ function runTestsForParser(parserId: string) {
       " Make sure done() remains the final statement in this function,"
     );
 
-    var secondComment = lastStatement.comments[1];
+    const secondComment = lastStatement.comments[1];
 
     assert.strictEqual(
       secondComment.type,
@@ -151,14 +151,14 @@ function runTestsForParser(parserId: string) {
   });
 
   it("[" + parserName + "] LocationFixer", function() {
-    var code = [
+    const code = [
       "function foo() {",
       "    a()",
       "    b()",
       "}"
     ].join(eol);
-    var ast = parse(code, { parser });
-    var printer = new Printer;
+    const ast = parse(code, { parser });
+    const printer = new Printer;
 
     types.visit(ast, {
       visitFunctionDeclaration: function(path) {
@@ -169,7 +169,7 @@ function runTestsForParser(parserId: string) {
       }
     });
 
-    var altered = code
+    const altered = code
       .replace("a()", "xxx")
       .replace("b()", "a()")
       .replace("xxx", "b()");
@@ -179,11 +179,11 @@ function runTestsForParser(parserId: string) {
 
   it("[" + parserName + "] TabHandling", function() {
     function check(code: string, tabWidth: number) {
-      var lines = fromString(code, { tabWidth: tabWidth });
+      const lines = fromString(code, { tabWidth: tabWidth });
       assert.strictEqual(lines.length, 1);
 
       function checkId(s: any, loc: types.namedTypes.SourceLocation) {
-        var sliced = lines.slice(loc.start, loc.end);
+        const sliced = lines.slice(loc.start, loc.end);
         assert.strictEqual(s + "", sliced.toString());
       }
 
@@ -192,20 +192,20 @@ function runTestsForParser(parserId: string) {
         parser,
       }), {
         visitIdentifier(path) {
-          var ident = path.node;
+          const ident = path.node;
           checkId(ident.name, ident.loc!);
           this.traverse(path);
         },
 
         visitLiteral(path) {
-          var lit = path.node;
+          const lit = path.node;
           checkId(lit.value, lit.loc!);
           this.traverse(path);
         }
       });
     }
 
-    for (var tabWidth = 1; tabWidth <= 8; ++tabWidth) {
+    for (let tabWidth = 1; tabWidth <= 8; ++tabWidth) {
       check("\t\ti = 10;", tabWidth);
       check("\t\ti \t= 10;", tabWidth);
       check("\t\ti \t=\t 10;", tabWidth);

--- a/test/patcher.ts
+++ b/test/patcher.ts
@@ -1,15 +1,15 @@
 import assert from "assert";
 import * as recast from "../main";
 import * as types from "ast-types";
-var n = types.namedTypes;
-var b = types.builders;
+const n = types.namedTypes;
+const b = types.builders;
 import { getReprinter, Patcher } from "../lib/patcher";
 import { fromString } from "../lib/lines";
 import { parse } from "../lib/parser";
 import FastPath from "../lib/fast-path";
 import { EOL as eol } from "os";
 
-var code = [
+const code = [
   "// file comment",
   "exports.foo({",
   "    // some comment",
@@ -27,9 +27,7 @@ function loc(sl: number, sc: number, el: number, ec: number) {
 
 describe("patcher", function() {
   it("Patcher", function() {
-    var lines = fromString(code.join(eol)),
-    patcher = new Patcher(lines),
-    selfLoc = loc(5, 9, 5, 13);
+    let lines = fromString(code.join(eol)), patcher = new Patcher(lines), selfLoc = loc(5, 9, 5, 13);
 
     assert.strictEqual(patcher.get(selfLoc).toString(), "this");
 
@@ -37,14 +35,13 @@ describe("patcher", function() {
 
     assert.strictEqual(patcher.get(selfLoc).toString(), "self");
 
-    var got = patcher.get().toString();
+    const got = patcher.get().toString();
     assert.strictEqual(got, code.join(eol).replace("this", "self"));
 
     // Make sure comments are preserved.
     assert.ok(got.indexOf("// some") >= 0);
 
-    var oyezLoc = loc(2, 12, 6, 1),
-    beforeOyez = patcher.get(oyezLoc).toString();
+    const oyezLoc = loc(2, 12, 6, 1), beforeOyez = patcher.get(oyezLoc).toString();
     assert.strictEqual(beforeOyez.indexOf("exports"), -1);
     assert.ok(beforeOyez.indexOf("comment") >= 0);
 
@@ -66,7 +63,7 @@ describe("patcher", function() {
     ].join(eol));
   });
 
-  var trickyCode = [
+  const trickyCode = [
     "    function",
     "      foo(bar,",
     "  baz) {",
@@ -76,13 +73,13 @@ describe("patcher", function() {
 
   it("GetIndent", function() {
     function check(indent: number) {
-      var lines = fromString(trickyCode).indent(indent);
-      var file = parse(lines.toString());
-      var reprinter = FastPath.from(file).call(function(bodyPath: any) {
+      const lines = fromString(trickyCode).indent(indent);
+      const file = parse(lines.toString());
+      const reprinter = FastPath.from(file).call(function(bodyPath: any) {
         return getReprinter(bodyPath);
       }, "program", "body", 0, "body");
 
-      var reprintedLines = reprinter(function() {
+      const reprintedLines = reprinter(function() {
         assert.ok(false, "should not have called print function");
       });
 
@@ -97,14 +94,14 @@ describe("patcher", function() {
       ].join(eol));
     }
 
-    for (var indent = -4; indent <= 4; ++indent) {
+    for (let indent = -4; indent <= 4; ++indent) {
       check(indent);
     }
   });
 
   it("should patch return/throw/etc. arguments correctly", function() {
-    var strAST = parse('return"foo"');
-    var returnStmt = strAST.program.body[0];
+    const strAST = parse('return"foo"');
+    const returnStmt = strAST.program.body[0];
     n.ReturnStatement.assert(returnStmt);
     assert.strictEqual(
       recast.print(strAST).code,
@@ -117,8 +114,8 @@ describe("patcher", function() {
       "return null;" // Instead of returnnull.
     );
 
-    var arrAST = parse("throw[1,2,3]");
-    var throwStmt = arrAST.program.body[0];
+    const arrAST = parse("throw[1,2,3]");
+    const throwStmt = arrAST.program.body[0];
     n.ThrowStatement.assert(throwStmt);
     assert.strictEqual(
       recast.print(arrAST).code,
@@ -131,8 +128,8 @@ describe("patcher", function() {
       "throw false" // Instead of throwfalse.
     );
 
-    var inAST = parse('"foo"in bar');
-    var inExpr = inAST.program.body[0].expression;
+    const inAST = parse('"foo"in bar');
+    const inExpr = inAST.program.body[0].expression;
 
     n.BinaryExpression.assert(inExpr);
     assert.strictEqual(inExpr.operator, "in");
@@ -153,15 +150,15 @@ describe("patcher", function() {
   });
 
   it("should not add spaces to the beginnings of lines", function() {
-    var twoLineCode = [
+    const twoLineCode = [
       "return", // Because of ASI rules, these two lines will
       'xxx'     // parse as separate statements.
     ].join(eol);
 
-    var twoLineAST = parse(twoLineCode);
+    const twoLineAST = parse(twoLineCode);
 
     assert.strictEqual(twoLineAST.program.body.length, 2);
-    var xxx = twoLineAST.program.body[1];
+    const xxx = twoLineAST.program.body[1];
     n.ExpressionStatement.assert(xxx);
     n.Identifier.assert(xxx.expression);
     assert.strictEqual(xxx.expression.name, "xxx");
@@ -173,7 +170,7 @@ describe("patcher", function() {
 
     xxx.expression = b.identifier("expression");
 
-    var withExpression = recast.print(twoLineAST).code;
+    const withExpression = recast.print(twoLineAST).code;
     assert.strictEqual(withExpression, [
       "return",
       "expression" // The key is that no space should be added to the
@@ -184,7 +181,7 @@ describe("patcher", function() {
       b.callExpression(b.identifier("foo"), [])
     );
 
-    var withFooCall = recast.print(twoLineAST).code;
+    const withFooCall = recast.print(twoLineAST).code;
     assert.strictEqual(withFooCall, [
       "return",
       "foo()"

--- a/test/perf.ts
+++ b/test/perf.ts
@@ -2,16 +2,16 @@ import path from "path";
 import fs from "fs";
 import * as recast from "../main";
 
-var source = fs.readFileSync(
+const source = fs.readFileSync(
     path.join(__dirname, "data", "backbone.js"),
     "utf8"
 );
 
-var start = +new Date;
-var ast = recast.parse(source);
-var types = Object.create(null);
+const start = +new Date;
+const ast = recast.parse(source);
+const types = Object.create(null);
 
-var parseTime = +new Date - start;
+const parseTime = +new Date - start;
 console.log("parse", parseTime, "ms");
 
 recast.visit(ast, {
@@ -21,12 +21,12 @@ recast.visit(ast, {
     }
 });
 
-var visitTime = +new Date - start - parseTime;
+const visitTime = +new Date - start - parseTime;
 console.log("visit", visitTime, "ms");
 
 recast.prettyPrint(ast).code;
 
-var printTime = +new Date - start - visitTime - parseTime;
+const printTime = +new Date - start - visitTime - parseTime;
 console.log("print", printTime, "ms");
 
 console.log("total", +new Date - start, "ms");

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -3,23 +3,23 @@ import * as recast from "../main";
 import { parse } from "../lib/parser";
 import { Printer } from "../lib/printer";
 import * as types from "ast-types";
-var n = types.namedTypes;
-var b = types.builders;
+const n = types.namedTypes;
+const b = types.builders;
 import { fromString } from "../lib/lines";
 import { EOL as eol } from "os";
-var linesModule = require("../lib/lines");
-var nodeMajorVersion = parseInt(process.versions.node, 10);
+const linesModule = require("../lib/lines");
+const nodeMajorVersion = parseInt(process.versions.node, 10);
 
 describe("printer", function() {
   it("Printer", function testPrinter(done) {
-    var code = testPrinter + "";
-    var ast = parse(code);
-    var printer = new Printer;
+    const code = testPrinter + "";
+    const ast = parse(code);
+    const printer = new Printer;
 
     assert.strictEqual(typeof printer.print, "function");
     assert.strictEqual(printer.print(null).code, "");
 
-    var string = printer.printGenerically(ast).code;
+    let string = printer.printGenerically(ast).code;
     assert.ok(string.indexOf("done();") > 0);
 
     string = printer.print(ast).code;
@@ -31,7 +31,7 @@ describe("printer", function() {
     done();
   });
 
-  var uselessSemicolons = [
+  const uselessSemicolons = [
     'function a() {',
     '  return "a";',
     '};',
@@ -42,46 +42,46 @@ describe("printer", function() {
   ].join(eol);
 
   it("EmptyStatements", function() {
-    var ast = parse(uselessSemicolons);
-    var printer = new Printer({ tabWidth: 2 });
+    const ast = parse(uselessSemicolons);
+    const printer = new Printer({ tabWidth: 2 });
 
-    var reprinted = printer.print(ast).code;
+    const reprinted = printer.print(ast).code;
     assert.strictEqual(typeof reprinted, "string");
     assert.strictEqual(reprinted, uselessSemicolons);
 
-    var generic = printer.printGenerically(ast).code;
-    var withoutTrailingSemicolons = uselessSemicolons.replace(/\};/g, "}");
+    const generic = printer.printGenerically(ast).code;
+    const withoutTrailingSemicolons = uselessSemicolons.replace(/\};/g, "}");
     assert.strictEqual(typeof generic, "string");
     assert.strictEqual(generic, withoutTrailingSemicolons);
   });
 
-  var importantSemicolons = [
+  const importantSemicolons = [
     "var a = {};", // <--- this trailing semi-colon is very important
     "(function() {})();"
   ].join(eol);
 
   it("IffeAfterVariableDeclarationEndingInObjectLiteral", function() {
-    var ast = parse(importantSemicolons);
-    var printer = new Printer({ tabWidth: 2 });
+    const ast = parse(importantSemicolons);
+    const printer = new Printer({ tabWidth: 2 });
 
-    var reprinted = printer.printGenerically(ast).code;
+    const reprinted = printer.printGenerically(ast).code;
     assert.strictEqual(typeof reprinted, "string");
     assert.strictEqual(reprinted, importantSemicolons);
   });
 
-  var arrayExprWithTrailingComma = '[1, 2,];';
-  var arrayExprWithoutTrailingComma = '[1, 2];';
+  const arrayExprWithTrailingComma = '[1, 2,];';
+  const arrayExprWithoutTrailingComma = '[1, 2];';
 
   it("ArrayExpressionWithTrailingComma", function() {
-    var ast = parse(arrayExprWithTrailingComma);
-    var printer = new Printer({ tabWidth: 2 });
+    const ast = parse(arrayExprWithTrailingComma);
+    const printer = new Printer({ tabWidth: 2 });
 
-    var body = ast.program.body;
-    var arrayExpr = body[0].expression;
+    const body = ast.program.body;
+    const arrayExpr = body[0].expression;
     n.ArrayExpression.assert(arrayExpr);
 
     // This causes the array expression to be reprinted.
-    var arrayExprOrig = arrayExpr.original;
+    const arrayExprOrig = arrayExpr.original;
     arrayExpr.original = null;
 
     assert.strictEqual(
@@ -97,18 +97,18 @@ describe("printer", function() {
     );
   });
 
-  var arrayExprWithHoles = '[,,];';
+  const arrayExprWithHoles = '[,,];';
 
   it("ArrayExpressionWithHoles", function() {
-    var ast = parse(arrayExprWithHoles);
-    var printer = new Printer({ tabWidth: 2 });
+    const ast = parse(arrayExprWithHoles);
+    const printer = new Printer({ tabWidth: 2 });
 
-    var body = ast.program.body;
-    var arrayExpr = body[0].expression;
+    const body = ast.program.body;
+    const arrayExpr = body[0].expression;
     n.ArrayExpression.assert(arrayExpr);
 
     // This causes the array expression to be reprinted.
-    var arrayExprOrig = arrayExpr.original;
+    const arrayExprOrig = arrayExpr.original;
     arrayExpr.original = null;
 
     assert.strictEqual(
@@ -124,19 +124,19 @@ describe("printer", function() {
     );
   });
 
-  var objectExprWithTrailingComma = '({x: 1, y: 2,});';
-  var objectExprWithoutTrailingComma = '({' + eol + '  x: 1,' + eol + '  y: 2' + eol + '});';
+  const objectExprWithTrailingComma = '({x: 1, y: 2,});';
+  const objectExprWithoutTrailingComma = '({' + eol + '  x: 1,' + eol + '  y: 2' + eol + '});';
 
   it("ArrayExpressionWithTrailingComma", function() {
-    var ast = parse(objectExprWithTrailingComma);
-    var printer = new Printer({ tabWidth: 2 });
+    const ast = parse(objectExprWithTrailingComma);
+    const printer = new Printer({ tabWidth: 2 });
 
-    var body = ast.program.body;
-    var objectExpr = body[0].expression;
+    const body = ast.program.body;
+    const objectExpr = body[0].expression;
     n.ObjectExpression.assert(objectExpr);
 
     // This causes the array expression to be reprinted.
-    var objectExprOrig = objectExpr.original;
+    const objectExprOrig = objectExpr.original;
     objectExpr.original = null;
 
     assert.strictEqual(
@@ -152,7 +152,7 @@ describe("printer", function() {
     );
   });
 
-  var switchCase = [
+  const switchCase = [
     "switch (test) {",
     "  default:",
     "  case a: break",
@@ -162,7 +162,7 @@ describe("printer", function() {
     "}",
   ].join(eol);
 
-  var switchCaseReprinted = [
+  const switchCaseReprinted = [
     "if (test) {",
     "  switch (test) {",
     "  default:",
@@ -173,7 +173,7 @@ describe("printer", function() {
     "}"
   ].join(eol);
 
-  var switchCaseGeneric = [
+  const switchCaseGeneric = [
     "if (test) {",
     "  switch (test) {",
     "  default:",
@@ -186,11 +186,11 @@ describe("printer", function() {
   ].join(eol);
 
   it("SwitchCase", function() {
-    var ast = parse(switchCase);
-    var printer = new Printer({ tabWidth: 2 });
+    const ast = parse(switchCase);
+    const printer = new Printer({ tabWidth: 2 });
 
-    var body = ast.program.body;
-    var switchStmt = body[0];
+    const body = ast.program.body;
+    const switchStmt = body[0];
     n.SwitchStatement.assert(switchStmt);
 
     // This causes the switch statement to be reprinted.
@@ -214,7 +214,7 @@ describe("printer", function() {
     );
   });
 
-  var tryCatch = [
+  const tryCatch = [
     "try {",
     "  a();",
     "} catch (e) {",
@@ -223,17 +223,17 @@ describe("printer", function() {
   ].join(eol);
 
   it("IndentTryCatch", function() {
-    var ast = parse(tryCatch);
-    var printer = new Printer({ tabWidth: 2 });
-    var body = ast.program.body;
-    var tryStmt = body[0];
+    const ast = parse(tryCatch);
+    const printer = new Printer({ tabWidth: 2 });
+    const body = ast.program.body;
+    const tryStmt = body[0];
     n.TryStatement.assert(tryStmt);
 
     // Force reprinting.
     assert.strictEqual(printer.printGenerically(ast).code, tryCatch);
   });
 
-  var classBody = [
+  const classBody = [
     "class A {",
     "  foo(x) { return x }",
     "  bar(y) { this.foo(y); }",
@@ -244,7 +244,7 @@ describe("printer", function() {
     "}"
   ];
 
-  var classBodyExpected = [
+  const classBodyExpected = [
     "class A {",
     "  foo(x) { return x }",
     "  bar(y) { this.foo(y); }",
@@ -257,15 +257,15 @@ describe("printer", function() {
   ];
 
   it("MethodPrinting", function() {
-    var code = classBody.join(eol);
+    const code = classBody.join(eol);
     try {
       var ast = parse(code);
     } catch (e) {
       // ES6 not supported, silently finish
       return;
     }
-    var printer = new Printer({ tabWidth: 2 });
-    var cb = ast.program.body[0].body;
+    const printer = new Printer({ tabWidth: 2 });
+    const cb = ast.program.body[0].body;
     n.ClassBody.assert(cb);
 
     // Trigger reprinting of the class body.
@@ -277,7 +277,7 @@ describe("printer", function() {
     );
   });
 
-  var multiLineParams = [
+  const multiLineParams = [
     "function f(/* first",
     "              xxx",
     "              param */ a,",
@@ -289,7 +289,7 @@ describe("printer", function() {
     "}"
   ];
 
-  var multiLineParamsExpected = [
+  const multiLineParamsExpected = [
     "function f(",
     "  /* first",
     "     xxx",
@@ -305,9 +305,9 @@ describe("printer", function() {
   ];
 
   it("MultiLineParams", function() {
-    var code = multiLineParams.join(eol);
-    var ast = parse(code);
-    var printer = new Printer({ tabWidth: 2 });
+    const code = multiLineParams.join(eol);
+    const ast = parse(code);
+    const printer = new Printer({ tabWidth: 2 });
 
     recast.visit(ast, {
       visitNode: function(path) {
@@ -323,8 +323,8 @@ describe("printer", function() {
   });
 
   it("SimpleVarPrinting", function() {
-    var printer = new Printer({ tabWidth: 2 });
-    var varDecl = b.variableDeclaration("var", [
+    const printer = new Printer({ tabWidth: 2 });
+    const varDecl = b.variableDeclaration("var", [
       b.variableDeclarator(b.identifier("x"), null),
       b.variableDeclarator(b.identifier("y"), null),
       b.variableDeclarator(b.identifier("z"), null)
@@ -335,7 +335,7 @@ describe("printer", function() {
       "var x, y, z;"
     );
 
-    var z: any = varDecl.declarations.pop();
+    const z: any = varDecl.declarations.pop();
     varDecl.declarations.pop();
     varDecl.declarations.push(z);
 
@@ -346,8 +346,8 @@ describe("printer", function() {
   });
 
   it("MultiLineVarPrinting", function() {
-    var printer = new Printer({ tabWidth: 2 });
-    var varDecl = b.variableDeclaration("var", [
+    const printer = new Printer({ tabWidth: 2 });
+    const varDecl = b.variableDeclaration("var", [
       b.variableDeclarator(b.identifier("x"), null),
       b.variableDeclarator(
         b.identifier("y"),
@@ -368,8 +368,8 @@ describe("printer", function() {
   });
 
   it("ForLoopPrinting", function() {
-    var printer = new Printer({ tabWidth: 2 });
-    var loop = b.forStatement(
+    const printer = new Printer({ tabWidth: 2 });
+    const loop = b.forStatement(
       b.variableDeclaration("var", [
         b.variableDeclarator(b.identifier("i"), b.literal(0))
       ]),
@@ -388,8 +388,8 @@ describe("printer", function() {
   });
 
   it("EmptyForLoopPrinting", function() {
-    var printer = new Printer({ tabWidth: 2 });
-    var loop = b.forStatement(
+    const printer = new Printer({ tabWidth: 2 });
+    const loop = b.forStatement(
       b.variableDeclaration("var", [
         b.variableDeclarator(b.identifier("i"), b.literal(0))
       ]),
@@ -406,8 +406,8 @@ describe("printer", function() {
   });
 
   it("ForInLoopPrinting", function() {
-    var printer = new Printer({ tabWidth: 2 });
-    var loop = b.forInStatement(
+    const printer = new Printer({ tabWidth: 2 });
+    const loop = b.forInStatement(
       b.variableDeclaration("var", [
         b.variableDeclarator(b.identifier("key"), null)
       ]),
@@ -425,32 +425,32 @@ describe("printer", function() {
   });
 
   it("GuessTabWidth", function() {
-    var code = [
+    const code = [
       "function identity(x) {",
       "  return x;",
       "}"
     ].join(eol);
 
-    var guessedTwo = [
+    const guessedTwo = [
       "function identity(x) {",
       "  log(x);",
       "  return x;",
       "}"
     ].join(eol);
 
-    var explicitFour = [
+    const explicitFour = [
       "function identity(x) {",
       "    log(x);",
       "    return x;",
       "}"
     ].join(eol);
 
-    var ast = parse(code);
+    const ast = parse(code);
 
-    var funDecl = ast.program.body[0];
+    const funDecl = ast.program.body[0];
     n.FunctionDeclaration.assert(funDecl);
 
-    var funBody = funDecl.body.body;
+    const funBody = funDecl.body.body;
 
     funBody.unshift(
       b.expressionStatement(
@@ -475,8 +475,8 @@ describe("printer", function() {
   });
 
   it("FunctionDefaultsAndRest", function() {
-    var printer = new Printer();
-    var funExpr = b.functionExpression(
+    const printer = new Printer();
+    const funExpr = b.functionExpression(
       b.identifier('a'),
       [b.identifier('b'), b.identifier('c')],
       b.blockStatement([]),
@@ -492,7 +492,7 @@ describe("printer", function() {
       "function a(b, c = 1, ...d) {}"
     );
 
-    var arrowFunExpr = b.arrowFunctionExpression(
+    const arrowFunExpr = b.arrowFunctionExpression(
       [b.identifier('b'), b.identifier('c')],
       b.blockStatement([]),
       false);
@@ -507,8 +507,8 @@ describe("printer", function() {
   });
 
   it("generically prints parsed code and generated code the same way", function() {
-    var printer = new Printer();
-    var ast = b.program([
+    const printer = new Printer();
+    const ast = b.program([
       b.expressionStatement(b.literal(1)),
       b.expressionStatement(b.literal(2))
     ]);
@@ -520,9 +520,9 @@ describe("printer", function() {
   });
 
   it("ExportDeclaration semicolons", function() {
-    var printer = new Printer();
-    var code = "export var foo = 42;";
-    var ast = parse(code);
+    const printer = new Printer();
+    let code = "export var foo = 42;";
+    let ast = parse(code);
 
     assert.strictEqual(printer.print(ast).code, code);
     assert.strictEqual(printer.printGenerically(ast).code, code);
@@ -547,17 +547,17 @@ describe("printer", function() {
   });
 
   it("empty ExportDeclaration", function() {
-    var printer = new Printer();
-    var code = "export {};";
-    var ast = parse(code);
+    const printer = new Printer();
+    const code = "export {};";
+    const ast = parse(code);
 
     assert.strictEqual(printer.print(ast).code, code);
     assert.strictEqual(printer.printGenerically(ast).code, code);
   });
 
   it("export default of IIFE", function() {
-    var printer = new Printer();
-    var ast = b.exportDefaultDeclaration(
+    const printer = new Printer();
+    let ast = b.exportDefaultDeclaration(
       b.callExpression(
         b.functionExpression(
           null,
@@ -567,14 +567,14 @@ describe("printer", function() {
         []
       )
     );
-    var code = printer.print(ast).code;
+    const code = printer.print(ast).code;
     ast = parse(code);
 
     assert.strictEqual(printer.print(ast).code, code);
     assert.strictEqual(printer.printGenerically(ast).code, code);
   });
 
-  var stmtListSpaces = [
+  const stmtListSpaces = [
     "",
     "var x = 1;",
     "",
@@ -589,7 +589,7 @@ describe("printer", function() {
     ""
   ].join(eol);
 
-  var stmtListSpacesExpected = [
+  const stmtListSpacesExpected = [
     "",
     "debugger;",
     "var x = 1;",
@@ -609,9 +609,9 @@ describe("printer", function() {
   ].join(eol);
 
   it("Statement list whitespace reuse", function() {
-    var ast = parse(stmtListSpaces);
-    var printer = new Printer({ tabWidth: 2 });
-    var debugStmt = b.expressionStatement(b.identifier("debugger"));
+    const ast = parse(stmtListSpaces);
+    const printer = new Printer({ tabWidth: 2 });
+    const debugStmt = b.expressionStatement(b.identifier("debugger"));
 
     ast.program.body.splice(2, 0, debugStmt);
     ast.program.body.unshift(debugStmt);
@@ -622,7 +622,7 @@ describe("printer", function() {
       stmtListSpacesExpected
     );
 
-    var funDecl = b.functionDeclaration(
+    const funDecl = b.functionDeclaration(
       b.identifier("foo"),
       [],
       b.blockStatement(ast.program.body)
@@ -641,17 +641,17 @@ describe("printer", function() {
   });
 
   it("should print static methods with the static keyword", function() {
-    var printer = new Printer({ tabWidth: 4 });
-    var ast = parse([
+    const printer = new Printer({ tabWidth: 4 });
+    const ast = parse([
       "class A {",
       "  static foo() {}",
       "}"
     ].join(eol));
 
-    var classBody = ast.program.body[0].body;
+    const classBody = ast.program.body[0].body;
     n.ClassBody.assert(classBody);
 
-    var foo = classBody.body[0];
+    const foo = classBody.body[0];
     n.MethodDefinition.assert(foo);
 
     classBody.body.push(foo);
@@ -667,17 +667,17 @@ describe("printer", function() {
   });
 
   it("should print string literals with the specified delimiter", function() {
-    var ast = parse([
+    const ast = parse([
       "var obj = {",
       "    \"foo's\": 'bar',",
       "    '\"bar\\'s\"': /regex/m",
       "};"
     ].join(eol));
 
-    var variableDeclaration = ast.program.body[0];
+    const variableDeclaration = ast.program.body[0];
     n.VariableDeclaration.assert(variableDeclaration);
 
-    var printer = new Printer({ quote: "single" });
+    const printer = new Printer({ quote: "single" });
     assert.strictEqual(printer.printGenerically(ast).code, [
       "var obj = {",
       "    'foo\\'s': 'bar',",
@@ -685,7 +685,7 @@ describe("printer", function() {
       "};"
     ].join(eol));
 
-    var printer2 = new Printer({ quote: "double" });
+    const printer2 = new Printer({ quote: "double" });
     assert.strictEqual(printer2.printGenerically(ast).code, [
       "var obj = {",
       "    \"foo's\": \"bar\",",
@@ -693,7 +693,7 @@ describe("printer", function() {
       "};"
     ].join(eol));
 
-    var printer3 = new Printer({ quote: "auto" });
+    const printer3 = new Printer({ quote: "auto" });
     assert.strictEqual(printer3.printGenerically(ast).code, [
       "var obj = {",
       '    "foo\'s": "bar",',
@@ -704,7 +704,7 @@ describe("printer", function() {
 
   it("should print block comments at head of class once", function() {
     // Given.
-    var ast = parse([
+    const ast = parse([
       "/**",
       " * This class was in an IIFE and returned an instance of itself.",
       " */",
@@ -712,15 +712,15 @@ describe("printer", function() {
       "};"
     ].join(eol));
 
-    var classIdentifier = b.identifier('SimpleClass');
-    var exportsExpression = b.memberExpression(b.identifier('module'), b.identifier('exports'), false);
-    var assignmentExpression = b.assignmentExpression('=', exportsExpression, classIdentifier);
-    var exportStatement = b.expressionStatement(assignmentExpression);
+    const classIdentifier = b.identifier('SimpleClass');
+    const exportsExpression = b.memberExpression(b.identifier('module'), b.identifier('exports'), false);
+    const assignmentExpression = b.assignmentExpression('=', exportsExpression, classIdentifier);
+    const exportStatement = b.expressionStatement(assignmentExpression);
 
     ast.program.body.push(exportStatement);
 
     // When.
-    var printedClass = new Printer().print(ast).code;
+    const printedClass = new Printer().print(ast).code;
 
     // Then.
     assert.strictEqual(printedClass, [
@@ -763,9 +763,9 @@ describe("printer", function() {
       '}'
     ].join(eol);
 
-    var ast = parse(code);
+    let ast = parse(code);
 
-    var printer = new Printer({
+    const printer = new Printer({
       tabWidth: 2
     });
 
@@ -809,7 +809,7 @@ describe("printer", function() {
       "};"
     ].join(eol));
 
-    var objExpr = ast.program.body[0].declarations[0].init;
+    const objExpr = ast.program.body[0].declarations[0].init;
     n.ObjectExpression.assert(objExpr);
 
     assert.strictEqual(objExpr.properties[0].computed, false);
@@ -825,24 +825,24 @@ describe("printer", function() {
   });
 
   it("prints trailing commas in object literals", function() {
-    var code = [
+    const code = [
       "({",
       "  foo: bar,",
       "  bar: foo,",
       "});"
     ].join(eol);
 
-    var ast = parse(code, {
+    const ast = parse(code, {
       // Supports trailing commas whereas plain esprima does not.
       parser: require("esprima-fb")
     });
 
-    var printer = new Printer({
+    let printer = new Printer({
       tabWidth: 2,
       trailingComma: true,
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    let pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
 
     // It should also work when using the `trailingComma` option as an object.
@@ -856,25 +856,25 @@ describe("printer", function() {
   });
 
   it("prints trailing commas in function calls", function() {
-    var code = [
+    const code = [
       "call(",
       "  1,",
       "  2,",
       ");"
     ].join(eol);
 
-    var ast = parse(code, {
+    const ast = parse(code, {
       // Supports trailing commas whereas plain esprima does not.
       parser: require("esprima-fb")
     });
 
-    var printer = new Printer({
+    let printer = new Printer({
       tabWidth: 2,
       wrapColumn: 1,
       trailingComma: true,
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    let pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
 
     // It should also work when using the `trailingComma` option as an object.
@@ -889,25 +889,25 @@ describe("printer", function() {
   });
 
   it("prints trailing commas in array expressions", function() {
-    var code = [
+    const code = [
       "[",
       "  1,",
       "  2,",
       "];"
     ].join(eol);
 
-    var ast = parse(code, {
+    const ast = parse(code, {
       // Supports trailing commas whereas plain esprima does not.
       parser: require("esprima-fb")
     });
 
-    var printer = new Printer({
+    let printer = new Printer({
       tabWidth: 2,
       wrapColumn: 1,
       trailingComma: true,
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    let pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
 
     // It should also work when using the `trailingComma` option as an object.
@@ -922,25 +922,25 @@ describe("printer", function() {
   });
 
   it("prints trailing commas in function definitions", function() {
-    var code = [
+    const code = [
       "function foo(",
       "  a,",
       "  b,",
       ") {}"
     ].join(eol);
 
-    var ast = parse(code, {
+    const ast = parse(code, {
       // Supports trailing commas whereas plain esprima does not.
       parser: require("esprima-fb")
     });
 
-    var printer = new Printer({
+    let printer = new Printer({
       tabWidth: 2,
       wrapColumn: 1,
       trailingComma: true,
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    let pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
 
     // It should also work when using the `trailingComma` option as an object.
@@ -956,7 +956,7 @@ describe("printer", function() {
 
   (nodeMajorVersion >= 6 ? it : xit)
   ("shouldn't print a trailing comma for a RestElement", function() {
-    var code = [
+    const code = [
       "function foo(",
       "  a,",
       "  b,",
@@ -964,46 +964,46 @@ describe("printer", function() {
       ") {}"
     ].join(eol);
 
-    var ast = parse(code, {
+    const ast = parse(code, {
       // The flow parser and Babylon recognize `...rest` as a `RestElement`
       parser: require("@babel/parser")
     });
 
-    var printer = new Printer({
+    const printer = new Printer({
       tabWidth: 2,
       wrapColumn: 1,
       trailingComma: true,
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("should support AssignmentPattern and RestElement", function() {
-    var code = [
+    const code = [
       "function foo(a, [b, c] = d(a), ...[e, f, ...rest]) {",
       "  return [a, b, c, e, f, rest];",
       "}"
     ].join(eol);
 
-    var ast = parse(code, {
+    const ast = parse(code, {
       // Supports rest parameter destructuring whereas plain esprima
       // does not.
       parser: require("esprima-fb")
     });
 
-    var printer = new Printer({
+    const printer = new Printer({
       tabWidth: 2
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("adds parenthesis around spread patterns", function() {
-    var code = "(...rest) => rest;";
+    const code = "(...rest) => rest;";
 
-    var ast = b.program([
+    let ast = b.program([
       b.expressionStatement(b.arrowFunctionExpression(
         [b.spreadElementPattern(b.identifier('rest'))],
         b.identifier('rest'),
@@ -1011,11 +1011,11 @@ describe("printer", function() {
       ))
     ]);
 
-    var printer = new Printer({
+    const printer = new Printer({
       tabWidth: 2
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    let pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
 
     // Print RestElement the same way
@@ -1031,7 +1031,7 @@ describe("printer", function() {
     assert.strictEqual(pretty, code);
 
     // Do the same for the `rest` field.
-    var arrowFunction = b.arrowFunctionExpression(
+    const arrowFunction = b.arrowFunctionExpression(
       [],
       b.identifier('rest'),
       false
@@ -1046,34 +1046,34 @@ describe("printer", function() {
   });
 
   it("adds parenthesis around single arrow function arg when options.arrowParensAlways is true", function() {
-    var code = "(a) => {};";
+    const code = "(a) => {};";
 
-    var fn = b.arrowFunctionExpression(
+    const fn = b.arrowFunctionExpression(
       [b.identifier('a')],
       b.blockStatement([]),
       false
     );
 
-    var ast = b.program([
+    const ast = b.program([
       b.expressionStatement(fn)
     ]);
 
-    var printer = new Printer({
+    const printer = new Printer({
       arrowParensAlways: true
     });
-    var pretty = printer.printGenerically(ast).code;
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("adds parenthesis around arrow function when binding", function() {
-    var code = "var a = (x => y).bind(z);";
+    const code = "var a = (x => y).bind(z);";
 
-    var fn = b.arrowFunctionExpression(
+    const fn = b.arrowFunctionExpression(
       [b.identifier("x")],
       b.identifier("y")
     );
 
-    var declaration = b.variableDeclaration("var", [
+    const declaration = b.variableDeclaration("var", [
       b.variableDeclarator(
         b.identifier("a"),
         b.callExpression(
@@ -1083,32 +1083,32 @@ describe("printer", function() {
       )
     ]);
 
-    var ast = b.program([declaration]);
+    const ast = b.program([declaration]);
 
-    var printer = new Printer();
-    var pretty = printer.printGenerically(ast).code;
+    const printer = new Printer();
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("adds parenthesis around async arrow functions with args", function() {
-    var code = "async () => {};";
+    let code = "async () => {};";
 
-    var fn = b.arrowFunctionExpression(
+    const fn = b.arrowFunctionExpression(
       [],
       b.blockStatement([]),
       false
     );
     fn.async = true;
 
-    var ast = b.program([
+    const ast = b.program([
       b.expressionStatement(fn)
     ]);
 
-    var printer = new Printer({
+    const printer = new Printer({
       tabWidth: 2
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    let pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
 
     // No parenthesis for single params if they are identifiers
@@ -1127,34 +1127,34 @@ describe("printer", function() {
   });
 
   it("adds parenthesis around arrow functions with single arg and a type", function() {
-    var code = "(a: b) => {};";
+    const code = "(a: b) => {};";
 
-    var arg = b.identifier('a');
+    const arg = b.identifier('a');
     arg.typeAnnotation = b.typeAnnotation(
       b.genericTypeAnnotation(b.identifier('b'), null)
     );
 
-    var fn = b.arrowFunctionExpression(
+    const fn = b.arrowFunctionExpression(
       [arg],
       b.blockStatement([]),
       false
     );
 
-    var ast = b.program([
+    const ast = b.program([
       b.expressionStatement(fn)
     ]);
 
-    var printer = new Printer();
-    var pretty = printer.printGenerically(ast).code;
+    const printer = new Printer();
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("adds parenthesis around arrow functions with single arg and a return type", function() {
-    var code = "(a): void => {};";
+    const code = "(a): void => {};";
 
-    var arg = b.identifier('a');
+    const arg = b.identifier('a');
 
-    var fn = b.arrowFunctionExpression(
+    const fn = b.arrowFunctionExpression(
       [arg],
       b.blockStatement([]),
       false
@@ -1164,19 +1164,19 @@ describe("printer", function() {
       b.voidTypeAnnotation()
     );
 
-    var ast = b.program([
+    const ast = b.program([
       b.expressionStatement(fn)
     ]);
 
-    var printer = new Printer();
-    var pretty = printer.printGenerically(ast).code;
+    const printer = new Printer();
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("adds parenthesis around arrow function body when returning object literal with typescript typecast", function() {
-    var code = "() => ({} as object);";
+    const code = "() => ({} as object);";
 
-    var fn = b.arrowFunctionExpression(
+    const fn = b.arrowFunctionExpression(
       [],
       b.tsAsExpression(
       b.objectExpression([]),
@@ -1185,28 +1185,28 @@ describe("printer", function() {
       false
     );
 
-    var ast = b.program([
+    const ast = b.program([
       b.expressionStatement(fn)
     ]);
 
-    var printer = new Printer();
-    var pretty = printer.printGenerically(ast).code;
+    const printer = new Printer();
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("prints class property initializers with type annotations correctly", function() {
-    var code = [
+    const code = [
       "class A {",
       "  foo = (a: b): void => {};",
       "}",
     ].join(eol);
 
-    var arg = b.identifier('a');
+    const arg = b.identifier('a');
     arg.typeAnnotation = b.typeAnnotation(
       b.genericTypeAnnotation(b.identifier('b'), null)
     );
 
-    var fn = b.arrowFunctionExpression(
+    const fn = b.arrowFunctionExpression(
       [arg],
       b.blockStatement([]),
       false
@@ -1215,7 +1215,7 @@ describe("printer", function() {
       b.voidTypeAnnotation()
     );
 
-    var ast = b.program([
+    const ast = b.program([
       b.classDeclaration(
         b.identifier('A'),
         b.classBody([
@@ -1229,22 +1229,22 @@ describe("printer", function() {
       )
     ]);
 
-    var printer = new Printer({
+    const printer = new Printer({
       tabWidth: 2
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("prints ClassProperty correctly", function() {
-    var code = [
+    const code = [
       "class A {",
       "  foo: Type = Bar;",
       "}",
     ].join(eol);
 
-    var ast = b.program([
+    const ast = b.program([
       b.classDeclaration(
         b.identifier('A'),
         b.classBody([
@@ -1259,22 +1259,22 @@ describe("printer", function() {
       )
     ]);
 
-    var printer = new Printer({
+    const printer = new Printer({
       tabWidth: 2
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("prints static ClassProperty correctly", function() {
-    var code = [
+    const code = [
       "class A {",
       "  static foo = Bar;",
       "}",
     ].join(eol);
 
-    var ast = b.program([
+    const ast = b.program([
       b.classDeclaration(
         b.identifier('A'),
         b.classBody([
@@ -1288,20 +1288,20 @@ describe("printer", function() {
       )
     ]);
 
-    var printer = new Printer({
+    const printer = new Printer({
       tabWidth: 2
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("prints template expressions correctly", function() {
-    var code = [
+    let code = [
       "graphql`query`;",
     ].join(eol);
 
-    var ast = b.program([
+    let ast = b.program([
       b.taggedTemplateStatement(
         b.identifier('graphql'),
         b.templateLiteral(
@@ -1311,11 +1311,11 @@ describe("printer", function() {
       )
     ]);
 
-    var printer = new Printer({
+    const printer = new Printer({
       tabWidth: 2
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    let pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
 
     code = [
@@ -1374,17 +1374,17 @@ describe("printer", function() {
   });
 
   it("preserves newlines at the beginning/end of files", function() {
-    var code = [
+    const code = [
       "",
       "f();",
       ""
     ].join(eol);
 
-    var lines = fromString(code);
-    var ast = parse(code, {
+    const lines = fromString(code);
+    const ast = parse(code, {
       esprima: {
         parse: function(source: string, options?: any) {
-          var program = require("esprima").parse(source, options);
+          const program = require("esprima").parse(source, options);
           n.Program.assert(program);
           // Expand ast.program.loc to include any
           // leading/trailing whitespace, to simulate the
@@ -1398,7 +1398,7 @@ describe("printer", function() {
 
     ast.program.body.unshift(b.debuggerStatement());
 
-    var printer = new Printer({
+    const printer = new Printer({
       tabWidth: 2
     });
 
@@ -1411,12 +1411,12 @@ describe("printer", function() {
   });
 
   it("respects options.lineTerminator", function() {
-    var lines = [
+    const lines = [
       "var first = 1;",
       "var second = 2;"
     ];
-    var code = lines.join("\n");
-    var ast = parse(code);
+    const code = lines.join("\n");
+    const ast = parse(code);
 
     assert.strictEqual(
       new Printer({
@@ -1427,11 +1427,11 @@ describe("printer", function() {
   });
 
   it("preserves indentation in unmodified template expressions", function() {
-    var printer = new Printer({
+    const printer = new Printer({
       tabWidth: 2
     });
 
-    var code = [
+    const code = [
       "var x = {",
       "  y: () => Relay.QL`",
       "    query {",
@@ -1442,13 +1442,13 @@ describe("printer", function() {
       "};",
     ].join(eol);
 
-    var ast = parse(code);
-    var pretty = printer.printGenerically(ast).code;
+    const ast = parse(code);
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("preserves indentation in modified template expressions", function() {
-    var code = [
+    const code = [
       "const fragments = {",
       "  viewer: Relay.QL`",
       "    fragment on Viewer {   // 2 extraneous spaces.",
@@ -1468,8 +1468,8 @@ describe("printer", function() {
       "};"
     ].join(eol);
 
-    var ast = parse(code);
-    var printer = new Printer({
+    const ast = parse(code);
+    const printer = new Printer({
       tabWidth: 2
     });
 
@@ -1488,21 +1488,21 @@ describe("printer", function() {
       }
     });
 
-    var actual = printer.print(ast).code;
-    var expected = code.replace(/\bid\b/g, "nodeID");
+    const actual = printer.print(ast).code;
+    const expected = code.replace(/\bid\b/g, "nodeID");
 
     assert.strictEqual(actual, expected);
   });
 
   it("prints commas for flow object types by default", function() {
-    var code = [
+    const code = [
       "type MyType = {",
       "    message: string,",
       "    isAwesome: boolean,",
       "};"
     ].join(eol);
 
-    var ast = b.typeAlias(
+    const ast = b.typeAlias(
       b.identifier("MyType"),
       null,
       b.objectTypeAnnotation([
@@ -1519,16 +1519,16 @@ describe("printer", function() {
       ])
     );
 
-    var printer = new Printer();
-    var pretty = printer.printGenerically(ast).code;
+    const printer = new Printer();
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("shouldn't print a trailing comma for single-line flow object types", function() {
-    var code1 = "type MyType = { message: string };";
-    var code2 = "type MyType = { [key: string]: string };";
+    const code1 = "type MyType = { message: string };";
+    const code2 = "type MyType = { [key: string]: string };";
 
-    var ast1 = b.typeAlias(
+    const ast1 = b.typeAlias(
       b.identifier("MyType"),
       null,
       b.objectTypeAnnotation([
@@ -1540,7 +1540,7 @@ describe("printer", function() {
       ])
     );
 
-    var ast2 = b.typeAlias(
+    const ast2 = b.typeAlias(
       b.identifier("MyType"),
       null,
       b.objectTypeAnnotation([], [
@@ -1552,22 +1552,22 @@ describe("printer", function() {
       ])
     );
 
-    var printer = new Printer({trailingComma: true});
-    var pretty1 = printer.printGenerically(ast1).code;
-    var pretty2 = printer.printGenerically(ast2).code;
+    const printer = new Printer({trailingComma: true});
+    const pretty1 = printer.printGenerically(ast1).code;
+    const pretty2 = printer.printGenerically(ast2).code;
     assert.strictEqual(pretty1, code1);
     assert.strictEqual(pretty2, code2);
   });
 
   it("prints semicolons for flow object types when options.flowObjectCommas is falsy", function() {
-    var code = [
+    const code = [
       "type MyType = {",
       "    message: string;",
       "    isAwesome: boolean;",
       "};"
     ].join(eol);
 
-    var ast = b.typeAlias(
+    const ast = b.typeAlias(
       b.identifier("MyType"),
       null,
       b.objectTypeAnnotation([
@@ -1584,15 +1584,15 @@ describe("printer", function() {
       ])
     );
 
-    var printer = new Printer({ flowObjectCommas: false });
-    var pretty = printer.printGenerically(ast).code;
+    const printer = new Printer({ flowObjectCommas: false });
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("prints parens for nullable union/intersection types", function() {
-    var code = "type MyType = ?(string | number);";
+    const code = "type MyType = ?(string | number);";
 
-    var ast = b.typeAlias(
+    const ast = b.typeAlias(
       b.identifier("MyType"),
       null,
       b.nullableTypeAnnotation(
@@ -1602,15 +1602,15 @@ describe("printer", function() {
       )
     );
 
-    var printer = new Printer({});
-    var pretty = printer.printGenerically(ast).code;
+    const printer = new Printer({});
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   (nodeMajorVersion >= 6 ? it : xit)
   ("uses the `arrayBracketSpacing` and the `objectCurlySpacing` option", function() {
-    var babelParser = require("@babel/parser");
-    var parseOptions = {
+    const babelParser = require("@babel/parser");
+    const parseOptions = {
       parser: {
         parse: function (source: string) {
           return babelParser.parse(source, {
@@ -1621,7 +1621,7 @@ describe("printer", function() {
       }
     };
 
-    var testCaseList = [{
+    const testCaseList = [{
       printerConfig: {arrayBracketSpacing: false, objectCurlySpacing: false},
       code: [
         'import {java, script} from "javascript";',
@@ -1672,11 +1672,11 @@ describe("printer", function() {
     }];
 
     testCaseList.forEach(function(testCase) {
-      var code = testCase.code;
-      var printer = new Printer(testCase.printerConfig);
+      const code = testCase.code;
+      const printer = new Printer(testCase.printerConfig);
 
-      var ast = parse(code, parseOptions);
-      var pretty = printer.printGenerically(ast).code;
+      const ast = parse(code, parseOptions);
+      const pretty = printer.printGenerically(ast).code;
 
       assert.strictEqual(pretty, code);
     });
@@ -1684,21 +1684,21 @@ describe("printer", function() {
 
   it("prints no extra semicolons in for-loop heads (#377)", function () {
     function check(head: any, parser: any) {
-      var source = "for (" + head + ") console.log(i);";
-      var ast = recast.parse(source, { parser: parser });
-      var loop = ast.program.body[0];
+      const source = "for (" + head + ") console.log(i);";
+      const ast = recast.parse(source, { parser: parser });
+      const loop = ast.program.body[0];
       assert.strictEqual(loop.type, "ForStatement");
       loop.body = b.blockStatement([]);
 
-      var reprinted = recast.print(ast).code;
+      const reprinted = recast.print(ast).code;
 
-      var openParenIndex = reprinted.indexOf("(");
+      const openParenIndex = reprinted.indexOf("(");
       assert.notStrictEqual(openParenIndex, -1);
 
-      var closeParenIndex = reprinted.indexOf(")", openParenIndex);
+      const closeParenIndex = reprinted.indexOf(")", openParenIndex);
       assert.notStrictEqual(closeParenIndex, -1);
 
-      var newHead = reprinted.slice(
+      const newHead = reprinted.slice(
         openParenIndex + 1,
         closeParenIndex
       );
@@ -1728,12 +1728,12 @@ describe("printer", function() {
   });
 
   it("parenthesizes NumericLiteral MemberExpression objects", function () {
-    var nonBabelNode = b.memberExpression(
+    const nonBabelNode = b.memberExpression(
       b.literal(1),
       b.identifier('foo')
     );
 
-    var babelNode = b.memberExpression(
+    const babelNode = b.memberExpression(
       b.numericLiteral(1),
       b.identifier('foo')
     );
@@ -1750,7 +1750,7 @@ describe("printer", function() {
   });
 
   it("obeys 'optional' property of OptionalMemberExpression", function () {
-    var node = b.optionalMemberExpression(
+    const node = b.optionalMemberExpression(
       b.identifier('foo'),
       b.identifier('bar')
     );
@@ -1760,7 +1760,7 @@ describe("printer", function() {
       "foo?.bar"
     );
 
-    var nonOptionalNode = b.optionalMemberExpression(
+    const nonOptionalNode = b.optionalMemberExpression(
       b.identifier('foo'),
       b.identifier('bar'),
       false,
@@ -1774,15 +1774,15 @@ describe("printer", function() {
   });
 
   it("prints numbers in bases other than 10 without converting them", function() {
-    var code = [
+    const code = [
       'let decimal = 6;',
       'let hex = 0xf00d;',
       'let binary = 0b1010;',
       'let octal = 0o744;'
     ].join(eol);
-    var ast = parse(code);
-    var printer = new Printer({});
-    var pretty = printer.printGenerically(ast).code;
+    const ast = parse(code);
+    const printer = new Printer({});
+    const pretty = printer.printGenerically(ast).code;
 
     assert.strictEqual(pretty, code);
   });
@@ -1801,7 +1801,7 @@ describe("printer", function() {
   });
 
   it("prints flow tuple type annotations correctly, respecting array options", function () {
-    var code = [
+    const code = [
       'type MyTupleType = [',
       '  "tuple element 1",',
       '  "tuple element 2",',
@@ -1809,7 +1809,7 @@ describe("printer", function() {
       '];',
     ].join(eol);
 
-    var ast = b.program([
+    const ast = b.program([
       b.typeAlias(
         b.identifier('MyTupleType'),
         null,
@@ -1821,55 +1821,55 @@ describe("printer", function() {
       ),
     ]);
 
-    var printer = new Printer({
+    const printer = new Printer({
       tabWidth: 2,
       wrapColumn: 40,
       trailingComma: true,
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("adds parenthesis around object expression", function() {
-    var code = "({}).x = 1;";
+    const code = "({}).x = 1;";
 
-    var assignment = b.assignmentExpression(
+    const assignment = b.assignmentExpression(
       '=',
       b.memberExpression(b.objectExpression([]), b.identifier('x'), false),
       b.literal(1)
     );
 
-    var ast = b.program([
+    const ast = b.program([
       b.expressionStatement(assignment)
     ]);
 
-    var printer = new Printer({
+    const printer = new Printer({
       arrowParensAlways: true
     });
-    var pretty = printer.printGenerically(ast).code;
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("adds parenthesis around conditional", function() {
-    var code = 'new (typeof a ? b : c)();';
-    var callee = recast.parse("typeof a ? b : c").program.body[0].expression;
+    const code = 'new (typeof a ? b : c)();';
+    const callee = recast.parse("typeof a ? b : c").program.body[0].expression;
 
-    var newExpression = b.newExpression(callee, []);
+    const newExpression = b.newExpression(callee, []);
 
-    var ast = b.program([
+    const ast = b.program([
       b.expressionStatement(newExpression)
     ]);
 
-    var printer = new Printer({
+    const printer = new Printer({
       arrowParensAlways: true
     });
-    var pretty = printer.print(ast).code;
+    const pretty = printer.print(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("prints flow object type internal slots correctly", function() {
-    var code = [
+    const code = [
       'type MyObjectType = {',
       '  [myIndexer: string]: any,',
       '  (myParameter: any): any,',
@@ -1882,7 +1882,7 @@ describe("printer", function() {
       '};',
     ].join(eol);
 
-    var ast = b.program([
+    const ast = b.program([
       b.typeAlias(
         b.identifier('MyObjectType'),
         null,
@@ -1976,18 +1976,18 @@ describe("printer", function() {
       ),
     ]);
 
-    var printer = new Printer({
+    const printer = new Printer({
       tabWidth: 2,
       wrapColumn: 40,
       trailingComma: true,
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("prints class private methods and properties correctly", function() {
-    var code = [
+    const code = [
       'class MyClassWithPrivate {',
       '  #myPrivateProperty: any;',
       '  #myPrivatePropertyWithValue: any = value;',
@@ -1995,7 +1995,7 @@ describe("printer", function() {
       '}',
     ].join(eol);
 
-    var ast = b.program([
+    const ast = b.program([
       b.classDeclaration(
         b.identifier("MyClassWithPrivate"),
         b.classBody([
@@ -2018,23 +2018,23 @@ describe("printer", function() {
       ),
     ]);
 
-    var printer = new Printer({
+    const printer = new Printer({
       tabWidth: 2,
       wrapColumn: 40,
       trailingComma: true,
     });
 
-    var pretty = printer.printGenerically(ast).code;
+    const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("prints an interpreter directive correctly", function() {
-    var code = [
+    const code = [
       '#!/usr/bin/env node',
       'console.log("Hello, world!");'
     ].join(eol);
 
-    var ast = b.program.from({
+    const ast = b.program.from({
       interpreter: b.interpreterDirective("/usr/bin/env node"),
       body: [
         b.expressionStatement(
@@ -2046,16 +2046,16 @@ describe("printer", function() {
       ],
     });
 
-    var pretty = new Printer().printGenerically(ast).code;
+    const pretty = new Printer().printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("prints an interface type annotation correctly", function() {
-    var code = [
+    const code = [
       'let myVar: interface extends MyOtherInterface { myProperty: any };',
     ].join(eol);
 
-    var ast = b.program([
+    const ast = b.program([
       b.variableDeclaration("let", [
         b.variableDeclarator(
           b.identifier.from({
@@ -2077,12 +2077,12 @@ describe("printer", function() {
       ])
     ]);
 
-    var pretty = new Printer().printGenerically(ast).code;
+    const pretty = new Printer().printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
   it("object destructuring for function parameters", function() {
-    var code = [
+    const code = [
       'function myFunction(',
       '    {',
       '        yes = "y",',
@@ -2115,7 +2115,7 @@ describe("printer", function() {
 
     const notSimplifiedProperty = b.property('init', b.identifier('long'), b.identifier('longHand'));
 
-    var ast = b.program([
+    const ast = b.program([
       b.functionDeclaration(
         b.identifier('myFunction'),
         [b.objectPattern([
@@ -2128,7 +2128,7 @@ describe("printer", function() {
       )
     ]);
 
-    var pretty = new Printer().printGenerically(ast).code;
+    const pretty = new Printer().printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 });

--- a/test/syntax.ts
+++ b/test/syntax.ts
@@ -3,36 +3,36 @@ import fs from "fs";
 import path from "path";
 import * as types from "ast-types";
 import { parse } from "../lib/parser";
-var hasOwn = Object.prototype.hasOwnProperty;
+const hasOwn = Object.prototype.hasOwnProperty;
 
 // Babel 7 no longer supports Node 4 or 5.
-var nodeMajorVersion = parseInt(process.versions.node, 10);
+const nodeMajorVersion = parseInt(process.versions.node, 10);
 (nodeMajorVersion >= 6 ? describe : xdescribe)
 ("syntax", function() {
   // Make sure we handle all possible node types in Syntax, and no additional
   // types that are not present in Syntax.
   it("Completeness", function(done) {
-    var printer = path.join(__dirname, "../lib/printer.ts");
+    const printer = path.join(__dirname, "../lib/printer.ts");
 
     fs.readFile(printer, "utf-8", function(err, data) {
       assert.ok(!err);
 
-      var ast = parse(data, { parser: require("../parsers/typescript") });
+      const ast = parse(data, { parser: require("../parsers/typescript") });
       assert.ok(ast);
 
-      var typeNames: { [name: string]: string } = {};
+      const typeNames: { [name: string]: string } = {};
       types.visit(ast, {
         visitFunctionDeclaration(path) {
-          var decl = path.node;
+          const decl = path.node;
           if (types.namedTypes.Identifier.check(decl.id) &&
               decl.id.name === "genericPrintNoParens") {
             this.traverse(path, {
               visitSwitchCase(path) {
-                var test = path.node.test;
+                const test = path.node.test;
                 if (test &&
                     test.type === "StringLiteral" &&
                     typeof test.value === "string") {
-                  var name = test.value;
+                  const name = test.value;
                   typeNames[name] = name;
                 }
                 return false;

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -7,7 +7,7 @@ import {EOL as eol} from "os";
 import * as parser from "../parsers/typescript";
 
 // Babel 7 no longer supports Node 4 or 5.
-var nodeMajorVersion = parseInt(process.versions.node, 10);
+const nodeMajorVersion = parseInt(process.versions.node, 10);
 (nodeMajorVersion >= 6 ? describe : xdescribe)
 ("TypeScript", function() {
   it('basic printing', function() {
@@ -343,13 +343,12 @@ function testReprinting(pattern: any, description: any) {
     }).filter((file: string) => !(
       // Skip the following files, because they have problems that are not due
       // to any problems in Recast. TODO Revisit this list periodically.
-      file.indexOf("/tsx/") >= 0 ||
+      (file.indexOf("/tsx/") >= 0 ||
       file.endsWith("stitching/errors.ts") ||
       file.endsWith("decorators/type-arguments-invalid/input.js") ||
       // Throws an error with a slightly different message than expected:
-      file.endsWith("types/tuple-rest-invalid/input.js") ||
-      // @babel/parser can't handle naked arrow function expression statements:
-      file.endsWith("/optional-parameter/input.js")
+      file.endsWith("types/tuple-rest-invalid/input.js") || // @babel/parser can't handle naked arrow function expression statements:
+      file.endsWith("/optional-parameter/input.js"))
     )).forEach((file: string) => it(file, function () {
       const absPath = path.join(__dirname, file);
       const source = fs.readFileSync(absPath, "utf8");

--- a/test/visit.ts
+++ b/test/visit.ts
@@ -1,12 +1,12 @@
 import assert from "assert";
 import * as types from "ast-types";
-var namedTypes = types.namedTypes;
-var builders = types.builders;
+const namedTypes = types.namedTypes;
+const builders = types.builders;
 import { parse } from "../lib/parser";
 import { Printer } from "../lib/printer";
 import { EOL as eol } from "os";
 
-var lines = [
+const lines = [
     "// file comment",
     "exports.foo({",
     "    // some comment",
@@ -17,11 +17,11 @@ var lines = [
 
 describe("types.visit", function() {
     it("replacement", function() {
-        var source = lines.join(eol);
-        var printer = new Printer;
-        var ast = parse(source);
-        var withThis = printer.print(ast).code;
-        var thisExp = /\bthis\b/g;
+        const source = lines.join(eol);
+        const printer = new Printer;
+        const ast = parse(source);
+        const withThis = printer.print(ast).code;
+        const thisExp = /\bthis\b/g;
 
         assert.ok(thisExp.test(withThis));
 
@@ -36,10 +36,10 @@ describe("types.visit", function() {
             withThis.replace(thisExp, "self")
         );
 
-        var propNames: any[] = [];
-        var methods: types.Visitor = {
+        const propNames: any[] = [];
+        const methods: types.Visitor = {
             visitProperty: function(path) {
-                var key: any = path.node.key;
+                const key: any = path.node.key;
                 propNames.push(key.value || key.name);
                 this.traverse(path);
             }
@@ -68,7 +68,7 @@ describe("types.visit", function() {
     });
 
     it("reindent", function() {
-        var lines = [
+        const lines = [
             "a(b(c({",
             "    m: d(function() {",
             "        if (e('y' + 'z'))",
@@ -80,7 +80,7 @@ describe("types.visit", function() {
             "})));"
         ];
 
-        var altered = [
+        const altered = [
             "a(xxx(function() {",
             "    if (e('y' > 'z'))",
             "        f(42).h()",
@@ -96,11 +96,11 @@ describe("types.visit", function() {
             "})));"
         ];
 
-        var source = lines.join(eol);
-        var ast = parse(source);
-        var printer = new Printer;
+        const source = lines.join(eol);
+        const ast = parse(source);
+        const printer = new Printer;
 
-        var funExpr: any;
+        let funExpr: any;
         types.visit(ast, {
             visitFunctionExpression: function(path) {
                 assert.strictEqual(typeof funExpr, "undefined");
@@ -119,7 +119,7 @@ describe("types.visit", function() {
         types.visit(ast, {
             visitCallExpression: function(path) {
                 this.traverse(path);
-                var expr = path.node;
+                const expr = path.node;
                 if (namedTypes.Identifier.check(expr.callee) &&
                     expr.callee.name === "b") {
                     expr.callee.name = "xxx";


### PR DESCRIPTION
This was done automatically using the following:

```
npm i @codemod/cli @resugar/codemod-declarations-block-scope
./node_modules/.bin/codemod -p @resugar/codemod-declarations-block-scope {src,test}/**/*.ts
```

@benjamn, if there's some reason not to do this let me know. Otherwise I'll merge in a few days.