### PR TITLE
style: reformat `lib/` using prettier

### DIFF
--- a/lib/comments.ts
+++ b/lib/comments.ts
@@ -22,14 +22,12 @@ function getSortedChildNodes(node: any, lines: any, resultArray?: any) {
   fixFaultyLocations(node, lines);
 
   if (resultArray) {
-    if (n.Node.check(node) &&
-        n.SourceLocation.check(node.loc)) {
+    if (n.Node.check(node) && n.SourceLocation.check(node.loc)) {
       // This reverse insertion sort almost always takes constant
       // time because we almost always (maybe always?) append the
       // nodes in order anyway.
       for (var i = resultArray.length - 1; i >= 0; --i) {
-        if (comparePos(resultArray[i].loc.end,
-                       node.loc.start) <= 0) {
+        if (comparePos(resultArray[i].loc.end, node.loc.start) <= 0) {
           break;
         }
       }
@@ -70,15 +68,18 @@ function decorateComment(node: any, comment: any, lines: any) {
   const childNodes = getSortedChildNodes(node, lines);
 
   // Time to dust off the old binary search robes and wizard hat.
-  let left = 0, right = childNodes.length;
+  let left = 0,
+    right = childNodes.length;
   while (left < right) {
     const middle = (left + right) >> 1;
     const child = childNodes[middle];
 
-    if (comparePos(child.loc.start, comment.loc.start) <= 0 &&
-        comparePos(comment.loc.end, child.loc.end) <= 0) {
+    if (
+      comparePos(child.loc.start, comment.loc.start) <= 0 &&
+      comparePos(comment.loc.end, child.loc.end) <= 0
+    ) {
       // The comment is completely contained by this child node.
-      decorateComment(comment.enclosingNode = child, comment, lines);
+      decorateComment((comment.enclosingNode = child), comment, lines);
       return; // Abandon the binary search at this level.
     }
 
@@ -145,23 +146,19 @@ export function attach(comments: any[], ast: any, lines: any) {
       }
 
       tiesToBreak.push(comment);
-
     } else if (pn) {
       // No contest: we have a trailing comment.
       breakTies(tiesToBreak, lines);
       addTrailingComment(pn, comment);
-
     } else if (fn) {
       // No contest: we have a leading comment.
       breakTies(tiesToBreak, lines);
       addLeadingComment(fn, comment);
-
     } else if (en) {
       // The enclosing node has no child nodes at all, so what we
       // have here is a dangling comment, e.g. [/* crickets */].
       breakTies(tiesToBreak, lines);
       addDanglingComment(en, comment);
-
     } else {
       throw new Error("AST contains no nodes at all?");
     }
@@ -177,7 +174,7 @@ export function attach(comments: any[], ast: any, lines: any) {
     delete comment.enclosingNode;
     delete comment.followingNode;
   });
-};
+}
 
 function breakTies(tiesToBreak: any[], lines: any) {
   const tieCount = tiesToBreak.length;
@@ -193,9 +190,11 @@ function breakTies(tiesToBreak: any[], lines: any) {
   // between the tied comments. In order to qualify as leading, a
   // comment must be separated from fn by an unbroken series of
   // whitespace-only gaps (or other comments).
-  for (var indexOfFirstLeadingComment = tieCount;
-       indexOfFirstLeadingComment > 0;
-       --indexOfFirstLeadingComment) {
+  for (
+    var indexOfFirstLeadingComment = tieCount;
+    indexOfFirstLeadingComment > 0;
+    --indexOfFirstLeadingComment
+  ) {
     var comment = tiesToBreak[indexOfFirstLeadingComment - 1];
     assert.strictEqual(comment.precedingNode, pn);
     assert.strictEqual(comment.followingNode, fn);
@@ -209,12 +208,14 @@ function breakTies(tiesToBreak: any[], lines: any) {
     gapEndPos = comment.loc.start;
   }
 
-  while (indexOfFirstLeadingComment <= tieCount &&
-         (comment = tiesToBreak[indexOfFirstLeadingComment]) &&
-         // If the comment is a //-style comment and indented more
-         // deeply than the node itself, reconsider it as trailing.
-         (comment.type === "Line" || comment.type === "CommentLine") &&
-         comment.loc.start.column > fn.loc.start.column) {
+  while (
+    indexOfFirstLeadingComment <= tieCount &&
+    (comment = tiesToBreak[indexOfFirstLeadingComment]) &&
+    // If the comment is a //-style comment and indented more
+    // deeply than the node itself, reconsider it as trailing.
+    (comment.type === "Line" || comment.type === "CommentLine") &&
+    comment.loc.start.column > fn.loc.start.column
+  ) {
     ++indexOfFirstLeadingComment;
   }
 
@@ -264,11 +265,10 @@ function printLeadingComment(commentPath: any, print: any) {
     // When we print trailing comments as leading comments, we don't
     // want to bring any trailing spaces along.
     parts.push("\n");
-
   } else if (lines instanceof Lines) {
     const trailingSpace = lines.slice(
       loc.end,
-      lines.skipSpaces(loc.end) || lines.lastPos(),
+      lines.skipSpaces(loc.end) || lines.lastPos()
     );
 
     if (trailingSpace.length === 1) {
@@ -280,7 +280,6 @@ function printLeadingComment(commentPath: any, print: any) {
       // with just that many newlines, with all other spaces removed.
       parts.push(new Array(trailingSpace.length).join("\n"));
     }
-
   } else {
     parts.push("\n");
   }
@@ -319,8 +318,8 @@ function printTrailingComment(commentPath: any, print: any) {
 export function printComments(path: any, print: any) {
   const value = path.getValue();
   const innerLines = print(path);
-  const comments = n.Node.check(value) &&
-    types.getFieldValue(value, "comments");
+  const comments =
+    n.Node.check(value) && types.getFieldValue(value, "comments");
 
   if (!comments || comments.length === 0) {
     return innerLines;
@@ -334,9 +333,15 @@ export function printComments(path: any, print: any) {
     const leading = types.getFieldValue(comment, "leading");
     const trailing = types.getFieldValue(comment, "trailing");
 
-    if (leading || (trailing && !(n.Statement.check(value) ||
-                                  comment.type === "Block" ||
-                                  comment.type === "CommentBlock"))) {
+    if (
+      leading ||
+      (trailing &&
+        !(
+          n.Statement.check(value) ||
+          comment.type === "Block" ||
+          comment.type === "CommentBlock"
+        ))
+    ) {
       leadingParts.push(printLeadingComment(commentPath, print));
     } else if (trailing) {
       trailingParts.push(printTrailingComment(commentPath, print));
@@ -345,4 +350,4 @@ export function printComments(path: any, print: any) {
 
   leadingParts.push.apply(leadingParts, trailingParts);
   return concat(leadingParts);
-};
+}

--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -10,30 +10,30 @@ interface FastPathType {
   copy(): any;
   getName(): any;
   getValue(): any;
-  valueIsDuplicate (): any;
+  valueIsDuplicate(): any;
   getNode(count?: number): any;
   getParentNode(count?: number): any;
   getRootValue(): any;
   call(callback: any, ...names: any[]): any;
   each(callback: any, ...names: any[]): any;
   map(callback: any, ...names: any[]): any;
-  hasParens (): any;
-  getPrevToken (node: any): any;
-  getNextToken (node: any): any;
+  hasParens(): any;
+  getPrevToken(node: any): any;
+  getNextToken(node: any): any;
   needsParens(assumeExpressionContext: any): any;
   canBeFirstInStatement(): any;
   firstInStatement(): any;
 }
 
 interface FastPathConstructor {
-  new(value: any): FastPathType;
+  new (value: any): FastPathType;
   from(obj: any): any;
 }
 
-const FastPath = function FastPath(this: FastPathType, value: any) {
+const FastPath = (function FastPath(this: FastPathType, value: any) {
   assert.ok(this instanceof FastPath);
   this.stack = [value];
-} as any as FastPathConstructor;
+} as any) as FastPathConstructor;
 
 const FPp: FastPathType = FastPath.prototype;
 
@@ -85,7 +85,7 @@ FPp.getValue = function getValue() {
   return s[s.length - 1];
 };
 
-FPp.valueIsDuplicate = function () {
+FPp.valueIsDuplicate = function() {
   const s = this.stack;
   const valueIndex = s.length - 1;
   return s.lastIndexOf(s[valueIndex], valueIndex - 1) >= 0;
@@ -130,7 +130,7 @@ FPp.getRootValue = function getRootValue() {
 // reference to this (modified) FastPath object. Note that the stack will
 // be restored to its original state after the callback is finished, so it
 // is probably a mistake to retain a reference to the path.
-FPp.call = function call(callback/*, name1, name2, ... */) {
+FPp.call = function call(callback /*, name1, name2, ... */) {
   const s = this.stack;
   const origLen = s.length;
   let value = s[origLen - 1];
@@ -149,7 +149,7 @@ FPp.call = function call(callback/*, name1, name2, ... */) {
 // accessing this.getValue()[name1][name2]... should be array-like. The
 // callback will be called with a reference to this path object for each
 // element of the array.
-FPp.each = function each(callback/*, name1, name2, ... */) {
+FPp.each = function each(callback /*, name1, name2, ... */) {
   const s = this.stack;
   const origLen = s.length;
   let value = s[origLen - 1];
@@ -177,7 +177,7 @@ FPp.each = function each(callback/*, name1, name2, ... */) {
 // Similar to FastPath.prototype.each, except that the results of the
 // callback function invocations are stored in an array and returned at
 // the end of the iteration.
-FPp.map = function map(callback/*, name1, name2, ... */) {
+FPp.map = function map(callback /*, name1, name2, ... */) {
   const s = this.stack;
   const origLen = s.length;
   let value = s[origLen - 1];
@@ -214,16 +214,16 @@ FPp.map = function map(callback/*, name1, name2, ... */) {
 // the AST but can be determined using FastPath#getPrevToken), there is no
 // ambiguity about how to parse it, so it counts as having parentheses,
 // even though it is not immediately followed by a `)`.
-FPp.hasParens = function () {
+FPp.hasParens = function() {
   const node = this.getNode();
 
   const prevToken = this.getPrevToken(node);
-  if (! prevToken) {
+  if (!prevToken) {
     return false;
   }
 
   const nextToken = this.getNextToken(node);
-  if (! nextToken) {
+  if (!nextToken) {
     return false;
   }
 
@@ -242,9 +242,9 @@ FPp.hasParens = function () {
     // returns false, then it just needs an opening parenthesis to resolve
     // the parsing ambiguity that made it appear to need parentheses.
     const justNeedsOpeningParen =
-      ! this.canBeFirstInStatement() &&
+      !this.canBeFirstInStatement() &&
       this.firstInStatement() &&
-      ! this.needsParens(true);
+      !this.needsParens(true);
 
     if (justNeedsOpeningParen) {
       return true;
@@ -254,7 +254,7 @@ FPp.hasParens = function () {
   return false;
 };
 
-FPp.getPrevToken = function (node) {
+FPp.getPrevToken = function(node) {
   node = node || this.getNode();
   const loc = node && node.loc;
   const tokens = loc && loc.tokens;
@@ -271,7 +271,7 @@ FPp.getPrevToken = function (node) {
   return null;
 };
 
-FPp.getNextToken = function (node) {
+FPp.getNextToken = function(node) {
   node = node || this.getNode();
   const loc = node && node.loc;
   const tokens = loc && loc.tokens;
@@ -296,7 +296,10 @@ FPp.needsParens = function(assumeExpressionContext) {
   // This needs to come before `if (!parent) { return false }` because
   // an object destructuring assignment requires parens for
   // correctness even when it's the topmost expression.
-  if (node.type === "AssignmentExpression" && node.left.type === 'ObjectPattern') {
+  if (
+    node.type === "AssignmentExpression" &&
+    node.left.type === "ObjectPattern"
+  ) {
     return true;
   }
 
@@ -329,176 +332,182 @@ FPp.needsParens = function(assumeExpressionContext) {
   }
 
   switch (node.type) {
-  case "UnaryExpression":
-  case "SpreadElement":
-  case "SpreadProperty":
-    return parent.type === "MemberExpression"
-      && name === "object"
-      && parent.object === node;
-
-  case "BinaryExpression":
-  case "LogicalExpression":
-    switch (parent.type) {
-    case "CallExpression":
-      return name === "callee"
-        && parent.callee === node;
-
     case "UnaryExpression":
     case "SpreadElement":
     case "SpreadProperty":
-      return true;
-
-    case "MemberExpression":
-      return name === "object"
-        && parent.object === node;
+      return (
+        parent.type === "MemberExpression" &&
+        name === "object" &&
+        parent.object === node
+      );
 
     case "BinaryExpression":
     case "LogicalExpression":
-      var po = parent.operator;
-      var pp = PRECEDENCE[po];
-      var no = node.operator;
-      var np = PRECEDENCE[no];
+      switch (parent.type) {
+        case "CallExpression":
+          return name === "callee" && parent.callee === node;
 
-      if (pp > np) {
-        return true;
+        case "UnaryExpression":
+        case "SpreadElement":
+        case "SpreadProperty":
+          return true;
+
+        case "MemberExpression":
+          return name === "object" && parent.object === node;
+
+        case "BinaryExpression":
+        case "LogicalExpression":
+          var po = parent.operator;
+          var pp = PRECEDENCE[po];
+          var no = node.operator;
+          var np = PRECEDENCE[no];
+
+          if (pp > np) {
+            return true;
+          }
+
+          if (pp === np && name === "right") {
+            assert.strictEqual(parent.right, node);
+            return true;
+          }
+
+        default:
+          return false;
       }
 
-      if (pp === np && name === "right") {
-        assert.strictEqual(parent.right, node);
-        return true;
+    case "SequenceExpression":
+      switch (parent.type) {
+        case "ReturnStatement":
+          return false;
+
+        case "ForStatement":
+          // Although parentheses wouldn't hurt around sequence expressions in
+          // the head of for loops, traditional style dictates that e.g. i++,
+          // j++ should not be wrapped with parentheses.
+          return false;
+
+        case "ExpressionStatement":
+          return name !== "expression";
+
+        default:
+          // Otherwise err on the side of overparenthesization, adding
+          // explicit exceptions above if this proves overzealous.
+          return true;
       }
 
-    default:
-      return false;
-    }
-
-  case "SequenceExpression":
-    switch (parent.type) {
-    case "ReturnStatement":
-      return false;
-
-    case "ForStatement":
-      // Although parentheses wouldn't hurt around sequence expressions in
-      // the head of for loops, traditional style dictates that e.g. i++,
-      // j++ should not be wrapped with parentheses.
-      return false;
-
-    case "ExpressionStatement":
-      return name !== "expression";
-
-    default:
-      // Otherwise err on the side of overparenthesization, adding
-      // explicit exceptions above if this proves overzealous.
-      return true;
-    }
-
-  case "YieldExpression":
-    switch (parent.type) {
-    case "BinaryExpression":
-    case "LogicalExpression":
-    case "UnaryExpression":
-    case "SpreadElement":
-    case "SpreadProperty":
-    case "CallExpression":
-    case "MemberExpression":
-    case "NewExpression":
-    case "ConditionalExpression":
     case "YieldExpression":
-      return true;
+      switch (parent.type) {
+        case "BinaryExpression":
+        case "LogicalExpression":
+        case "UnaryExpression":
+        case "SpreadElement":
+        case "SpreadProperty":
+        case "CallExpression":
+        case "MemberExpression":
+        case "NewExpression":
+        case "ConditionalExpression":
+        case "YieldExpression":
+          return true;
 
-    default:
-      return false;
-    }
+        default:
+          return false;
+      }
 
-  case "IntersectionTypeAnnotation":
-  case "UnionTypeAnnotation":
-    return parent.type === "NullableTypeAnnotation";
+    case "IntersectionTypeAnnotation":
+    case "UnionTypeAnnotation":
+      return parent.type === "NullableTypeAnnotation";
 
-  case "Literal":
-    return parent.type === "MemberExpression"
-      && isNumber.check(node.value)
-      && name === "object"
-      && parent.object === node;
+    case "Literal":
+      return (
+        parent.type === "MemberExpression" &&
+        isNumber.check(node.value) &&
+        name === "object" &&
+        parent.object === node
+      );
 
-  // Babel 6 Literal split
-  case "NumericLiteral":
-    return parent.type === "MemberExpression"
-      && name === "object"
-      && parent.object === node;
+    // Babel 6 Literal split
+    case "NumericLiteral":
+      return (
+        parent.type === "MemberExpression" &&
+        name === "object" &&
+        parent.object === node
+      );
 
-  case "AssignmentExpression":
-  case "ConditionalExpression":
-    switch (parent.type) {
-    case "UnaryExpression":
-    case "SpreadElement":
-    case "SpreadProperty":
-    case "BinaryExpression":
-    case "LogicalExpression":
-      return true;
+    case "AssignmentExpression":
+    case "ConditionalExpression":
+      switch (parent.type) {
+        case "UnaryExpression":
+        case "SpreadElement":
+        case "SpreadProperty":
+        case "BinaryExpression":
+        case "LogicalExpression":
+          return true;
+
+        case "CallExpression":
+        case "NewExpression":
+          return name === "callee" && parent.callee === node;
+
+        case "ConditionalExpression":
+          return name === "test" && parent.test === node;
+
+        case "MemberExpression":
+          return name === "object" && parent.object === node;
+
+        default:
+          return false;
+      }
+
+    case "ArrowFunctionExpression":
+      if (n.CallExpression.check(parent) && name === "callee") {
+        return true;
+      }
+
+      if (n.MemberExpression.check(parent) && name === "object") {
+        return true;
+      }
+
+      return isBinary(parent);
+
+    case "ObjectExpression":
+      if (parent.type === "ArrowFunctionExpression" && name === "body") {
+        return true;
+      }
+
+      break;
+
+    case "TSAsExpression":
+      if (
+        parent.type === "ArrowFunctionExpression" &&
+        name === "body" &&
+        node.expression.type === "ObjectExpression"
+      ) {
+        return true;
+      }
+      break;
 
     case "CallExpression":
-    case "NewExpression":
-      return name === "callee"
-        && parent.callee === node;
-
-    case "ConditionalExpression":
-      return name === "test"
-        && parent.test === node;
-
-    case "MemberExpression":
-      return name === "object"
-        && parent.object === node;
-
-    default:
-      return false;
-    }
-
-  case "ArrowFunctionExpression":
-    if (n.CallExpression.check(parent) &&
-        name === 'callee') {
-      return true;
-    }
-
-    if (n.MemberExpression.check(parent) &&
-        name === 'object') {
-      return true;
-    }
-
-    return isBinary(parent);
-
-  case "ObjectExpression":
-    if (parent.type === "ArrowFunctionExpression" &&
-        name === "body") {
-      return true;
-    }
-
-    break;
-
-  case 'TSAsExpression':
-    if (parent.type === 'ArrowFunctionExpression' &&
-      name === 'body' &&
-      node.expression.type === 'ObjectExpression') {
-      return true;
-    }
-    break;
-
-  case "CallExpression":
-    if (name === "declaration" &&
+      if (
+        name === "declaration" &&
         n.ExportDefaultDeclaration.check(parent) &&
-        n.FunctionExpression.check(node.callee)) {
-      return true;
-    }
+        n.FunctionExpression.check(node.callee)
+      ) {
+        return true;
+      }
   }
 
-  if (parent.type === "NewExpression" &&
-      name === "callee" &&
-      parent.callee === node) {
+  if (
+    parent.type === "NewExpression" &&
+    name === "callee" &&
+    parent.callee === node
+  ) {
     return containsCallExpression(node);
   }
 
-  if (assumeExpressionContext !== true &&
-      !this.canBeFirstInStatement() &&
-      this.firstInStatement()) {
+  if (
+    assumeExpressionContext !== true &&
+    !this.canBeFirstInStatement() &&
+    this.firstInStatement()
+  ) {
     return true;
   }
 
@@ -506,30 +515,32 @@ FPp.needsParens = function(assumeExpressionContext) {
 };
 
 function isBinary(node: any) {
-  return n.BinaryExpression.check(node)
-    || n.LogicalExpression.check(node);
+  return n.BinaryExpression.check(node) || n.LogicalExpression.check(node);
 }
 
 // @ts-ignore 'isUnaryLike' is declared but its value is never read. [6133]
 function isUnaryLike(node: any) {
-  return n.UnaryExpression.check(node)
-  // I considered making SpreadElement and SpreadProperty subtypes of
-  // UnaryExpression, but they're not really Expression nodes.
-    || (n.SpreadElement && n.SpreadElement.check(node))
-    || (n.SpreadProperty && n.SpreadProperty.check(node));
+  return (
+    n.UnaryExpression.check(node) ||
+    // I considered making SpreadElement and SpreadProperty subtypes of
+    // UnaryExpression, but they're not really Expression nodes.
+    (n.SpreadElement && n.SpreadElement.check(node)) ||
+    (n.SpreadProperty && n.SpreadProperty.check(node))
+  );
 }
 
 var PRECEDENCE: any = {};
-[["||"],
- ["&&"],
- ["|"],
- ["^"],
- ["&"],
- ["==", "===", "!=", "!=="],
- ["<", ">", "<=", ">=", "in", "instanceof"],
- [">>", "<<", ">>>"],
- ["+", "-"],
- ["*", "/", "%", "**"]
+[
+  ["||"],
+  ["&&"],
+  ["|"],
+  ["^"],
+  ["&"],
+  ["==", "===", "!=", "!=="],
+  ["<", ">", "<=", ">=", "in", "instanceof"],
+  [">>", "<<", ">>>"],
+  ["+", "-"],
+  ["*", "/", "%", "**"]
 ].forEach(function(tier, i) {
   tier.forEach(function(op) {
     PRECEDENCE[op] = i;
@@ -589,65 +600,64 @@ FPp.firstInStatement = function() {
       continue;
     }
 
-    if (n.BlockStatement.check(parent) &&
-        parentName === "body" &&
-        childName === 0) {
+    if (
+      n.BlockStatement.check(parent) &&
+      parentName === "body" &&
+      childName === 0
+    ) {
       assert.strictEqual(parent.body[0], child);
       return true;
     }
 
-    if (n.ExpressionStatement.check(parent) &&
-        childName === "expression") {
+    if (n.ExpressionStatement.check(parent) && childName === "expression") {
       assert.strictEqual(parent.expression, child);
       return true;
     }
 
-    if (n.AssignmentExpression.check(parent) &&
-        childName === "left") {
+    if (n.AssignmentExpression.check(parent) && childName === "left") {
       assert.strictEqual(parent.left, child);
       return true;
     }
 
-    if (n.ArrowFunctionExpression.check(parent) &&
-        childName === "body") {
+    if (n.ArrowFunctionExpression.check(parent) && childName === "body") {
       assert.strictEqual(parent.body, child);
       return true;
     }
 
-    if (n.SequenceExpression.check(parent) &&
-        parentName === "expressions" &&
-        childName === 0) {
+    if (
+      n.SequenceExpression.check(parent) &&
+      parentName === "expressions" &&
+      childName === 0
+    ) {
       assert.strictEqual(parent.expressions[0], child);
       continue;
     }
 
-    if (n.CallExpression.check(parent) &&
-        childName === "callee") {
+    if (n.CallExpression.check(parent) && childName === "callee") {
       assert.strictEqual(parent.callee, child);
       continue;
     }
 
-    if (n.MemberExpression.check(parent) &&
-        childName === "object") {
+    if (n.MemberExpression.check(parent) && childName === "object") {
       assert.strictEqual(parent.object, child);
       continue;
     }
 
-    if (n.ConditionalExpression.check(parent) &&
-        childName === "test") {
+    if (n.ConditionalExpression.check(parent) && childName === "test") {
       assert.strictEqual(parent.test, child);
       continue;
     }
 
-    if (isBinary(parent) &&
-        childName === "left") {
+    if (isBinary(parent) && childName === "left") {
       assert.strictEqual(parent.left, child);
       continue;
     }
 
-    if (n.UnaryExpression.check(parent) &&
-        !parent.prefix &&
-        childName === "argument") {
+    if (
+      n.UnaryExpression.check(parent) &&
+      !parent.prefix &&
+      childName === "argument"
+    ) {
       assert.strictEqual(parent.argument, child);
       continue;
     }

--- a/lib/lines.ts
+++ b/lib/lines.ts
@@ -29,19 +29,18 @@ export class Lines {
   private cachedSourceMap: any = null;
   private cachedTabWidth: number | void = void 0;
 
-  constructor(
-    private infos: LineInfo[],
-    sourceFileName: string | null = null,
-  ) {
+  constructor(private infos: LineInfo[], sourceFileName: string | null = null) {
     assert.ok(infos.length > 0);
     this.length = infos.length;
     this.name = sourceFileName || null;
 
     if (this.name) {
-      this.mappings.push(new Mapping(this, {
-        start: this.firstPos(),
-        end: this.lastPos(),
-      }));
+      this.mappings.push(
+        new Mapping(this, {
+          start: this.firstPos(),
+          end: this.lastPos()
+        })
+      );
     }
   }
 
@@ -83,17 +82,18 @@ export class Lines {
     const sourcesToContents: any = {};
 
     targetLines.mappings.forEach(function(mapping: any) {
-      const sourceCursor = mapping.sourceLines.skipSpaces(
-        mapping.sourceLoc.start
-      ) || mapping.sourceLines.lastPos();
+      const sourceCursor =
+        mapping.sourceLines.skipSpaces(mapping.sourceLoc.start) ||
+        mapping.sourceLines.lastPos();
 
-      const targetCursor = targetLines.skipSpaces(
-        mapping.targetLoc.start
-      ) || targetLines.lastPos();
+      const targetCursor =
+        targetLines.skipSpaces(mapping.targetLoc.start) ||
+        targetLines.lastPos();
 
-      while (comparePos(sourceCursor, mapping.sourceLoc.end) < 0 &&
-             comparePos(targetCursor, mapping.targetLoc.end) < 0) {
-
+      while (
+        comparePos(sourceCursor, mapping.sourceLoc.end) < 0 &&
+        comparePos(targetCursor, mapping.targetLoc.end) < 0
+      ) {
         const sourceChar = mapping.sourceLines.charAt(sourceCursor);
         const targetChar = targetLines.charAt(targetCursor);
         assert.strictEqual(sourceChar, targetChar);
@@ -103,10 +103,8 @@ export class Lines {
         // Add mappings one character at a time for maximum resolution.
         smg.addMapping({
           source: sourceName,
-          original: { line: sourceCursor.line,
-                      column: sourceCursor.column },
-          generated: { line: targetCursor.line,
-                       column: targetCursor.column }
+          original: { line: sourceCursor.line, column: sourceCursor.column },
+          generated: { line: targetCursor.line, column: targetCursor.column }
         });
 
         if (!hasOwn.call(sourcesToContents, sourceName)) {
@@ -130,17 +128,16 @@ export class Lines {
     assert.strictEqual(typeof pos.line, "number");
     assert.strictEqual(typeof pos.column, "number");
 
-    const line = pos.line, column = pos.column, strings = this.toString().split(lineTerminatorSeqExp), string = strings[line - 1];
+    const line = pos.line,
+      column = pos.column,
+      strings = this.toString().split(lineTerminatorSeqExp),
+      string = strings[line - 1];
 
-    if (typeof string === "undefined")
-      return "";
+    if (typeof string === "undefined") return "";
 
-    if (column === string.length &&
-        line < strings.length)
-      return "\n";
+    if (column === string.length && line < strings.length) return "\n";
 
-    if (column >= string.length)
-      return "";
+    if (column >= string.length) return "";
 
     return string.charAt(column);
   }
@@ -150,45 +147,45 @@ export class Lines {
     assert.strictEqual(typeof pos.line, "number");
     assert.strictEqual(typeof pos.column, "number");
 
-    let line = pos.line, column = pos.column, secret = this, infos = secret.infos, info = infos[line - 1], c = column;
+    let line = pos.line,
+      column = pos.column,
+      secret = this,
+      infos = secret.infos,
+      info = infos[line - 1],
+      c = column;
 
-    if (typeof info === "undefined" || c < 0)
-      return "";
+    if (typeof info === "undefined" || c < 0) return "";
 
     const indent = this.getIndentAt(line);
-    if (c < indent)
-      return " ";
+    if (c < indent) return " ";
 
     c += info.sliceStart - indent;
 
-    if (c === info.sliceEnd &&
-        line < this.length)
-      return "\n";
+    if (c === info.sliceEnd && line < this.length) return "\n";
 
-    if (c >= info.sliceEnd)
-      return "";
+    if (c >= info.sliceEnd) return "";
 
     return info.line.charAt(c);
   }
 
   stripMargin(width: number, skipFirstLine: boolean) {
-    if (width === 0)
-      return this;
+    if (width === 0) return this;
 
     assert.ok(width > 0, "negative margin: " + width);
 
-    if (skipFirstLine && this.length === 1)
-      return this;
+    if (skipFirstLine && this.length === 1) return this;
 
-    const lines = new Lines(this.infos.map(function(info: any, i: any) {
-      if (info.line && (i > 0 || !skipFirstLine)) {
-        info = {
-          ...info,
-          indent: Math.max(0, info.indent - width),
-        };
-      }
-      return info;
-    }));
+    const lines = new Lines(
+      this.infos.map(function(info: any, i: any) {
+        if (info.line && (i > 0 || !skipFirstLine)) {
+          info = {
+            ...info,
+            indent: Math.max(0, info.indent - width)
+          };
+        }
+        return info;
+      })
+    );
 
     if (this.mappings.length > 0) {
       const newMappings = lines.mappings;
@@ -206,15 +203,17 @@ export class Lines {
       return this;
     }
 
-    const lines = new Lines(this.infos.map(function(info: any) {
-      if (info.line && ! info.locked) {
-        info = {
-          ...info,
-          indent: info.indent + by,
-        };
-      }
-      return info
-    }));
+    const lines = new Lines(
+      this.infos.map(function(info: any) {
+        if (info.line && !info.locked) {
+          info = {
+            ...info,
+            indent: info.indent + by
+          };
+        }
+        return info;
+      })
+    );
 
     if (this.mappings.length > 0) {
       const newMappings = lines.mappings;
@@ -236,16 +235,18 @@ export class Lines {
       return this;
     }
 
-    const lines = new Lines(this.infos.map(function(info: any, i: any) {
-      if (i > 0 && info.line && ! info.locked) {
-        info = {
-          ...info,
-          indent: info.indent + by,
-        };
-      }
+    const lines = new Lines(
+      this.infos.map(function(info: any, i: any) {
+        if (i > 0 && info.line && !info.locked) {
+          info = {
+            ...info,
+            indent: info.indent + by
+          };
+        }
 
-      return info;
-    }));
+        return info;
+      })
+    );
 
     if (this.mappings.length > 0) {
       const newMappings = lines.mappings;
@@ -263,12 +264,14 @@ export class Lines {
       return this;
     }
 
-    return new Lines(this.infos.map(function (info: any, i: any) {
-      return {
-        ...info,
-        locked: i > 0,
-      };
-    }));
+    return new Lines(
+      this.infos.map(function(info: any, i: any) {
+        return {
+          ...info,
+          locked: i > 0
+        };
+      })
+    );
   }
 
   getIndentAt(line: number) {
@@ -302,17 +305,14 @@ export class Lines {
     let maxCount = -1;
     let result = 2;
 
-    for (let tabWidth = 1;
-         tabWidth < counts.length;
-         tabWidth += 1) {
-      if (hasOwn.call(counts, tabWidth) &&
-          counts[tabWidth] > maxCount) {
+    for (let tabWidth = 1; tabWidth < counts.length; tabWidth += 1) {
+      if (hasOwn.call(counts, tabWidth) && counts[tabWidth] > maxCount) {
         maxCount = counts[tabWidth];
         result = tabWidth;
       }
     }
 
-    return this.cachedTabWidth = result;
+    return (this.cachedTabWidth = result);
   }
 
   // Determine if the list of lines has a first line that starts with a //
@@ -322,10 +322,15 @@ export class Lines {
     if (this.infos.length === 0) {
       return false;
     }
-    const firstLineInfo = this.infos[0], sliceStart = firstLineInfo.sliceStart, sliceEnd = firstLineInfo.sliceEnd, firstLine = firstLineInfo.line.slice(sliceStart, sliceEnd).trim();
-    return firstLine.length === 0 ||
+    const firstLineInfo = this.infos[0],
+      sliceStart = firstLineInfo.sliceStart,
+      sliceEnd = firstLineInfo.sliceEnd,
+      firstLine = firstLineInfo.line.slice(sliceStart, sliceEnd).trim();
+    return (
+      firstLine.length === 0 ||
       firstLine.slice(0, 2) === "//" ||
-      firstLine.slice(0, 2) === "/*";
+      firstLine.slice(0, 2) === "/*"
+    );
   }
 
   isOnlyWhitespace() {
@@ -356,39 +361,35 @@ export class Lines {
   }
 
   nextPos(pos: Pos, skipSpaces: boolean = false) {
-    const l = Math.max(pos.line, 0), c = Math.max(pos.column, 0);
+    const l = Math.max(pos.line, 0),
+      c = Math.max(pos.column, 0);
 
     if (c < this.getLineLength(l)) {
       pos.column += 1;
 
-      return skipSpaces
-        ? !!this.skipSpaces(pos, false, true)
-        : true;
+      return skipSpaces ? !!this.skipSpaces(pos, false, true) : true;
     }
 
     if (l < this.length) {
       pos.line += 1;
       pos.column = 0;
 
-      return skipSpaces
-        ? !!this.skipSpaces(pos, false, true)
-        : true;
+      return skipSpaces ? !!this.skipSpaces(pos, false, true) : true;
     }
 
     return false;
   }
 
   prevPos(pos: Pos, skipSpaces: boolean = false) {
-    let l = pos.line, c = pos.column;
+    let l = pos.line,
+      c = pos.column;
 
     if (c < 1) {
       l -= 1;
 
-      if (l < 1)
-        return false;
+      if (l < 1) return false;
 
       c = this.getLineLength(l);
-
     } else {
       c = Math.min(c - 1, this.getLineLength(l));
     }
@@ -396,9 +397,7 @@ export class Lines {
     pos.line = l;
     pos.column = c;
 
-    return skipSpaces
-      ? !!this.skipSpaces(pos, true, true)
-      : true;
+    return skipSpaces ? !!this.skipSpaces(pos, true, true) : true;
   }
 
   firstPos() {
@@ -416,13 +415,15 @@ export class Lines {
   skipSpaces(
     pos: Pos,
     backward: boolean = false,
-    modifyInPlace: boolean = false,
+    modifyInPlace: boolean = false
   ) {
     if (pos) {
-      pos = modifyInPlace ? pos : {
-        line: pos.line,
-        column: pos.column
-      };
+      pos = modifyInPlace
+        ? pos
+        : {
+            line: pos.line,
+            column: pos.column
+          };
     } else if (backward) {
       pos = this.lastPos();
     } else {
@@ -431,14 +432,12 @@ export class Lines {
 
     if (backward) {
       while (this.prevPos(pos)) {
-        if (!isOnlyWhitespace(this.charAt(pos)) &&
-            this.nextPos(pos)) {
+        if (!isOnlyWhitespace(this.charAt(pos)) && this.nextPos(pos)) {
           return pos;
         }
       }
 
       return null;
-
     } else {
       while (isOnlyWhitespace(this.charAt(pos))) {
         if (!this.nextPos(pos)) {
@@ -477,13 +476,12 @@ export class Lines {
   eachPos(
     callback: (pos: Pos) => any,
     startPos: Pos = this.firstPos(),
-    skipSpaces: boolean = false,
+    skipSpaces: boolean = false
   ) {
     var pos = this.firstPos();
 
     if (startPos) {
-      pos.line = startPos.line,
-      pos.column = startPos.column
+      (pos.line = startPos.line), (pos.column = startPos.column);
     }
 
     if (skipSpaces && !this.skipSpaces(pos, false, true)) {
@@ -495,12 +493,9 @@ export class Lines {
   }
 
   bootstrapSlice(start: Pos, end: Pos) {
-    const strings = this.toString().split(
-      lineTerminatorSeqExp
-    ).slice(
-      start.line - 1,
-      end.line
-    );
+    const strings = this.toString()
+      .split(lineTerminatorSeqExp)
+      .slice(start.line - 1, end.line);
 
     if (strings.length > 0) {
       strings.push(strings.pop()!.slice(0, end.column));
@@ -560,7 +555,7 @@ export class Lines {
   sliceString(
     start: Pos = this.firstPos(),
     end: Pos = this.lastPos(),
-    options?: Options,
+    options?: Options
   ) {
     options = normalizeOptions(options);
 
@@ -583,9 +578,11 @@ export class Lines {
       const indent = Math.max(info.indent, 0);
 
       const before = info.line.slice(0, info.sliceStart);
-      if (options.reuseWhitespace &&
-          isOnlyWhitespace(before) &&
-          countSpaces(before, options.tabWidth) === indent) {
+      if (
+        options.reuseWhitespace &&
+        isOnlyWhitespace(before) &&
+        countSpaces(before, options.tabWidth) === indent
+      ) {
         // Reuse original spaces if the indentation is correct.
         parts.push(info.line.slice(0, info.sliceEnd));
         continue;
@@ -636,12 +633,15 @@ export class Lines {
         const info = linesOrNull.infos[0];
         const indent = new Array(info.indent + 1).join(" ");
         const prevLine = infos.length;
-        const prevColumn = Math.max(prevInfo.indent, 0) +
-          prevInfo.sliceEnd - prevInfo.sliceStart;
+        const prevColumn =
+          Math.max(prevInfo.indent, 0) +
+          prevInfo.sliceEnd -
+          prevInfo.sliceStart;
 
-        prevInfo.line = prevInfo.line.slice(
-          0, prevInfo.sliceEnd) + indent + info.line.slice(
-            info.sliceStart, info.sliceEnd);
+        prevInfo.line =
+          prevInfo.line.slice(0, prevInfo.sliceEnd) +
+          indent +
+          info.line.slice(info.sliceStart, info.sliceEnd);
 
         // If any part of a line is indentation-locked, the whole line
         // will be indentation-locked.
@@ -654,7 +654,6 @@ export class Lines {
             mappings.push(mapping.add(prevLine, prevColumn));
           });
         }
-
       } else if (linesOrNull.mappings.length > 0) {
         mappings.push.apply(mappings, linesOrNull.mappings);
       }
@@ -668,26 +667,25 @@ export class Lines {
     }
 
     function appendWithSeparator(linesOrNull: Lines | null, i: number) {
-      if (i > 0)
-        appendLines(separator);
+      if (i > 0) appendLines(separator);
       appendLines(linesOrNull);
     }
 
-    elements.map(function(elem: any) {
-      const lines = fromString(elem);
-      if (lines.isEmpty())
-        return null;
-      return lines;
-    }).forEach((linesOrNull, i) => {
-      if (separator.isEmpty()) {
-        appendLines(linesOrNull);
-      } else {
-        appendWithSeparator(linesOrNull, i);
-      }
-    });
+    elements
+      .map(function(elem: any) {
+        const lines = fromString(elem);
+        if (lines.isEmpty()) return null;
+        return lines;
+      })
+      .forEach((linesOrNull, i) => {
+        if (separator.isEmpty()) {
+          appendLines(linesOrNull);
+        } else {
+          appendWithSeparator(linesOrNull, i);
+        }
+      });
 
-    if (infos.length < 1)
-      return emptyLines;
+    if (infos.length < 1) return emptyLines;
 
     const lines = new Lines(infos);
 
@@ -714,30 +712,31 @@ export function countSpaces(spaces: any, tabWidth?: number) {
 
   for (let i = 0; i < len; ++i) {
     switch (spaces.charCodeAt(i)) {
-    case 9: // '\t'
-      assert.strictEqual(typeof tabWidth, "number");
-      assert.ok(tabWidth! > 0);
+      case 9: // '\t'
+        assert.strictEqual(typeof tabWidth, "number");
+        assert.ok(tabWidth! > 0);
 
-      var next = Math.ceil(count / tabWidth!) * tabWidth!;
-      if (next === count) {
-        count += tabWidth!;
-      } else {
-        count = next;
-      }
+        var next = Math.ceil(count / tabWidth!) * tabWidth!;
+        if (next === count) {
+          count += tabWidth!;
+        } else {
+          count = next;
+        }
 
-      break;
+        break;
 
-    case 11: // '\v'
-    case 12: // '\f'
-    case 13: // '\r'
-    case 0xfeff: // zero-width non-breaking space
-      // These characters contribute nothing to indentation.
-      break;
+      case 11: // '\v'
+      case 12: // '\f'
+      case 13: // '\r'
+      case 0xfeff: // zero-width non-breaking space
+        // These characters contribute nothing to indentation.
+        break;
 
-    case 32: // ' '
-    default: // Treat all other whitespace like ' '.
-      count += 1;
-      break;
+      case 32: // ' '
+      default:
+        // Treat all other whitespace like ' '.
+        count += 1;
+        break;
     }
   }
 
@@ -747,45 +746,45 @@ export function countSpaces(spaces: any, tabWidth?: number) {
 const leadingSpaceExp = /^\s*/;
 
 // As specified here: http://www.ecma-international.org/ecma-262/6.0/#sec-line-terminators
-var lineTerminatorSeqExp =
-  /\u000D\u000A|\u000D(?!\u000A)|\u000A|\u2028|\u2029/;
+var lineTerminatorSeqExp = /\u000D\u000A|\u000D(?!\u000A)|\u000A|\u2028|\u2029/;
 
 /**
  * @param {Object} options - Options object that configures printing.
  */
-export function fromString(
-  string: string | Lines,
-  options?: Options,
-): Lines {
-  if (string instanceof Lines)
-    return string;
+export function fromString(string: string | Lines, options?: Options): Lines {
+  if (string instanceof Lines) return string;
 
   string += "";
 
   const tabWidth = options && options.tabWidth;
   const tabless = string.indexOf("\t") < 0;
-  const cacheable = !options && tabless && (string.length <= maxCacheKeyLen);
+  const cacheable = !options && tabless && string.length <= maxCacheKeyLen;
 
-  assert.ok(tabWidth || tabless, "No tab width specified but encountered tabs in string\n" + string);
+  assert.ok(
+    tabWidth || tabless,
+    "No tab width specified but encountered tabs in string\n" + string
+  );
 
   if (cacheable && hasOwn.call(fromStringCache, string))
     return fromStringCache[string];
 
-  const lines = new Lines(string.split(lineTerminatorSeqExp).map(function(line) {
-    // TODO: handle null exec result
-    const spaces = leadingSpaceExp.exec(line)![0];
-    return {
-      line: line,
-      indent: countSpaces(spaces, tabWidth),
-      // Boolean indicating whether this line can be reindented.
-      locked: false,
-      sliceStart: spaces.length,
-      sliceEnd: line.length
-    };
-  }), normalizeOptions(options).sourceFileName);
+  const lines = new Lines(
+    string.split(lineTerminatorSeqExp).map(function(line) {
+      // TODO: handle null exec result
+      const spaces = leadingSpaceExp.exec(line)![0];
+      return {
+        line: line,
+        indent: countSpaces(spaces, tabWidth),
+        // Boolean indicating whether this line can be reindented.
+        locked: false,
+        sliceStart: spaces.length,
+        sliceEnd: line.length
+      };
+    }),
+    normalizeOptions(options).sourceFileName
+  );
 
-  if (cacheable)
-    fromStringCache[string] = lines;
+  if (cacheable) fromStringCache[string] = lines;
 
   return lines;
 }
@@ -830,9 +829,11 @@ function sliceInfo(info: any, startCol: number, endCol?: number) {
   assert.ok(sliceStart <= sliceEnd);
   assert.strictEqual(lineLength, indent + sliceEnd - sliceStart);
 
-  if (info.indent === indent &&
-      info.sliceStart === sliceStart &&
-      info.sliceEnd === sliceEnd) {
+  if (
+    info.indent === indent &&
+    info.sliceStart === sliceStart &&
+    info.sliceEnd === sliceEnd
+  ) {
     return info;
   }
 
@@ -848,7 +849,7 @@ function sliceInfo(info: any, startCol: number, endCol?: number) {
 
 export function concat(elements: any) {
   return emptyLines.join(elements);
-};
+}
 
 // The emptyLines object needs to be created all the way down here so that
 // Lines.prototype will be fully populated.

--- a/lib/mapping.ts
+++ b/lib/mapping.ts
@@ -10,14 +10,10 @@ export default class Mapping {
   constructor(
     public sourceLines: Lines,
     public sourceLoc: Loc,
-    public targetLoc: Loc = sourceLoc,
+    public targetLoc: Loc = sourceLoc
   ) {}
 
-  slice(
-    lines: Lines,
-    start: Pos,
-    end: Pos = lines.lastPos(),
-  ) {
+  slice(lines: Lines, start: Pos, end: Pos = lines.lastPos()) {
     const sourceLines = this.sourceLines;
     let sourceLoc = this.sourceLoc;
     let targetLoc = this.targetLoc;
@@ -34,8 +30,11 @@ export default class Mapping {
       }
 
       return skipChars(
-        sourceLines, sourceFromPos,
-        lines, targetFromPos, targetToPos
+        sourceLines,
+        sourceFromPos,
+        lines,
+        targetFromPos,
+        targetToPos
       );
     }
 
@@ -48,10 +47,8 @@ export default class Mapping {
 
         // The sourceLoc can stay the same because the contents of the
         // targetLoc have not changed.
-
       } else if (comparePos(end, targetLoc.start) <= 0) {
         return null;
-
       } else {
         sourceLoc = {
           start: sourceLoc.start,
@@ -63,7 +60,6 @@ export default class Mapping {
           end: subtractPos(end, start.line, start.column)
         };
       }
-
     } else {
       if (comparePos(targetLoc.end, start) <= 0) {
         return null;
@@ -80,7 +76,6 @@ export default class Mapping {
           start: { line: 1, column: 0 },
           end: subtractPos(targetLoc.end, start.line, start.column)
         };
-
       } else {
         sourceLoc = {
           start: skip("start"),
@@ -115,7 +110,7 @@ export default class Mapping {
   indent(
     by: number,
     skipFirstLine: boolean = false,
-    noNegativeColumns: boolean = false,
+    noNegativeColumns: boolean = false
   ) {
     if (by === 0) {
       return this;
@@ -138,9 +133,7 @@ export default class Mapping {
       const startColumn = targetLoc.start.column + by;
       targetLoc.start = {
         line: startLine,
-        column: noNegativeColumns
-          ? Math.max(0, startColumn)
-          : startColumn
+        column: noNegativeColumns ? Math.max(0, startColumn) : startColumn
       };
     }
 
@@ -148,9 +141,7 @@ export default class Mapping {
       const endColumn = targetLoc.end.column + by;
       targetLoc.end = {
         line: endLine,
-        column: noNegativeColumns
-          ? Math.max(0, endColumn)
-          : endColumn
+        column: noNegativeColumns ? Math.max(0, endColumn) : endColumn
       };
     }
 
@@ -161,18 +152,14 @@ export default class Mapping {
 function addPos(toPos: any, line: number, column: number) {
   return {
     line: toPos.line + line - 1,
-    column: (toPos.line === 1)
-      ? toPos.column + column
-      : toPos.column
+    column: toPos.line === 1 ? toPos.column + column : toPos.column
   };
 }
 
 function subtractPos(fromPos: any, line: number, column: number) {
   return {
     line: fromPos.line - line + 1,
-    column: (fromPos.line === line)
-      ? fromPos.column - column
-      : fromPos.column
+    column: fromPos.line === line ? fromPos.column - column : fromPos.column
   };
 }
 
@@ -181,7 +168,7 @@ function skipChars(
   sourceFromPos: Pos,
   targetLines: Lines,
   targetFromPos: Pos,
-  targetToPos: Pos,
+  targetToPos: Pos
 ) {
   const targetComparison = comparePos(targetFromPos, targetToPos);
   if (targetComparison === 0) {
@@ -191,8 +178,10 @@ function skipChars(
 
   if (targetComparison < 0) {
     // Skipping forward.
-    var sourceCursor = sourceLines.skipSpaces(sourceFromPos) || sourceLines.lastPos();
-    var targetCursor = targetLines.skipSpaces(targetFromPos) || targetLines.lastPos();
+    var sourceCursor =
+      sourceLines.skipSpaces(sourceFromPos) || sourceLines.lastPos();
+    var targetCursor =
+      targetLines.skipSpaces(targetFromPos) || targetLines.lastPos();
 
     var lineDiff = targetToPos.line - targetCursor.line;
     sourceCursor.line += lineDiff;
@@ -207,19 +196,22 @@ function skipChars(
       assert.strictEqual(lineDiff, 0);
     }
 
-    while (comparePos(targetCursor, targetToPos) < 0 &&
-           targetLines.nextPos(targetCursor, true)) {
+    while (
+      comparePos(targetCursor, targetToPos) < 0 &&
+      targetLines.nextPos(targetCursor, true)
+    ) {
       assert.ok(sourceLines.nextPos(sourceCursor, true));
       assert.strictEqual(
         sourceLines.charAt(sourceCursor),
         targetLines.charAt(targetCursor)
       );
     }
-
   } else {
     // Skipping backward.
-    var sourceCursor = sourceLines.skipSpaces(sourceFromPos, true) || sourceLines.firstPos();
-    var targetCursor = targetLines.skipSpaces(targetFromPos, true) || targetLines.firstPos();
+    var sourceCursor =
+      sourceLines.skipSpaces(sourceFromPos, true) || sourceLines.firstPos();
+    var targetCursor =
+      targetLines.skipSpaces(targetFromPos, true) || targetLines.firstPos();
 
     var lineDiff = targetToPos.line - targetCursor.line;
     sourceCursor.line += lineDiff;
@@ -234,8 +226,10 @@ function skipChars(
       assert.strictEqual(lineDiff, 0);
     }
 
-    while (comparePos(targetToPos, targetCursor) < 0 &&
-           targetLines.prevPos(targetCursor, true)) {
+    while (
+      comparePos(targetToPos, targetCursor) < 0 &&
+      targetLines.prevPos(targetCursor, true)
+    ) {
       assert.ok(sourceLines.prevPos(sourceCursor, true));
       assert.strictEqual(
         sourceLines.charAt(sourceCursor),

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -101,7 +101,7 @@ export interface Options extends DeprecatedOptions {
    * which results in the shorter literal) Otherwise, use double quotes.
    * @default null
    */
-  quote?: 'single' | 'double' | 'auto' | null;
+  quote?: "single" | "double" | "auto" | null;
 
   /**
    * Controls the printing of trailing commas in object literals, array
@@ -187,16 +187,16 @@ const defaults: Options = {
 };
 const hasOwn = defaults.hasOwnProperty;
 
-export type NormalizedOptions = Required<Omit<Options, keyof DeprecatedOptions>>;
+export type NormalizedOptions = Required<
+  Omit<Options, keyof DeprecatedOptions>
+>;
 
 // Copy options and fill in default values.
 export function normalize(opts?: Options): NormalizedOptions {
   const options = opts || defaults;
 
   function get(key: keyof Options) {
-    return hasOwn.call(options, key)
-      ? options[key]
-      : defaults[key];
+    return hasOwn.call(options, key) ? options[key] : defaults[key];
   }
 
   return {
@@ -220,4 +220,4 @@ export function normalize(opts?: Options): NormalizedOptions {
     flowObjectCommas: get("flowObjectCommas"),
     tokens: !!get("tokens")
   };
-};
+}

--- a/lib/parts-codemod.ts
+++ b/lib/parts-codemod.ts
@@ -1,0 +1,18 @@
+import * as t from "@babel/types";
+import { PluginItem } from "@babel/core";
+import { NodePath } from "@babel/traverse";
+
+export default function(): PluginItem {
+  return {
+    visitor: {
+      SwitchCase(path: NodePath<t.SwitchCase>): void {
+        if (
+          path.node.consequent.length > 0 &&
+          !t.isBlockStatement(path.node.consequent[0])
+        ) {
+          path.node.consequent = [t.blockStatement(path.node.consequent)];
+        }
+      }
+    }
+  };
+}

--- a/lib/patcher.ts
+++ b/lib/patcher.ts
@@ -20,18 +20,18 @@ interface PatcherType {
 }
 
 interface PatcherConstructor {
-  new(lines: any): PatcherType;
+  new (lines: any): PatcherType;
 }
 
-const Patcher = function Patcher(this: PatcherType, lines: any) {
+const Patcher = (function Patcher(this: PatcherType, lines: any) {
   assert.ok(this instanceof Patcher);
   assert.ok(lines instanceof linesModule.Lines);
 
-  const self = this, replacements: any[] = [];
+  const self = this,
+    replacements: any[] = [];
 
   self.replace = function(loc, lines) {
-    if (isString.check(lines))
-      lines = linesModule.fromString(lines);
+    if (isString.check(lines)) lines = linesModule.fromString(lines);
 
     replacements.push({
       lines: lines,
@@ -44,34 +44,36 @@ const Patcher = function Patcher(this: PatcherType, lines: any) {
     // If no location is provided, return the complete Lines object.
     loc = loc || {
       start: { line: 1, column: 0 },
-      end: { line: lines.length,
-             column: lines.getLineLength(lines.length) }
+      end: { line: lines.length, column: lines.getLineLength(lines.length) }
     };
 
-    let sliceFrom = loc.start, toConcat: any[] = [];
+    let sliceFrom = loc.start,
+      toConcat: any[] = [];
 
     function pushSlice(from: any, to: any) {
       assert.ok(comparePos(from, to) <= 0);
       toConcat.push(lines.slice(from, to));
     }
 
-    replacements.sort(function(a, b) {
-      return comparePos(a.start, b.start);
-    }).forEach(function(rep) {
-      if (comparePos(sliceFrom, rep.start) > 0) {
-        // Ignore nested replacement ranges.
-      } else {
-        pushSlice(sliceFrom, rep.start);
-        toConcat.push(rep.lines);
-        sliceFrom = rep.end;
-      }
-    });
+    replacements
+      .sort(function(a, b) {
+        return comparePos(a.start, b.start);
+      })
+      .forEach(function(rep) {
+        if (comparePos(sliceFrom, rep.start) > 0) {
+          // Ignore nested replacement ranges.
+        } else {
+          pushSlice(sliceFrom, rep.start);
+          toConcat.push(rep.lines);
+          sliceFrom = rep.end;
+        }
+      });
 
     pushSlice(sliceFrom, loc.end);
 
     return linesModule.concat(toConcat);
   };
-} as any as PatcherConstructor;
+} as any) as PatcherConstructor;
 export { Patcher };
 
 const Pp: PatcherType = Patcher.prototype;
@@ -79,8 +81,7 @@ const Pp: PatcherType = Patcher.prototype;
 Pp.tryToReprintComments = function(newNode, oldNode, print) {
   const patcher = this;
 
-  if (!newNode.comments &&
-      !oldNode.comments) {
+  if (!newNode.comments && !oldNode.comments) {
     // We were (vacuously) able to reprint all the comments!
     return true;
   }
@@ -92,8 +93,7 @@ Pp.tryToReprintComments = function(newNode, oldNode, print) {
   oldPath.stack.push("comments", getSurroundingComments(oldNode));
 
   const reprints: any[] = [];
-  const ableToReprintComments =
-    findArrayReprints(newPath, oldPath, reprints);
+  const ableToReprintComments = findArrayReprints(newPath, oldPath, reprints);
 
   // No need to pop anything from newPath.stack or oldPath.stack, since
   // newPath and oldPath are fresh local variables.
@@ -119,8 +119,7 @@ Pp.tryToReprintComments = function(newNode, oldNode, print) {
 // with no leading or trailing comments.
 function getSurroundingComments(node: any) {
   const result: any[] = [];
-  if (node.comments &&
-      node.comments.length > 0) {
+  if (node.comments && node.comments.length > 0) {
     node.comments.forEach(function(comment: any) {
       if (comment.leading || comment.trailing) {
         result.push(comment);
@@ -141,20 +140,23 @@ Pp.deleteComments = function(node) {
     if (comment.leading) {
       // Delete leading comments along with any trailing whitespace they
       // might have.
-      patcher.replace({
-        start: comment.loc.start,
-        end: node.loc.lines.skipSpaces(
-          comment.loc.end, false, false)
-      }, "");
-
+      patcher.replace(
+        {
+          start: comment.loc.start,
+          end: node.loc.lines.skipSpaces(comment.loc.end, false, false)
+        },
+        ""
+      );
     } else if (comment.trailing) {
       // Delete trailing comments along with any leading whitespace they
       // might have.
-      patcher.replace({
-        start: node.loc.lines.skipSpaces(
-          comment.loc.start, true, false),
-        end: comment.loc.end
-      }, "");
+      patcher.replace(
+        {
+          start: node.loc.lines.skipSpaces(comment.loc.start, true, false),
+          end: comment.loc.end
+        },
+        ""
+      );
     }
   });
 };
@@ -165,16 +167,14 @@ export function getReprinter(path: any) {
   // Make sure that this path refers specifically to a Node, rather than
   // some non-Node subproperty of a Node.
   const node = path.getValue();
-  if (!Printable.check(node))
-    return;
+  if (!Printable.check(node)) return;
 
   const orig = (node as any).original;
   const origLoc = orig && orig.loc;
   const lines = origLoc && origLoc.lines;
   const reprints: any[] = [];
 
-  if (!lines || !findReprints(path, reprints))
-    return;
+  if (!lines || !findReprints(path, reprints)) return;
 
   return function(print: any) {
     const patcher = new Patcher(lines);
@@ -185,8 +185,11 @@ export function getReprinter(path: any) {
 
       SourceLocation.assert(oldNode.loc, true);
 
-      const needToPrintNewPathWithComments =
-        !patcher.tryToReprintComments(newNode, oldNode, print);
+      const needToPrintNewPathWithComments = !patcher.tryToReprintComments(
+        newNode,
+        oldNode,
+        print
+      );
 
       if (needToPrintNewPathWithComments) {
         // Since we were not able to preserve all leading/trailing
@@ -203,8 +206,8 @@ export function getReprinter(path: any) {
         // because the existing parentheses will suffice. However, if the
         // newNode has a different type than the oldNode, let the printer
         // decide if reprint.newPath needs parentheses, as usual.
-        avoidRootParens: (oldNode.type === newNode.type &&
-                          reprint.oldPath.hasParens())
+        avoidRootParens:
+          oldNode.type === newNode.type && reprint.oldPath.hasParens()
       }).indentTail(oldNode.loc.indent);
 
       const nls = needsLeadingSpace(lines, oldNode.loc, newLines);
@@ -236,7 +239,7 @@ export function getReprinter(path: any) {
 
     return patchedLines;
   };
-};
+}
 
 // If the last character before oldLoc and the first character of newLines
 // are both identifier characters, they must be separated by a space,
@@ -246,16 +249,17 @@ function needsLeadingSpace(oldLines: any, oldLoc: any, newLines: any) {
 
   // The character just before the location occupied by oldNode.
   const charBeforeOldLoc =
-    oldLines.prevPos(posBeforeOldLoc) &&
-    oldLines.charAt(posBeforeOldLoc);
+    oldLines.prevPos(posBeforeOldLoc) && oldLines.charAt(posBeforeOldLoc);
 
   // First character of the reprinted node.
   const newFirstChar = newLines.charAt(newLines.firstPos());
 
-  return charBeforeOldLoc &&
+  return (
+    charBeforeOldLoc &&
     riskyAdjoiningCharExp.test(charBeforeOldLoc) &&
     newFirstChar &&
-    riskyAdjoiningCharExp.test(newFirstChar);
+    riskyAdjoiningCharExp.test(newFirstChar)
+  );
 }
 
 // If the last character of newLines and the first character after oldLoc
@@ -268,13 +272,15 @@ function needsTrailingSpace(oldLines: any, oldLoc: any, newLines: any) {
   const newLastPos = newLines.lastPos();
 
   // Last character of the reprinted node.
-  const newLastChar = newLines.prevPos(newLastPos) &&
-    newLines.charAt(newLastPos);
+  const newLastChar =
+    newLines.prevPos(newLastPos) && newLines.charAt(newLastPos);
 
-  return newLastChar &&
+  return (
+    newLastChar &&
     riskyAdjoiningCharExp.test(newLastChar) &&
     charAfterOldLoc &&
-    riskyAdjoiningCharExp.test(charAfterOldLoc);
+    riskyAdjoiningCharExp.test(charAfterOldLoc)
+  );
 }
 
 function findReprints(newPath: any, reprints: any) {
@@ -306,8 +312,7 @@ function findAnyReprints(newPath: any, oldPath: any, reprints: any) {
   const newNode = newPath.getValue();
   const oldNode = oldPath.getValue();
 
-  if (newNode === oldNode)
-    return true;
+  if (newNode === oldNode) return true;
 
   if (isArray.check(newNode))
     return findArrayReprints(newPath, oldPath, reprints);
@@ -322,18 +327,18 @@ function findArrayReprints(newPath: any, oldPath: any, reprints: any) {
   const newNode = newPath.getValue();
   const oldNode = oldPath.getValue();
 
-  if (newNode === oldNode ||
-      newPath.valueIsDuplicate() ||
-      oldPath.valueIsDuplicate()) {
+  if (
+    newNode === oldNode ||
+    newPath.valueIsDuplicate() ||
+    oldPath.valueIsDuplicate()
+  ) {
     return true;
   }
 
   isArray.assert(newNode);
   const len = newNode.length;
 
-  if (!(isArray.check(oldNode) &&
-        oldNode.length === len))
-    return false;
+  if (!(isArray.check(oldNode) && oldNode.length === len)) return false;
 
   for (let i = 0; i < len; ++i) {
     newPath.stack.push(i, newNode[i]);
@@ -359,12 +364,13 @@ function findObjectReprints(newPath: any, oldPath: any, reprints: any) {
   }
 
   const oldNode = oldPath.getValue();
-  if (!isObject.check(oldNode))
-    return false;
+  if (!isObject.check(oldNode)) return false;
 
-  if (newNode === oldNode ||
-      newPath.valueIsDuplicate() ||
-      oldPath.valueIsDuplicate()) {
+  if (
+    newNode === oldNode ||
+    newPath.valueIsDuplicate() ||
+    oldPath.valueIsDuplicate()
+  ) {
     return true;
   }
 
@@ -395,12 +401,13 @@ function findObjectReprints(newPath: any, oldPath: any, reprints: any) {
       return true;
     }
 
-    if (Expression.check(newNode) &&
-        Expression.check(oldNode) &&
-        // If we have no .loc information for oldNode, then we won't be
-        // able to reprint it.
-        oldNode.loc) {
-
+    if (
+      Expression.check(newNode) &&
+      Expression.check(oldNode) &&
+      // If we have no .loc information for oldNode, then we won't be
+      // able to reprint it.
+      oldNode.loc
+    ) {
       // If both nodes are subtypes of Expression, then we should be able
       // to fill the location occupied by the old node with code printed
       // for the new node with no ill consequences.
@@ -436,15 +443,13 @@ function findChildReprints(newPath: any, oldPath: any, reprints: any) {
   // If this node needs parentheses and will not be wrapped with
   // parentheses when reprinted, then return false to skip reprinting and
   // let it be printed generically.
-  if (newPath.needsParens() &&
-      ! oldPath.hasParens()) {
+  if (newPath.needsParens() && !oldPath.hasParens()) {
     return false;
   }
 
   const keys = getUnionOfKeys(oldNode, newNode);
 
-  if (oldNode.type === "File" ||
-      newNode.type === "File") {
+  if (oldNode.type === "File" || newNode.type === "File") {
     // Don't bother traversing file.tokens, an often very large array
     // returned by Babylon, and useless for our purposes.
     delete keys.tokens;
@@ -476,8 +481,10 @@ function findChildReprints(newPath: any, oldPath: any, reprints: any) {
   // Return statements might end up running into ASI issues due to
   // comments inserted deep within the tree, so reprint them if anything
   // changed within them.
-  if (ReturnStatement.check(newPath.getNode()) &&
-      reprints.length > originalReprintCount) {
+  if (
+    ReturnStatement.check(newPath.getNode()) &&
+    reprints.length > originalReprintCount
+  ) {
     return false;
   }
 

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -11,209 +11,217 @@ import FastPath from "./fast-path";
 import * as util from "./util";
 
 export interface PrintResultType {
-    code: string;
-    map?: any;
-    toString(): string;
+  code: string;
+  map?: any;
+  toString(): string;
 }
 
 interface PrintResultConstructor {
-    new(code: any, sourceMap?: any): PrintResultType;
+  new (code: any, sourceMap?: any): PrintResultType;
 }
 
-const PrintResult = function PrintResult(this: PrintResultType, code: any, sourceMap?: any) {
-    assert.ok(this instanceof PrintResult);
+const PrintResult = (function PrintResult(
+  this: PrintResultType,
+  code: any,
+  sourceMap?: any
+) {
+  assert.ok(this instanceof PrintResult);
 
-    isString.assert(code);
-    this.code = code;
+  isString.assert(code);
+  this.code = code;
 
-    if (sourceMap) {
-        isObject.assert(sourceMap);
-        this.map = sourceMap;
-    }
-} as any as PrintResultConstructor;
+  if (sourceMap) {
+    isObject.assert(sourceMap);
+    this.map = sourceMap;
+  }
+} as any) as PrintResultConstructor;
 
 const PRp: PrintResultType = PrintResult.prototype;
 let warnedAboutToString = false;
 
 PRp.toString = function() {
-    if (!warnedAboutToString) {
-        console.warn(
-            "Deprecation warning: recast.print now returns an object with " +
-            "a .code property. You appear to be treating the object as a " +
-            "string, which might still work but is strongly discouraged."
-        );
+  if (!warnedAboutToString) {
+    console.warn(
+      "Deprecation warning: recast.print now returns an object with " +
+        "a .code property. You appear to be treating the object as a " +
+        "string, which might still work but is strongly discouraged."
+    );
 
-        warnedAboutToString = true;
-    }
+    warnedAboutToString = true;
+  }
 
-    return this.code;
+  return this.code;
 };
 
 const emptyPrintResult = new PrintResult("");
 
 interface PrinterType {
-    print(ast: any): PrintResultType;
-    printGenerically(ast: any): PrintResultType;
+  print(ast: any): PrintResultType;
+  printGenerically(ast: any): PrintResultType;
 }
 
 interface PrinterConstructor {
-    new(config?: any): PrinterType;
+  new (config?: any): PrinterType;
 }
 
-const Printer = function Printer(this: PrinterType, config?: any) {
-    assert.ok(this instanceof Printer);
+const Printer = (function Printer(this: PrinterType, config?: any) {
+  assert.ok(this instanceof Printer);
 
-    const explicitTabWidth = config && config.tabWidth;
-    config = normalizeOptions(config);
+  const explicitTabWidth = config && config.tabWidth;
+  config = normalizeOptions(config);
 
-    // It's common for client code to pass the same options into both
-    // recast.parse and recast.print, but the Printer doesn't need (and
-    // can be confused by) config.sourceFileName, so we null it out.
-    config.sourceFileName = null;
+  // It's common for client code to pass the same options into both
+  // recast.parse and recast.print, but the Printer doesn't need (and
+  // can be confused by) config.sourceFileName, so we null it out.
+  config.sourceFileName = null;
 
-    // Non-destructively modifies options with overrides, and returns a
-    // new print function that uses the modified options.
-    function makePrintFunctionWith(options: any, overrides: any) {
-        options = Object.assign({}, options, overrides);
-        return function (path: any) {
-            return print(path, options);
-        };
+  // Non-destructively modifies options with overrides, and returns a
+  // new print function that uses the modified options.
+  function makePrintFunctionWith(options: any, overrides: any) {
+    options = Object.assign({}, options, overrides);
+    return function(path: any) {
+      return print(path, options);
+    };
+  }
+
+  function print(path: any, options: any) {
+    assert.ok(path instanceof FastPath);
+    options = options || {};
+
+    if (options.includeComments) {
+      return printComments(
+        path,
+        makePrintFunctionWith(options, {
+          includeComments: false
+        })
+      );
     }
 
-    function print(path: any, options: any) {
-        assert.ok(path instanceof FastPath);
-        options = options || {};
+    const oldTabWidth = config.tabWidth;
 
-        if (options.includeComments) {
-            return printComments(path, makePrintFunctionWith(options, {
-                includeComments: false
-            }));
-        }
-
-        const oldTabWidth = config.tabWidth;
-
-        if (! explicitTabWidth) {
-            const loc = path.getNode().loc;
-            if (loc && loc.lines && loc.lines.guessTabWidth) {
-                config.tabWidth = loc.lines.guessTabWidth();
-            }
-        }
-
-        const reprinter = getReprinter(path);
-        const lines = reprinter
-            // Since the print function that we pass to the reprinter will
-            // be used to print "new" nodes, it's tempting to think we
-            // should pass printRootGenerically instead of print, to avoid
-            // calling maybeReprint again, but that would be a mistake
-            // because the new nodes might not be entirely new, but merely
-            // moved from elsewhere in the AST. The print function is the
-            // right choice because it gives us the opportunity to reprint
-            // such nodes using their original source.
-            ? reprinter(print)
-            : genericPrint(
-                path,
-                config,
-                options,
-                makePrintFunctionWith(options, {
-                    includeComments: true,
-                    avoidRootParens: false
-                })
-            );
-
-        config.tabWidth = oldTabWidth;
-
-        return lines;
+    if (!explicitTabWidth) {
+      const loc = path.getNode().loc;
+      if (loc && loc.lines && loc.lines.guessTabWidth) {
+        config.tabWidth = loc.lines.guessTabWidth();
+      }
     }
 
-    this.print = function(ast) {
-        if (!ast) {
-            return emptyPrintResult;
-        }
-
-        const lines = print(FastPath.from(ast), {
+    const reprinter = getReprinter(path);
+    const lines = reprinter
+      ? // Since the print function that we pass to the reprinter will
+        // be used to print "new" nodes, it's tempting to think we
+        // should pass printRootGenerically instead of print, to avoid
+        // calling maybeReprint again, but that would be a mistake
+        // because the new nodes might not be entirely new, but merely
+        // moved from elsewhere in the AST. The print function is the
+        // right choice because it gives us the opportunity to reprint
+        // such nodes using their original source.
+        reprinter(print)
+      : genericPrint(
+          path,
+          config,
+          options,
+          makePrintFunctionWith(options, {
             includeComments: true,
             avoidRootParens: false
-        });
-
-        return new PrintResult(
-            lines.toString(config),
-            util.composeSourceMaps(
-                config.inputSourceMap,
-                lines.getSourceMap(
-                    config.sourceMapName,
-                    config.sourceRoot
-                )
-            )
+          })
         );
-    };
 
-    this.printGenerically = function(ast) {
-        if (!ast) {
-            return emptyPrintResult;
-        }
+    config.tabWidth = oldTabWidth;
 
-        // Print the entire AST generically.
-        function printGenerically(path: any) {
-            return printComments(path, function (path: any) {
-                return genericPrint(path, config, {
-                    includeComments: true,
-                    avoidRootParens: false
-                }, printGenerically);
-            });
-        }
+    return lines;
+  }
 
-        const path = FastPath.from(ast);
-        const oldReuseWhitespace = config.reuseWhitespace;
+  this.print = function(ast) {
+    if (!ast) {
+      return emptyPrintResult;
+    }
 
-        // Do not reuse whitespace (or anything else, for that matter)
-        // when printing generically.
-        config.reuseWhitespace = false;
+    const lines = print(FastPath.from(ast), {
+      includeComments: true,
+      avoidRootParens: false
+    });
 
-        // TODO Allow printing of comments?
-        const pr = new PrintResult(printGenerically(path).toString(config));
-        config.reuseWhitespace = oldReuseWhitespace;
-        return pr;
-    };
-} as any as PrinterConstructor;
+    return new PrintResult(
+      lines.toString(config),
+      util.composeSourceMaps(
+        config.inputSourceMap,
+        lines.getSourceMap(config.sourceMapName, config.sourceRoot)
+      )
+    );
+  };
+
+  this.printGenerically = function(ast) {
+    if (!ast) {
+      return emptyPrintResult;
+    }
+
+    // Print the entire AST generically.
+    function printGenerically(path: any) {
+      return printComments(path, function(path: any) {
+        return genericPrint(
+          path,
+          config,
+          {
+            includeComments: true,
+            avoidRootParens: false
+          },
+          printGenerically
+        );
+      });
+    }
+
+    const path = FastPath.from(ast);
+    const oldReuseWhitespace = config.reuseWhitespace;
+
+    // Do not reuse whitespace (or anything else, for that matter)
+    // when printing generically.
+    config.reuseWhitespace = false;
+
+    // TODO Allow printing of comments?
+    const pr = new PrintResult(printGenerically(path).toString(config));
+    config.reuseWhitespace = oldReuseWhitespace;
+    return pr;
+  };
+} as any) as PrinterConstructor;
 
 export { Printer };
 
 function genericPrint(path: any, config: any, options: any, printPath: any) {
-    assert.ok(path instanceof FastPath);
+  assert.ok(path instanceof FastPath);
 
-    const node = path.getValue();
-    const parts = [];
-    const linesWithoutParens =
-        genericPrintNoParens(path, config, printPath);
+  const node = path.getValue();
+  const parts = [];
+  const linesWithoutParens = genericPrintNoParens(path, config, printPath);
 
-    if (! node || linesWithoutParens.isEmpty()) {
-        return linesWithoutParens;
+  if (!node || linesWithoutParens.isEmpty()) {
+    return linesWithoutParens;
+  }
+
+  let shouldAddParens = false;
+  const decoratorsLines = printDecorators(path, printPath);
+
+  if (decoratorsLines.isEmpty()) {
+    // Nodes with decorators can't have parentheses, so we can avoid
+    // computing path.needsParens() except in this case.
+    if (!options.avoidRootParens) {
+      shouldAddParens = path.needsParens();
     }
+  } else {
+    parts.push(decoratorsLines);
+  }
 
-    let shouldAddParens = false;
-    const decoratorsLines = printDecorators(path, printPath);
+  if (shouldAddParens) {
+    parts.unshift("(");
+  }
 
-    if (decoratorsLines.isEmpty()) {
-        // Nodes with decorators can't have parentheses, so we can avoid
-        // computing path.needsParens() except in this case.
-        if (! options.avoidRootParens) {
-            shouldAddParens = path.needsParens();
-        }
-    } else {
-        parts.push(decoratorsLines);
-    }
+  parts.push(linesWithoutParens);
 
-    if (shouldAddParens) {
-        parts.unshift("(");
-    }
+  if (shouldAddParens) {
+    parts.push(")");
+  }
 
-    parts.push(linesWithoutParens);
-
-    if (shouldAddParens) {
-        parts.push(")");
-    }
-
-    return concat(parts);
+  return concat(parts);
 }
 
 // Note that the `options` parameter of this function is what other
@@ -221,108 +229,110 @@ function genericPrint(path: any, config: any, options: any, printPath: any) {
 // configuration object originally passed into the Printer constructor).
 // Its properties are documented in lib/options.js.
 function genericPrintNoParens(path: any, options: any, print: any) {
-    const n = path.getValue();
+  const n = path.getValue();
 
-    if (!n) {
-        return fromString("");
-    }
+  if (!n) {
+    return fromString("");
+  }
 
-    if (typeof n === "string") {
-        return fromString(n, options);
-    }
+  if (typeof n === "string") {
+    return fromString(n, options);
+  }
 
-    namedTypes.Printable.assert(n);
+  namedTypes.Printable.assert(n);
 
-    const parts: (string | Lines)[] = [];
+  const parts: (string | Lines)[] = [];
 
-    switch (n.type) {
+  switch (n.type) {
     case "File":
-        return path.call(print, "program");
+      return path.call(print, "program");
 
     case "Program":
-        // Babel 6
-        if (n.directives) {
-            path.each(function(childPath: any) {
-                parts.push(print(childPath), ";\n");
-            }, "directives");
-        }
+      // Babel 6
+      if (n.directives) {
+        path.each(function(childPath: any) {
+          parts.push(print(childPath), ";\n");
+        }, "directives");
+      }
 
-        if (n.interpreter) {
-            parts.push(path.call(print, "interpreter"));
-        }
+      if (n.interpreter) {
+        parts.push(path.call(print, "interpreter"));
+      }
 
-        parts.push(path.call(function(bodyPath: any) {
-            return printStatementSequence(bodyPath, options, print);
-        }, "body"));
+      parts.push(
+        path.call(function(bodyPath: any) {
+          return printStatementSequence(bodyPath, options, print);
+        }, "body")
+      );
 
-        return concat(parts);
+      return concat(parts);
 
     case "Noop": // Babel extension.
     case "EmptyStatement":
-        return fromString("");
+      return fromString("");
 
     case "ExpressionStatement":
-        return concat([path.call(print, "expression"), ";"]);
+      return concat([path.call(print, "expression"), ";"]);
 
     case "ParenthesizedExpression": // Babel extension.
-        return concat(["(", path.call(print, "expression"), ")"]);
+      return concat(["(", path.call(print, "expression"), ")"]);
 
     case "BinaryExpression":
     case "LogicalExpression":
     case "AssignmentExpression":
-        return fromString(" ").join([
-            path.call(print, "left"),
-            n.operator,
-            path.call(print, "right")
-        ]);
+      return fromString(" ").join([
+        path.call(print, "left"),
+        n.operator,
+        path.call(print, "right")
+      ]);
 
     case "AssignmentPattern":
-        return concat([
-            path.call(print, "left"),
-            " = ",
-            path.call(print, "right")
-        ]);
+      return concat([
+        path.call(print, "left"),
+        " = ",
+        path.call(print, "right")
+      ]);
 
     case "MemberExpression":
     case "OptionalMemberExpression":
-        parts.push(path.call(print, "object"));
+      parts.push(path.call(print, "object"));
 
-        var property = path.call(print, "property");
-        var optional = n.type === "OptionalMemberExpression" && n.optional;
+      var property = path.call(print, "property");
+      var optional = n.type === "OptionalMemberExpression" && n.optional;
 
-        if (n.computed) {
-            parts.push(optional ? "?.[" : "[", property, "]");
-        } else {
-            parts.push(optional ? "?." : ".", property);
-        }
+      if (n.computed) {
+        parts.push(optional ? "?.[" : "[", property, "]");
+      } else {
+        parts.push(optional ? "?." : ".", property);
+      }
 
-        return concat(parts);
+      return concat(parts);
 
     case "MetaProperty":
-        return concat([
-            path.call(print, "meta"),
-            ".",
-            path.call(print, "property")
-        ]);
+      return concat([
+        path.call(print, "meta"),
+        ".",
+        path.call(print, "property")
+      ]);
 
     case "BindExpression":
-        if (n.object) {
-            parts.push(path.call(print, "object"));
-        }
+      if (n.object) {
+        parts.push(path.call(print, "object"));
+      }
 
-        parts.push("::", path.call(print, "callee"));
+      parts.push("::", path.call(print, "callee"));
 
-        return concat(parts);
+      return concat(parts);
 
     case "Path":
-        return fromString(".").join(n.body);
+      return fromString(".").join(n.body);
 
     case "Identifier":
-        return concat([
-            fromString(n.name, options),
-            n.optional ? "?" : "",
-            path.call(print, "typeAnnotation")
-        ]);
+      return concat([
+        fromString(n.name, options),
+        n.optional ? "?" : "",
+        path.call(print, "typeAnnotation")
+      ]);
 
     case "SpreadElement":
     case "SpreadElementPattern":
@@ -331,1151 +341,1138 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     case "SpreadPropertyPattern":
     case "ObjectTypeSpreadProperty":
     case "RestElement":
-        return concat([
-            "...",
-            path.call(print, "argument"),
-            path.call(print, "typeAnnotation")
-        ]);
+      return concat([
+        "...",
+        path.call(print, "argument"),
+        path.call(print, "typeAnnotation")
+      ]);
 
     case "FunctionDeclaration":
     case "FunctionExpression":
     case "TSDeclareFunction":
-        if (n.declare) {
-            parts.push("declare ");
-        }
+      if (n.declare) {
+        parts.push("declare ");
+      }
 
-        if (n.async) {
-            parts.push("async ");
-        }
+      if (n.async) {
+        parts.push("async ");
+      }
 
-        parts.push("function");
+      parts.push("function");
 
-        if (n.generator)
-            parts.push("*");
+      if (n.generator) parts.push("*");
 
-        if (n.id) {
-            parts.push(
-                " ",
-                path.call(print, "id"),
-                path.call(print, "typeParameters")
-            );
-        } else {
-            if (n.typeParameters) {
-                parts.push(path.call(print, "typeParameters"));
-            }
-        }
-
+      if (n.id) {
         parts.push(
-            "(",
-            printFunctionParams(path, options, print),
-            ")",
-            path.call(print, "returnType")
+          " ",
+          path.call(print, "id"),
+          path.call(print, "typeParameters")
         );
-
-        if (n.body) {
-            parts.push(" ", path.call(print, "body"));
+      } else {
+        if (n.typeParameters) {
+          parts.push(path.call(print, "typeParameters"));
         }
+      }
 
-        return concat(parts);
+      parts.push(
+        "(",
+        printFunctionParams(path, options, print),
+        ")",
+        path.call(print, "returnType")
+      );
+
+      if (n.body) {
+        parts.push(" ", path.call(print, "body"));
+      }
+
+      return concat(parts);
 
     case "ArrowFunctionExpression":
-        if (n.async) {
-            parts.push("async ");
-        }
+      if (n.async) {
+        parts.push("async ");
+      }
 
-        if (n.typeParameters) {
-            parts.push(path.call(print, "typeParameters"));
-        }
+      if (n.typeParameters) {
+        parts.push(path.call(print, "typeParameters"));
+      }
 
-        if (! options.arrowParensAlways &&
-            n.params.length === 1 &&
-            ! n.rest &&
-            n.params[0].type === 'Identifier' &&
-            ! n.params[0].typeAnnotation &&
-            ! n.returnType) {
-            parts.push(path.call(print, "params", 0));
-        } else {
-            parts.push(
-                "(",
-                printFunctionParams(path, options, print),
-                ")",
-                path.call(print, "returnType")
-            );
-        }
+      if (
+        !options.arrowParensAlways &&
+        n.params.length === 1 &&
+        !n.rest &&
+        n.params[0].type === "Identifier" &&
+        !n.params[0].typeAnnotation &&
+        !n.returnType
+      ) {
+        parts.push(path.call(print, "params", 0));
+      } else {
+        parts.push(
+          "(",
+          printFunctionParams(path, options, print),
+          ")",
+          path.call(print, "returnType")
+        );
+      }
 
-        parts.push(" => ", path.call(print, "body"));
+      parts.push(" => ", path.call(print, "body"));
 
-        return concat(parts);
+      return concat(parts);
 
     case "MethodDefinition":
-        return printMethod(path, options, print);
+      return printMethod(path, options, print);
 
     case "YieldExpression":
-        parts.push("yield");
+      parts.push("yield");
 
-        if (n.delegate)
-            parts.push("*");
+      if (n.delegate) parts.push("*");
 
-        if (n.argument)
-            parts.push(" ", path.call(print, "argument"));
+      if (n.argument) parts.push(" ", path.call(print, "argument"));
 
-        return concat(parts);
+      return concat(parts);
 
     case "AwaitExpression":
-        parts.push("await");
+      parts.push("await");
 
-        if (n.all)
-            parts.push("*");
+      if (n.all) parts.push("*");
 
-        if (n.argument)
-            parts.push(" ", path.call(print, "argument"));
+      if (n.argument) parts.push(" ", path.call(print, "argument"));
 
-        return concat(parts);
+      return concat(parts);
 
     case "ModuleDeclaration":
-        parts.push("module", path.call(print, "id"));
+      parts.push("module", path.call(print, "id"));
 
-        if (n.source) {
-            assert.ok(!n.body);
-            parts.push("from", path.call(print, "source"));
-        } else {
-            parts.push(path.call(print, "body"));
-        }
+      if (n.source) {
+        assert.ok(!n.body);
+        parts.push("from", path.call(print, "source"));
+      } else {
+        parts.push(path.call(print, "body"));
+      }
 
-        return fromString(" ").join(parts);
+      return fromString(" ").join(parts);
 
     case "ImportSpecifier":
-        if (n.importKind && n.importKind !== "value") {
-            parts.push(n.importKind + " ");
+      if (n.importKind && n.importKind !== "value") {
+        parts.push(n.importKind + " ");
+      }
+      if (n.imported) {
+        parts.push(path.call(print, "imported"));
+        if (n.local && n.local.name !== n.imported.name) {
+          parts.push(" as ", path.call(print, "local"));
         }
-        if (n.imported) {
-            parts.push(path.call(print, "imported"));
-            if (n.local &&
-                n.local.name !== n.imported.name) {
-                parts.push(" as ", path.call(print, "local"));
-            }
-        } else if (n.id) {
-            parts.push(path.call(print, "id"));
-            if (n.name) {
-                parts.push(" as ", path.call(print, "name"));
-            }
+      } else if (n.id) {
+        parts.push(path.call(print, "id"));
+        if (n.name) {
+          parts.push(" as ", path.call(print, "name"));
         }
+      }
 
-        return concat(parts);
+      return concat(parts);
 
     case "ExportSpecifier":
-        if (n.local) {
-            parts.push(path.call(print, "local"));
-            if (n.exported &&
-                n.exported.name !== n.local.name) {
-                parts.push(" as ", path.call(print, "exported"));
-            }
-        } else if (n.id) {
-            parts.push(path.call(print, "id"));
-            if (n.name) {
-                parts.push(" as ", path.call(print, "name"));
-            }
+      if (n.local) {
+        parts.push(path.call(print, "local"));
+        if (n.exported && n.exported.name !== n.local.name) {
+          parts.push(" as ", path.call(print, "exported"));
         }
+      } else if (n.id) {
+        parts.push(path.call(print, "id"));
+        if (n.name) {
+          parts.push(" as ", path.call(print, "name"));
+        }
+      }
 
-        return concat(parts);
+      return concat(parts);
 
     case "ExportBatchSpecifier":
-        return fromString("*");
+      return fromString("*");
 
     case "ImportNamespaceSpecifier":
-        parts.push("* as ");
-        if (n.local) {
-            parts.push(path.call(print, "local"));
-        } else if (n.id) {
-            parts.push(path.call(print, "id"));
-        }
-        return concat(parts);
+      parts.push("* as ");
+      if (n.local) {
+        parts.push(path.call(print, "local"));
+      } else if (n.id) {
+        parts.push(path.call(print, "id"));
+      }
+      return concat(parts);
 
     case "ImportDefaultSpecifier":
-        if (n.local) {
-            return path.call(print, "local");
-        }
-        return path.call(print, "id");
+      if (n.local) {
+        return path.call(print, "local");
+      }
+      return path.call(print, "id");
 
     case "TSExportAssignment":
-        return concat(["export = ", path.call(print, "expression")]);
+      return concat(["export = ", path.call(print, "expression")]);
 
     case "ExportDeclaration":
     case "ExportDefaultDeclaration":
     case "ExportNamedDeclaration":
-        return printExportDeclaration(path, options, print);
+      return printExportDeclaration(path, options, print);
 
     case "ExportAllDeclaration":
-        parts.push("export *");
+      parts.push("export *");
 
-        if (n.exported) {
-            parts.push(" as ", path.call(print, "exported"));
-        }
+      if (n.exported) {
+        parts.push(" as ", path.call(print, "exported"));
+      }
 
-        parts.push(
-            " from ",
-            path.call(print, "source"),
-            ";"
-        );
+      parts.push(" from ", path.call(print, "source"), ";");
 
-        return concat(parts);
+      return concat(parts);
 
     case "TSNamespaceExportDeclaration":
-        parts.push("export as namespace ", path.call(print, "id"));
-        return maybeAddSemicolon(concat(parts));
+      parts.push("export as namespace ", path.call(print, "id"));
+      return maybeAddSemicolon(concat(parts));
 
     case "ExportNamespaceSpecifier":
-        return concat(["* as ", path.call(print, "exported")]);
+      return concat(["* as ", path.call(print, "exported")]);
 
     case "ExportDefaultSpecifier":
-        return path.call(print, "exported");
+      return path.call(print, "exported");
 
     case "Import":
-        return fromString("import", options);
+      return fromString("import", options);
 
     case "ImportDeclaration": {
-        parts.push("import ");
+      parts.push("import ");
 
-        if (n.importKind && n.importKind !== "value") {
-            parts.push(n.importKind + " ");
+      if (n.importKind && n.importKind !== "value") {
+        parts.push(n.importKind + " ");
+      }
+
+      if (n.specifiers && n.specifiers.length > 0) {
+        const unbracedSpecifiers: any[] = [];
+        const bracedSpecifiers: any[] = [];
+
+        path.each(function(specifierPath: any) {
+          const spec = specifierPath.getValue();
+          if (spec.type === "ImportSpecifier") {
+            bracedSpecifiers.push(print(specifierPath));
+          } else if (
+            spec.type === "ImportDefaultSpecifier" ||
+            spec.type === "ImportNamespaceSpecifier"
+          ) {
+            unbracedSpecifiers.push(print(specifierPath));
+          }
+        }, "specifiers");
+
+        unbracedSpecifiers.forEach((lines, i) => {
+          if (i > 0) {
+            parts.push(", ");
+          }
+          parts.push(lines);
+        });
+
+        if (bracedSpecifiers.length > 0) {
+          let lines = fromString(", ").join(bracedSpecifiers);
+          if (lines.getLineLength(1) > options.wrapColumn) {
+            lines = concat([
+              fromString(",\n")
+                .join(bracedSpecifiers)
+                .indent(options.tabWidth),
+              ","
+            ]);
+          }
+
+          if (unbracedSpecifiers.length > 0) {
+            parts.push(", ");
+          }
+
+          if (lines.length > 1) {
+            parts.push("{\n", lines, "\n}");
+          } else if (options.objectCurlySpacing) {
+            parts.push("{ ", lines, " }");
+          } else {
+            parts.push("{", lines, "}");
+          }
         }
 
-        if (n.specifiers &&
-            n.specifiers.length > 0) {
+        parts.push(" from ");
+      }
 
-            const unbracedSpecifiers: any[] = [];
-            const bracedSpecifiers: any[] = [];
+      parts.push(path.call(print, "source"), ";");
 
-            path.each(function (specifierPath: any) {
-                const spec = specifierPath.getValue();
-                if (spec.type === "ImportSpecifier") {
-                    bracedSpecifiers.push(print(specifierPath));
-                } else if (spec.type === "ImportDefaultSpecifier" ||
-                           spec.type === "ImportNamespaceSpecifier") {
-                    unbracedSpecifiers.push(print(specifierPath));
-                }
-            }, "specifiers");
-
-            unbracedSpecifiers.forEach((lines, i) => {
-                if (i > 0) {
-                    parts.push(", ");
-                }
-                parts.push(lines);
-            });
-
-            if (bracedSpecifiers.length > 0) {
-                let lines = fromString(", ").join(bracedSpecifiers);
-                if (lines.getLineLength(1) > options.wrapColumn) {
-                    lines = concat([
-                        fromString(",\n").join(
-                            bracedSpecifiers
-                        ).indent(options.tabWidth),
-                        ","
-                    ]);
-                }
-
-                if (unbracedSpecifiers.length > 0) {
-                    parts.push(", ");
-                }
-
-                if (lines.length > 1) {
-                    parts.push("{\n", lines, "\n}");
-                } else if (options.objectCurlySpacing) {
-                    parts.push("{ ", lines, " }");
-                } else {
-                    parts.push("{", lines, "}");
-                }
-            }
-
-            parts.push(" from ");
-        }
-
-        parts.push(path.call(print, "source"), ";");
-
-        return concat(parts);
+      return concat(parts);
     }
 
     case "BlockStatement":
-        var naked = path.call(function(bodyPath: any) {
-            return printStatementSequence(bodyPath, options, print);
-        }, "body");
+      var naked = path.call(function(bodyPath: any) {
+        return printStatementSequence(bodyPath, options, print);
+      }, "body");
 
-
-        if (naked.isEmpty()) {
-            if (!n.directives || n.directives.length === 0) {
-                return fromString("{}");
-            }
+      if (naked.isEmpty()) {
+        if (!n.directives || n.directives.length === 0) {
+          return fromString("{}");
         }
+      }
 
-        parts.push("{\n");
-        // Babel 6
-        if (n.directives) {
-            path.each(function(childPath: any) {
-                parts.push(
-                    maybeAddSemicolon(print(childPath).indent(options.tabWidth)),
-                    n.directives.length > 1 || !naked.isEmpty() ? "\n" : "");
-            }, "directives");
-        }
-        parts.push(naked.indent(options.tabWidth));
-        parts.push("\n}");
+      parts.push("{\n");
+      // Babel 6
+      if (n.directives) {
+        path.each(function(childPath: any) {
+          parts.push(
+            maybeAddSemicolon(print(childPath).indent(options.tabWidth)),
+            n.directives.length > 1 || !naked.isEmpty() ? "\n" : ""
+          );
+        }, "directives");
+      }
+      parts.push(naked.indent(options.tabWidth));
+      parts.push("\n}");
 
-        return concat(parts);
+      return concat(parts);
 
     case "ReturnStatement":
-        parts.push("return");
+      parts.push("return");
 
-        if (n.argument) {
-            const argLines = path.call(print, "argument");
-            if (argLines.startsWithComment() ||
-                (argLines.length > 1 &&
-                    namedTypes.JSXElement &&
-                    namedTypes.JSXElement.check(n.argument)
-                )) {
-                parts.push(
-                    " (\n",
-                    argLines.indent(options.tabWidth),
-                    "\n)"
-                );
-            } else {
-                parts.push(" ", argLines);
-            }
+      if (n.argument) {
+        const argLines = path.call(print, "argument");
+        if (
+          argLines.startsWithComment() ||
+          (argLines.length > 1 &&
+            namedTypes.JSXElement &&
+            namedTypes.JSXElement.check(n.argument))
+        ) {
+          parts.push(" (\n", argLines.indent(options.tabWidth), "\n)");
+        } else {
+          parts.push(" ", argLines);
         }
+      }
 
-        parts.push(";");
+      parts.push(";");
 
-        return concat(parts);
+      return concat(parts);
 
     case "CallExpression":
     case "OptionalCallExpression":
-        parts.push(path.call(print, "callee"));
+      parts.push(path.call(print, "callee"));
 
-        if (n.typeParameters) {
-            parts.push(path.call(print, "typeParameters"));
-        }
+      if (n.typeParameters) {
+        parts.push(path.call(print, "typeParameters"));
+      }
 
-        if (n.typeArguments) {
-            parts.push(path.call(print, "typeArguments"));
-        }
+      if (n.typeArguments) {
+        parts.push(path.call(print, "typeArguments"));
+      }
 
-        if (n.type === "OptionalCallExpression" &&
-            n.callee.type !== "OptionalMemberExpression") {
-            parts.push("?.");
-        }
+      if (
+        n.type === "OptionalCallExpression" &&
+        n.callee.type !== "OptionalMemberExpression"
+      ) {
+        parts.push("?.");
+      }
 
-        parts.push(printArgumentsList(path, options, print));
+      parts.push(printArgumentsList(path, options, print));
 
-        return concat(parts);
+      return concat(parts);
 
     case "ObjectExpression":
     case "ObjectPattern":
     case "ObjectTypeAnnotation":
-        var allowBreak = false;
-        var isTypeAnnotation = n.type === "ObjectTypeAnnotation";
-        var separator = options.flowObjectCommas ? "," : (isTypeAnnotation ? ";" : ",");
-        var fields = [];
+      var allowBreak = false;
+      var isTypeAnnotation = n.type === "ObjectTypeAnnotation";
+      var separator = options.flowObjectCommas
+        ? ","
+        : isTypeAnnotation
+        ? ";"
+        : ",";
+      var fields = [];
 
-        if (isTypeAnnotation) {
-            fields.push("indexers", "callProperties");
-            if (n.internalSlots != null) {
-                fields.push("internalSlots");
-            }
+      if (isTypeAnnotation) {
+        fields.push("indexers", "callProperties");
+        if (n.internalSlots != null) {
+          fields.push("internalSlots");
         }
+      }
 
-        fields.push("properties");
+      fields.push("properties");
 
-        var len = 0;
-        fields.forEach(function(field) {
-            len += n[field].length;
-        });
+      var len = 0;
+      fields.forEach(function(field) {
+        len += n[field].length;
+      });
 
-        var oneLine = (isTypeAnnotation && len === 1) || len === 0;
-        var leftBrace = n.exact ? "{|" : "{";
-        var rightBrace = n.exact ? "|}" : "}";
-        parts.push(oneLine ? leftBrace : leftBrace + "\n");
-        var leftBraceIndex = parts.length - 1;
+      var oneLine = (isTypeAnnotation && len === 1) || len === 0;
+      var leftBrace = n.exact ? "{|" : "{";
+      var rightBrace = n.exact ? "|}" : "}";
+      parts.push(oneLine ? leftBrace : leftBrace + "\n");
+      var leftBraceIndex = parts.length - 1;
 
-        var i = 0;
-        fields.forEach(function(field) {
-            path.each(function(childPath: any) {
-                let lines = print(childPath);
+      var i = 0;
+      fields.forEach(function(field) {
+        path.each(function(childPath: any) {
+          let lines = print(childPath);
 
-                if (!oneLine) {
-                    lines = lines.indent(options.tabWidth);
-                }
+          if (!oneLine) {
+            lines = lines.indent(options.tabWidth);
+          }
 
-                const multiLine = !isTypeAnnotation && lines.length > 1;
-                if (multiLine && allowBreak) {
-                    // Similar to the logic for BlockStatement.
-                    parts.push("\n");
-                }
+          const multiLine = !isTypeAnnotation && lines.length > 1;
+          if (multiLine && allowBreak) {
+            // Similar to the logic for BlockStatement.
+            parts.push("\n");
+          }
 
-                parts.push(lines);
+          parts.push(lines);
 
-                if (i < len - 1) {
-                    // Add an extra line break if the previous object property
-                    // had a multi-line value.
-                    parts.push(separator + (multiLine ? "\n\n" : "\n"));
-                    allowBreak = !multiLine;
-                } else if (len !== 1 && isTypeAnnotation) {
-                    parts.push(separator);
-                } else if (!oneLine && util.isTrailingCommaEnabled(options, "objects")) {
-                    parts.push(separator);
-                }
-                i++;
-            }, field);
-        });
+          if (i < len - 1) {
+            // Add an extra line break if the previous object property
+            // had a multi-line value.
+            parts.push(separator + (multiLine ? "\n\n" : "\n"));
+            allowBreak = !multiLine;
+          } else if (len !== 1 && isTypeAnnotation) {
+            parts.push(separator);
+          } else if (
+            !oneLine &&
+            util.isTrailingCommaEnabled(options, "objects")
+          ) {
+            parts.push(separator);
+          }
+          i++;
+        }, field);
+      });
 
-        if (n.inexact) {
-            const line = fromString("...", options);
-            if (oneLine) {
-                if (len > 0) {
-                    parts.push(separator, " ");
-                }
-                parts.push(line);
-            } else {
-                // No trailing separator after ... to maintain parity with prettier.
-                parts.push("\n", line.indent(options.tabWidth));
-            }
+      if (n.inexact) {
+        const line = fromString("...", options);
+        if (oneLine) {
+          if (len > 0) {
+            parts.push(separator, " ");
+          }
+          parts.push(line);
+        } else {
+          // No trailing separator after ... to maintain parity with prettier.
+          parts.push("\n", line.indent(options.tabWidth));
         }
+      }
 
-        parts.push(oneLine ? rightBrace : "\n" + rightBrace);
+      parts.push(oneLine ? rightBrace : "\n" + rightBrace);
 
-        if (i !== 0 && oneLine && options.objectCurlySpacing) {
-            parts[leftBraceIndex] = leftBrace + " ";
-            parts[parts.length - 1] = " " + rightBrace;
-        }
+      if (i !== 0 && oneLine && options.objectCurlySpacing) {
+        parts[leftBraceIndex] = leftBrace + " ";
+        parts[parts.length - 1] = " " + rightBrace;
+      }
 
-        if (n.typeAnnotation) {
-            parts.push(path.call(print, "typeAnnotation"));
-        }
+      if (n.typeAnnotation) {
+        parts.push(path.call(print, "typeAnnotation"));
+      }
 
-        return concat(parts);
+      return concat(parts);
 
     case "PropertyPattern":
-        return concat([
-            path.call(print, "key"),
-            ": ",
-            path.call(print, "pattern")
-        ]);
+      return concat([
+        path.call(print, "key"),
+        ": ",
+        path.call(print, "pattern")
+      ]);
 
     case "ObjectProperty": // Babel 6
     case "Property": // Non-standard AST node type.
-        if (n.method || n.kind === "get" || n.kind === "set") {
-            return printMethod(path, options, print);
-        }
+      if (n.method || n.kind === "get" || n.kind === "set") {
+        return printMethod(path, options, print);
+      }
 
-        if (n.shorthand && n.value.type === "AssignmentPattern") {
-            return path.call(print, "value");
-        }
+      if (n.shorthand && n.value.type === "AssignmentPattern") {
+        return path.call(print, "value");
+      }
 
-        var key = path.call(print, "key");
-        if (n.computed) {
-            parts.push("[", key, "]");
-        } else {
-            parts.push(key);
-        }
+      var key = path.call(print, "key");
+      if (n.computed) {
+        parts.push("[", key, "]");
+      } else {
+        parts.push(key);
+      }
 
-        if (! n.shorthand) {
-            parts.push(": ", path.call(print, "value"));
-        }
+      if (!n.shorthand) {
+        parts.push(": ", path.call(print, "value"));
+      }
 
-        return concat(parts);
+      return concat(parts);
 
     case "ClassMethod": // Babel 6
     case "ObjectMethod": // Babel 6
     case "ClassPrivateMethod":
     case "TSDeclareMethod":
-        return printMethod(path, options, print);
+      return printMethod(path, options, print);
 
     case "PrivateName":
-        return concat(["#", path.call(print, "id")]);
+      return concat(["#", path.call(print, "id")]);
 
     case "Decorator":
-        return concat(["@", path.call(print, "expression")]);
+      return concat(["@", path.call(print, "expression")]);
 
     case "ArrayExpression":
     case "ArrayPattern":
-        var elems: any[] = n.elements,
-            len = elems.length;
+      var elems: any[] = n.elements,
+        len = elems.length;
 
-        var printed = path.map(print, "elements");
-        var joined = fromString(", ").join(printed);
-        var oneLine = joined.getLineLength(1) <= options.wrapColumn;
-        if (oneLine) {
-          if (options.arrayBracketSpacing) {
-            parts.push("[ ");
+      var printed = path.map(print, "elements");
+      var joined = fromString(", ").join(printed);
+      var oneLine = joined.getLineLength(1) <= options.wrapColumn;
+      if (oneLine) {
+        if (options.arrayBracketSpacing) {
+          parts.push("[ ");
+        } else {
+          parts.push("[");
+        }
+      } else {
+        parts.push("[\n");
+      }
+
+      path.each(function(elemPath: any) {
+        const i = elemPath.getName();
+        const elem = elemPath.getValue();
+        if (!elem) {
+          // If the array expression ends with a hole, that hole
+          // will be ignored by the interpreter, but if it ends with
+          // two (or more) holes, we need to write out two (or more)
+          // commas so that the resulting code is interpreted with
+          // both (all) of the holes.
+          parts.push(",");
+        } else {
+          let lines = printed[i];
+          if (oneLine) {
+            if (i > 0) parts.push(" ");
           } else {
-            parts.push("[");
+            lines = lines.indent(options.tabWidth);
           }
-        } else {
-          parts.push("[\n");
+          parts.push(lines);
+          if (
+            i < len - 1 ||
+            (!oneLine && util.isTrailingCommaEnabled(options, "arrays"))
+          )
+            parts.push(",");
+          if (!oneLine) parts.push("\n");
         }
+      }, "elements");
 
-        path.each(function(elemPath: any) {
-            const i = elemPath.getName();
-            const elem = elemPath.getValue();
-            if (!elem) {
-                // If the array expression ends with a hole, that hole
-                // will be ignored by the interpreter, but if it ends with
-                // two (or more) holes, we need to write out two (or more)
-                // commas so that the resulting code is interpreted with
-                // both (all) of the holes.
-                parts.push(",");
-            } else {
-                let lines = printed[i];
-                if (oneLine) {
-                    if (i > 0)
-                        parts.push(" ");
-                } else {
-                    lines = lines.indent(options.tabWidth);
-                }
-                parts.push(lines);
-                if (i < len - 1 || (!oneLine && util.isTrailingCommaEnabled(options, "arrays")))
-                    parts.push(",");
-                if (!oneLine)
-                    parts.push("\n");
-            }
-        }, "elements");
+      if (oneLine && options.arrayBracketSpacing) {
+        parts.push(" ]");
+      } else {
+        parts.push("]");
+      }
 
-        if (oneLine && options.arrayBracketSpacing) {
-          parts.push(" ]");
-        } else {
-          parts.push("]");
-        }
+      if (n.typeAnnotation) {
+        parts.push(path.call(print, "typeAnnotation"));
+      }
 
-        if (n.typeAnnotation) {
-          parts.push(path.call(print, "typeAnnotation"));
-        }
-
-        return concat(parts);
+      return concat(parts);
 
     case "SequenceExpression":
-        return fromString(", ").join(path.map(print, "expressions"));
+      return fromString(", ").join(path.map(print, "expressions"));
 
     case "ThisExpression":
-        return fromString("this");
+      return fromString("this");
 
     case "Super":
-        return fromString("super");
+      return fromString("super");
 
     case "NullLiteral": // Babel 6 Literal split
-        return fromString("null");
+      return fromString("null");
 
     case "RegExpLiteral": // Babel 6 Literal split
-        return fromString(n.extra.raw);
+      return fromString(n.extra.raw);
 
     case "BigIntLiteral": // Babel 7 Literal split
-        return fromString(n.value + "n");
+      return fromString(n.value + "n");
 
     case "NumericLiteral": // Babel 6 Literal Split
-        // Keep original representation for numeric values not in base 10.
-        if (n.extra &&
-            typeof n.extra.raw === "string" &&
-            Number(n.extra.raw) === n.value) {
-            return fromString(n.extra.raw, options);
-        }
+      // Keep original representation for numeric values not in base 10.
+      if (
+        n.extra &&
+        typeof n.extra.raw === "string" &&
+        Number(n.extra.raw) === n.value
+      ) {
+        return fromString(n.extra.raw, options);
+      }
 
-        return fromString(n.value, options);
+      return fromString(n.value, options);
 
     case "BooleanLiteral": // Babel 6 Literal split
 
     case "StringLiteral": // Babel 6 Literal split
     case "Literal":
-        // Numeric values may be in bases other than 10. Use their raw
-        // representation if equivalent.
-        if (typeof n.value === "number" &&
-            typeof n.raw === "string" &&
-            Number(n.raw) === n.value) {
-            return fromString(n.raw, options);
-        }
+      // Numeric values may be in bases other than 10. Use their raw
+      // representation if equivalent.
+      if (
+        typeof n.value === "number" &&
+        typeof n.raw === "string" &&
+        Number(n.raw) === n.value
+      ) {
+        return fromString(n.raw, options);
+      }
 
-        if (typeof n.value !== "string") {
-            return fromString(n.value, options);
-        }
+      if (typeof n.value !== "string") {
+        return fromString(n.value, options);
+      }
 
-        return fromString(nodeStr(n.value, options), options);
+      return fromString(nodeStr(n.value, options), options);
 
     case "Directive": // Babel 6
-        return path.call(print, "value");
+      return path.call(print, "value");
 
     case "DirectiveLiteral": // Babel 6
-        return fromString(nodeStr(n.value, options));
+      return fromString(nodeStr(n.value, options));
 
     case "InterpreterDirective":
-        return fromString(`#!${n.value}\n`, options);
+      return fromString(`#!${n.value}\n`, options);
 
     case "ModuleSpecifier":
-        if (n.local) {
-            throw new Error(
-                "The ESTree ModuleSpecifier type should be abstract"
-            );
-        }
+      if (n.local) {
+        throw new Error("The ESTree ModuleSpecifier type should be abstract");
+      }
 
-        // The Esprima ModuleSpecifier type is just a string-valued
-        // Literal identifying the imported-from module.
-        return fromString(nodeStr(n.value, options), options);
+      // The Esprima ModuleSpecifier type is just a string-valued
+      // Literal identifying the imported-from module.
+      return fromString(nodeStr(n.value, options), options);
 
     case "UnaryExpression":
-        parts.push(n.operator);
-        if (/[a-z]$/.test(n.operator))
-            parts.push(" ");
-        parts.push(path.call(print, "argument"));
-        return concat(parts);
+      parts.push(n.operator);
+      if (/[a-z]$/.test(n.operator)) parts.push(" ");
+      parts.push(path.call(print, "argument"));
+      return concat(parts);
 
     case "UpdateExpression":
-        parts.push(
-            path.call(print, "argument"),
-            n.operator
-        );
+      parts.push(path.call(print, "argument"), n.operator);
 
-        if (n.prefix)
-            parts.reverse();
+      if (n.prefix) parts.reverse();
 
-        return concat(parts);
+      return concat(parts);
 
     case "ConditionalExpression":
-        return concat([
-            path.call(print, "test"),
-            " ? ", path.call(print, "consequent"),
-            " : ", path.call(print, "alternate")
-        ]);
+      return concat([
+        path.call(print, "test"),
+        " ? ",
+        path.call(print, "consequent"),
+        " : ",
+        path.call(print, "alternate")
+      ]);
 
     case "NewExpression":
-        parts.push("new ", path.call(print, "callee"));
-        if (n.typeParameters) {
-            parts.push(path.call(print, "typeParameters"));
-        }
-        if (n.typeArguments) {
-            parts.push(path.call(print, "typeArguments"));
-        }
-        var args = n.arguments;
-        if (args) {
-            parts.push(printArgumentsList(path, options, print));
-        }
+      parts.push("new ", path.call(print, "callee"));
+      if (n.typeParameters) {
+        parts.push(path.call(print, "typeParameters"));
+      }
+      if (n.typeArguments) {
+        parts.push(path.call(print, "typeArguments"));
+      }
+      var args = n.arguments;
+      if (args) {
+        parts.push(printArgumentsList(path, options, print));
+      }
 
-        return concat(parts);
+      return concat(parts);
 
     case "VariableDeclaration":
-        if (n.declare) {
-            parts.push("declare ");
-        }
+      if (n.declare) {
+        parts.push("declare ");
+      }
 
-        parts.push(n.kind, " ");
+      parts.push(n.kind, " ");
 
-        var maxLen = 0;
-        var printed = path.map(function(childPath: any) {
-            const lines = print(childPath);
-            maxLen = Math.max(lines.length, maxLen);
-            return lines;
-        }, "declarations");
+      var maxLen = 0;
+      var printed = path.map(function(childPath: any) {
+        const lines = print(childPath);
+        maxLen = Math.max(lines.length, maxLen);
+        return lines;
+      }, "declarations");
 
-        if (maxLen === 1) {
-            parts.push(fromString(", ").join(printed));
-        } else if (printed.length > 1 ) {
-            parts.push(
-                fromString(",\n").join(printed)
-                    .indentTail(n.kind.length + 1)
-            );
-        } else {
-            parts.push(printed[0]);
-        }
+      if (maxLen === 1) {
+        parts.push(fromString(", ").join(printed));
+      } else if (printed.length > 1) {
+        parts.push(
+          fromString(",\n")
+            .join(printed)
+            .indentTail(n.kind.length + 1)
+        );
+      } else {
+        parts.push(printed[0]);
+      }
 
-        // We generally want to terminate all variable declarations with a
-        // semicolon, except when they are children of for loops.
-        var parentNode = path.getParentNode();
-        if (!namedTypes.ForStatement.check(parentNode) &&
-            !namedTypes.ForInStatement.check(parentNode) &&
-            !(namedTypes.ForOfStatement &&
-              namedTypes.ForOfStatement.check(parentNode)) &&
-            !(namedTypes.ForAwaitStatement &&
-              namedTypes.ForAwaitStatement.check(parentNode))) {
-            parts.push(";");
-        }
+      // We generally want to terminate all variable declarations with a
+      // semicolon, except when they are children of for loops.
+      var parentNode = path.getParentNode();
+      if (
+        !namedTypes.ForStatement.check(parentNode) &&
+        !namedTypes.ForInStatement.check(parentNode) &&
+        !(
+          namedTypes.ForOfStatement &&
+          namedTypes.ForOfStatement.check(parentNode)
+        ) &&
+        !(
+          namedTypes.ForAwaitStatement &&
+          namedTypes.ForAwaitStatement.check(parentNode)
+        )
+      ) {
+        parts.push(";");
+      }
 
-        return concat(parts);
+      return concat(parts);
 
     case "VariableDeclarator":
-        return n.init ? fromString(" = ").join([
+      return n.init
+        ? fromString(" = ").join([
             path.call(print, "id"),
             path.call(print, "init")
-        ]) : path.call(print, "id");
+          ])
+        : path.call(print, "id");
 
     case "WithStatement":
-        return concat([
-            "with (",
-            path.call(print, "object"),
-            ") ",
-            path.call(print, "body")
-        ]);
+      return concat([
+        "with (",
+        path.call(print, "object"),
+        ") ",
+        path.call(print, "body")
+      ]);
 
     case "IfStatement":
-        var con = adjustClause(path.call(print, "consequent"), options);
-        parts.push("if (", path.call(print, "test"), ")", con);
+      var con = adjustClause(path.call(print, "consequent"), options);
+      parts.push("if (", path.call(print, "test"), ")", con);
 
-        if (n.alternate)
-            parts.push(
-                endsWithBrace(con) ? " else" : "\nelse",
-                adjustClause(path.call(print, "alternate"), options));
+      if (n.alternate)
+        parts.push(
+          endsWithBrace(con) ? " else" : "\nelse",
+          adjustClause(path.call(print, "alternate"), options)
+        );
 
-        return concat(parts);
+      return concat(parts);
 
     case "ForStatement":
-        // TODO Get the for (;;) case right.
-        var init = path.call(print, "init"),
-            sep = init.length > 1 ? ";\n" : "; ",
-            forParen = "for (",
-            indented = fromString(sep).join([
-                init,
-                path.call(print, "test"),
-                path.call(print, "update")
-            ]).indentTail(forParen.length),
-            head = concat([forParen, indented, ")"]),
-            clause = adjustClause(path.call(print, "body"), options);
+      // TODO Get the for (;;) case right.
+      var init = path.call(print, "init"),
+        sep = init.length > 1 ? ";\n" : "; ",
+        forParen = "for (",
+        indented = fromString(sep)
+          .join([init, path.call(print, "test"), path.call(print, "update")])
+          .indentTail(forParen.length),
+        head = concat([forParen, indented, ")"]),
+        clause = adjustClause(path.call(print, "body"), options);
 
-        parts.push(head);
+      parts.push(head);
 
-        if (head.length > 1) {
-            parts.push("\n");
-            clause = clause.trimLeft();
-        }
+      if (head.length > 1) {
+        parts.push("\n");
+        clause = clause.trimLeft();
+      }
 
-        parts.push(clause);
+      parts.push(clause);
 
-        return concat(parts);
+      return concat(parts);
 
     case "WhileStatement":
-        return concat([
-            "while (",
-            path.call(print, "test"),
-            ")",
-            adjustClause(path.call(print, "body"), options)
-        ]);
+      return concat([
+        "while (",
+        path.call(print, "test"),
+        ")",
+        adjustClause(path.call(print, "body"), options)
+      ]);
 
     case "ForInStatement":
-        // Note: esprima can't actually parse "for each (".
-        return concat([
-            n.each ? "for each (" : "for (",
-            path.call(print, "left"),
-            " in ",
-            path.call(print, "right"),
-            ")",
-            adjustClause(path.call(print, "body"), options)
-        ]);
+      // Note: esprima can't actually parse "for each (".
+      return concat([
+        n.each ? "for each (" : "for (",
+        path.call(print, "left"),
+        " in ",
+        path.call(print, "right"),
+        ")",
+        adjustClause(path.call(print, "body"), options)
+      ]);
 
     case "ForOfStatement":
     case "ForAwaitStatement":
-        parts.push("for ");
+      parts.push("for ");
 
-        if (n.await || n.type === "ForAwaitStatement") {
-            parts.push("await ");
-        }
+      if (n.await || n.type === "ForAwaitStatement") {
+        parts.push("await ");
+      }
 
-        parts.push(
-            "(",
-            path.call(print, "left"),
-            " of ",
-            path.call(print, "right"),
-            ")",
-            adjustClause(path.call(print, "body"), options)
-        );
+      parts.push(
+        "(",
+        path.call(print, "left"),
+        " of ",
+        path.call(print, "right"),
+        ")",
+        adjustClause(path.call(print, "body"), options)
+      );
 
-        return concat(parts);
+      return concat(parts);
 
     case "DoWhileStatement":
-        var doBody = concat([
-            "do",
-            adjustClause(path.call(print, "body"), options)
-        ]);
+      var doBody = concat([
+        "do",
+        adjustClause(path.call(print, "body"), options)
+      ]);
 
-        parts.push(doBody);
+      parts.push(doBody);
 
-        if (endsWithBrace(doBody))
-            parts.push(" while");
-        else
-            parts.push("\nwhile");
+      if (endsWithBrace(doBody)) parts.push(" while");
+      else parts.push("\nwhile");
 
-        parts.push(" (", path.call(print, "test"), ");");
+      parts.push(" (", path.call(print, "test"), ");");
 
-        return concat(parts);
+      return concat(parts);
 
     case "DoExpression":
-        var statements = path.call(function(bodyPath: any) {
-            return printStatementSequence(bodyPath, options, print);
-        }, "body");
+      var statements = path.call(function(bodyPath: any) {
+        return printStatementSequence(bodyPath, options, print);
+      }, "body");
 
-        return concat([
-            "do {\n",
-            statements.indent(options.tabWidth),
-            "\n}"
-        ]);
+      return concat(["do {\n", statements.indent(options.tabWidth), "\n}"]);
 
     case "BreakStatement":
-        parts.push("break");
-        if (n.label)
-            parts.push(" ", path.call(print, "label"));
-        parts.push(";");
-        return concat(parts);
+      parts.push("break");
+      if (n.label) parts.push(" ", path.call(print, "label"));
+      parts.push(";");
+      return concat(parts);
 
     case "ContinueStatement":
-        parts.push("continue");
-        if (n.label)
-            parts.push(" ", path.call(print, "label"));
-        parts.push(";");
-        return concat(parts);
+      parts.push("continue");
+      if (n.label) parts.push(" ", path.call(print, "label"));
+      parts.push(";");
+      return concat(parts);
 
     case "LabeledStatement":
-        return concat([
-            path.call(print, "label"),
-            ":\n",
-            path.call(print, "body")
-        ]);
+      return concat([
+        path.call(print, "label"),
+        ":\n",
+        path.call(print, "body")
+      ]);
 
     case "TryStatement":
-        parts.push(
-            "try ",
-            path.call(print, "block")
-        );
+      parts.push("try ", path.call(print, "block"));
 
-        if (n.handler) {
-            parts.push(" ", path.call(print, "handler"));
-        } else if (n.handlers) {
-            path.each(function(handlerPath: any) {
-                parts.push(" ", print(handlerPath));
-            }, "handlers");
-        }
+      if (n.handler) {
+        parts.push(" ", path.call(print, "handler"));
+      } else if (n.handlers) {
+        path.each(function(handlerPath: any) {
+          parts.push(" ", print(handlerPath));
+        }, "handlers");
+      }
 
-        if (n.finalizer) {
-            parts.push(" finally ", path.call(print, "finalizer"));
-        }
+      if (n.finalizer) {
+        parts.push(" finally ", path.call(print, "finalizer"));
+      }
 
-        return concat(parts);
+      return concat(parts);
 
     case "CatchClause":
-        parts.push("catch ");
+      parts.push("catch ");
 
-        if (n.param) {
-            parts.push("(", path.call(print, "param"));
-        }
+      if (n.param) {
+        parts.push("(", path.call(print, "param"));
+      }
 
-        if (n.guard) {
-            // Note: esprima does not recognize conditional catch clauses.
-            parts.push(" if ", path.call(print, "guard"));
-        }
+      if (n.guard) {
+        // Note: esprima does not recognize conditional catch clauses.
+        parts.push(" if ", path.call(print, "guard"));
+      }
 
-        if (n.param) {
-            parts.push(") ");
-        }
+      if (n.param) {
+        parts.push(") ");
+      }
 
-        parts.push(path.call(print, "body"));
+      parts.push(path.call(print, "body"));
 
-        return concat(parts);
+      return concat(parts);
 
     case "ThrowStatement":
-        return concat(["throw ", path.call(print, "argument"), ";"]);
+      return concat(["throw ", path.call(print, "argument"), ";"]);
 
     case "SwitchStatement":
-        return concat([
-            "switch (",
-            path.call(print, "discriminant"),
-            ") {\n",
-            fromString("\n").join(path.map(print, "cases")),
-            "\n}"
-        ]);
+      return concat([
+        "switch (",
+        path.call(print, "discriminant"),
+        ") {\n",
+        fromString("\n").join(path.map(print, "cases")),
+        "\n}"
+      ]);
 
-        // Note: ignoring n.lexical because it has no printing consequences.
+    // Note: ignoring n.lexical because it has no printing consequences.
 
     case "SwitchCase":
-        if (n.test)
-            parts.push("case ", path.call(print, "test"), ":");
-        else
-            parts.push("default:");
+      if (n.test) parts.push("case ", path.call(print, "test"), ":");
+      else parts.push("default:");
 
-        if (n.consequent.length > 0) {
-            parts.push("\n", path.call(function(consequentPath: any) {
-                return printStatementSequence(consequentPath, options, print);
-            }, "consequent").indent(options.tabWidth));
-        }
+      if (n.consequent.length > 0) {
+        parts.push(
+          "\n",
+          path
+            .call(function(consequentPath: any) {
+              return printStatementSequence(consequentPath, options, print);
+            }, "consequent")
+            .indent(options.tabWidth)
+        );
+      }
 
-        return concat(parts);
+      return concat(parts);
 
     case "DebuggerStatement":
-        return fromString("debugger;");
+      return fromString("debugger;");
 
     // JSX extensions below.
 
     case "JSXAttribute":
-        parts.push(path.call(print, "name"));
-        if (n.value)
-            parts.push("=", path.call(print, "value"));
-        return concat(parts);
+      parts.push(path.call(print, "name"));
+      if (n.value) parts.push("=", path.call(print, "value"));
+      return concat(parts);
 
     case "JSXIdentifier":
-        return fromString(n.name, options);
+      return fromString(n.name, options);
 
     case "JSXNamespacedName":
-        return fromString(":").join([
-            path.call(print, "namespace"),
-            path.call(print, "name")
-        ]);
+      return fromString(":").join([
+        path.call(print, "namespace"),
+        path.call(print, "name")
+      ]);
 
     case "JSXMemberExpression":
-        return fromString(".").join([
-            path.call(print, "object"),
-            path.call(print, "property")
-        ]);
+      return fromString(".").join([
+        path.call(print, "object"),
+        path.call(print, "property")
+      ]);
 
     case "JSXSpreadAttribute":
-        return concat(["{...", path.call(print, "argument"), "}"]);
+      return concat(["{...", path.call(print, "argument"), "}"]);
 
     case "JSXSpreadChild":
-        return concat(["{...", path.call(print, "expression"), "}"]);
+      return concat(["{...", path.call(print, "expression"), "}"]);
 
     case "JSXExpressionContainer":
-        return concat(["{", path.call(print, "expression"), "}"]);
+      return concat(["{", path.call(print, "expression"), "}"]);
 
     case "JSXElement":
     case "JSXFragment":
-        var openingPropName = "opening" + (
-            n.type === "JSXElement" ? "Element" : "Fragment");
+      var openingPropName =
+        "opening" + (n.type === "JSXElement" ? "Element" : "Fragment");
 
-        var closingPropName = "closing" + (
-            n.type === "JSXElement" ? "Element" : "Fragment");
+      var closingPropName =
+        "closing" + (n.type === "JSXElement" ? "Element" : "Fragment");
 
-        var openingLines = path.call(print, openingPropName);
+      var openingLines = path.call(print, openingPropName);
 
-        if (n[openingPropName].selfClosing) {
-            assert.ok(
-                !n[closingPropName],
-                "unexpected " + closingPropName + " element in self-closing " + n.type
-            );
-            return openingLines;
-        }
+      if (n[openingPropName].selfClosing) {
+        assert.ok(
+          !n[closingPropName],
+          "unexpected " + closingPropName + " element in self-closing " + n.type
+        );
+        return openingLines;
+      }
 
-        var childLines = concat(
-            path.map(function(childPath: any) {
-                const child = childPath.getValue();
+      var childLines = concat(
+        path.map(function(childPath: any) {
+          const child = childPath.getValue();
 
-                if (namedTypes.Literal.check(child) &&
-                    typeof child.value === "string") {
-                    if (/\S/.test(child.value)) {
-                        return child.value.replace(/^\s+|\s+$/g, "");
-                    } else if (/\n/.test(child.value)) {
-                        return "\n";
-                    }
-                }
+          if (
+            namedTypes.Literal.check(child) &&
+            typeof child.value === "string"
+          ) {
+            if (/\S/.test(child.value)) {
+              return child.value.replace(/^\s+|\s+$/g, "");
+            } else if (/\n/.test(child.value)) {
+              return "\n";
+            }
+          }
 
-                return print(childPath);
-            }, "children")
-        ).indentTail(options.tabWidth);
+          return print(childPath);
+        }, "children")
+      ).indentTail(options.tabWidth);
 
-        var closingLines = path.call(print, closingPropName);
+      var closingLines = path.call(print, closingPropName);
 
-        return concat([
-            openingLines,
-            childLines,
-            closingLines
-        ]);
+      return concat([openingLines, childLines, closingLines]);
 
     case "JSXOpeningElement":
-        parts.push("<", path.call(print, "name"));
-        var attrParts: any[] = [];
+      parts.push("<", path.call(print, "name"));
+      var attrParts: any[] = [];
 
-        path.each(function(attrPath: any) {
-            attrParts.push(" ", print(attrPath));
-        }, "attributes");
+      path.each(function(attrPath: any) {
+        attrParts.push(" ", print(attrPath));
+      }, "attributes");
 
-        var attrLines = concat(attrParts);
+      var attrLines = concat(attrParts);
 
-        var needLineWrap = (
-            attrLines.length > 1 ||
-            attrLines.getLineLength(1) > options.wrapColumn
-        );
+      var needLineWrap =
+        attrLines.length > 1 || attrLines.getLineLength(1) > options.wrapColumn;
 
-        if (needLineWrap) {
-            attrParts.forEach(function(part, i) {
-                if (part === " ") {
-                    assert.strictEqual(i % 2, 0);
-                    attrParts[i] = "\n";
-                }
-            });
+      if (needLineWrap) {
+        attrParts.forEach(function(part, i) {
+          if (part === " ") {
+            assert.strictEqual(i % 2, 0);
+            attrParts[i] = "\n";
+          }
+        });
 
-            attrLines = concat(attrParts).indentTail(options.tabWidth);
-        }
+        attrLines = concat(attrParts).indentTail(options.tabWidth);
+      }
 
-        parts.push(attrLines, n.selfClosing ? " />" : ">");
+      parts.push(attrLines, n.selfClosing ? " />" : ">");
 
-        return concat(parts);
+      return concat(parts);
 
     case "JSXClosingElement":
-        return concat(["</", path.call(print, "name"), ">"]);
+      return concat(["</", path.call(print, "name"), ">"]);
 
     case "JSXOpeningFragment":
-        return fromString("<>");
+      return fromString("<>");
 
     case "JSXClosingFragment":
-        return fromString("</>")
+      return fromString("</>");
 
     case "JSXText":
-        return fromString(n.value, options);
+      return fromString(n.value, options);
 
     case "JSXEmptyExpression":
-        return fromString("");
+      return fromString("");
 
     case "TypeAnnotatedIdentifier":
-        return concat([
-            path.call(print, "annotation"),
-            " ",
-            path.call(print, "identifier")
-        ]);
+      return concat([
+        path.call(print, "annotation"),
+        " ",
+        path.call(print, "identifier")
+      ]);
 
     case "ClassBody":
-        if (n.body.length === 0) {
-            return fromString("{}");
-        }
+      if (n.body.length === 0) {
+        return fromString("{}");
+      }
 
-        return concat([
-            "{\n",
-            path.call(function(bodyPath: any) {
-                return printStatementSequence(bodyPath, options, print);
-            }, "body").indent(options.tabWidth),
-            "\n}"
-        ]);
+      return concat([
+        "{\n",
+        path
+          .call(function(bodyPath: any) {
+            return printStatementSequence(bodyPath, options, print);
+          }, "body")
+          .indent(options.tabWidth),
+        "\n}"
+      ]);
 
     case "ClassPropertyDefinition":
-        parts.push("static ", path.call(print, "definition"));
-        if (!namedTypes.MethodDefinition.check(n.definition))
-            parts.push(";");
-        return concat(parts);
+      parts.push("static ", path.call(print, "definition"));
+      if (!namedTypes.MethodDefinition.check(n.definition)) parts.push(";");
+      return concat(parts);
 
     case "ClassProperty":
-        var access = n.accessibility || n.access;
-        if (typeof access === "string") {
-            parts.push(access, " ");
-        }
+      var access = n.accessibility || n.access;
+      if (typeof access === "string") {
+        parts.push(access, " ");
+      }
 
-        if (n.static) {
-            parts.push("static ");
-        }
+      if (n.static) {
+        parts.push("static ");
+      }
 
-        if (n.abstract) {
-            parts.push("abstract ");
-        }
+      if (n.abstract) {
+        parts.push("abstract ");
+      }
 
-        if (n.readonly) {
-            parts.push("readonly ");
-        }
+      if (n.readonly) {
+        parts.push("readonly ");
+      }
 
-        var key = path.call(print, "key");
+      var key = path.call(print, "key");
 
-        if (n.computed) {
-            key = concat(["[", key, "]"]);
-        }
+      if (n.computed) {
+        key = concat(["[", key, "]"]);
+      }
 
-        if (n.variance) {
-            key = concat([printVariance(path, print), key]);
-        }
+      if (n.variance) {
+        key = concat([printVariance(path, print), key]);
+      }
 
-        parts.push(key);
+      parts.push(key);
 
-        if (n.optional) {
-            parts.push("?");
-        }
+      if (n.optional) {
+        parts.push("?");
+      }
 
-        if (n.typeAnnotation) {
-            parts.push(path.call(print, "typeAnnotation"));
-        }
+      if (n.typeAnnotation) {
+        parts.push(path.call(print, "typeAnnotation"));
+      }
 
-        if (n.value) {
-            parts.push(" = ", path.call(print, "value"));
-        }
+      if (n.value) {
+        parts.push(" = ", path.call(print, "value"));
+      }
 
-        parts.push(";");
-        return concat(parts);
+      parts.push(";");
+      return concat(parts);
 
     case "ClassPrivateProperty":
-        if (n.static) {
-            parts.push("static ");
-        }
+      if (n.static) {
+        parts.push("static ");
+      }
 
-        parts.push(path.call(print, "key"));
+      parts.push(path.call(print, "key"));
 
-        if (n.typeAnnotation) {
-            parts.push(path.call(print, "typeAnnotation"));
-        }
+      if (n.typeAnnotation) {
+        parts.push(path.call(print, "typeAnnotation"));
+      }
 
-        if (n.value) {
-            parts.push(" = ", path.call(print, "value"));
-        }
+      if (n.value) {
+        parts.push(" = ", path.call(print, "value"));
+      }
 
-        parts.push(";");
-        return concat(parts);
+      parts.push(";");
+      return concat(parts);
 
     case "ClassDeclaration":
     case "ClassExpression":
-        if (n.declare) {
-            parts.push("declare ");
-        }
+      if (n.declare) {
+        parts.push("declare ");
+      }
 
-        if (n.abstract) {
-            parts.push("abstract ");
-        }
+      if (n.abstract) {
+        parts.push("abstract ");
+      }
 
-        parts.push("class");
+      parts.push("class");
 
-        if (n.id) {
-            parts.push(
-                " ",
-                path.call(print, "id")
-            );
-        }
+      if (n.id) {
+        parts.push(" ", path.call(print, "id"));
+      }
 
-        if (n.typeParameters) {
-            parts.push(path.call(print, "typeParameters"));
-        }
+      if (n.typeParameters) {
+        parts.push(path.call(print, "typeParameters"));
+      }
 
-        if (n.superClass) {
-            parts.push(
-                " extends ",
-                path.call(print, "superClass"),
-                path.call(print, "superTypeParameters")
-            );
-        }
+      if (n.superClass) {
+        parts.push(
+          " extends ",
+          path.call(print, "superClass"),
+          path.call(print, "superTypeParameters")
+        );
+      }
 
-        if (n["implements"] && n['implements'].length > 0) {
-            parts.push(
-                " implements ",
-                fromString(", ").join(path.map(print, "implements"))
-            );
-        }
+      if (n["implements"] && n["implements"].length > 0) {
+        parts.push(
+          " implements ",
+          fromString(", ").join(path.map(print, "implements"))
+        );
+      }
 
-        parts.push(" ", path.call(print, "body"));
+      parts.push(" ", path.call(print, "body"));
 
-        return concat(parts);
+      return concat(parts);
 
     case "TemplateElement":
-        return fromString(n.value.raw, options).lockIndentTail();
+      return fromString(n.value.raw, options).lockIndentTail();
 
     case "TemplateLiteral":
-        var expressions = path.map(print, "expressions");
-        parts.push("`");
+      var expressions = path.map(print, "expressions");
+      parts.push("`");
 
-        path.each(function(childPath: any) {
-            const i = childPath.getName();
-            parts.push(print(childPath));
-            if (i < expressions.length) {
-                parts.push("${", expressions[i], "}");
-            }
-        }, "quasis");
+      path.each(function(childPath: any) {
+        const i = childPath.getName();
+        parts.push(print(childPath));
+        if (i < expressions.length) {
+          parts.push("${", expressions[i], "}");
+        }
+      }, "quasis");
 
-        parts.push("`");
+      parts.push("`");
 
-        return concat(parts).lockIndentTail();
+      return concat(parts).lockIndentTail();
 
     case "TaggedTemplateExpression":
-        return concat([
-            path.call(print, "tag"),
-            path.call(print, "quasi")
-        ]);
+      return concat([path.call(print, "tag"), path.call(print, "quasi")]);
 
     // These types are unprintable because they serve as abstract
     // supertypes for other (printable) types.
@@ -1499,973 +1496,877 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     case "TSHasOptionalTypeParameterInstantiation":
     case "TSHasOptionalTypeParameters":
     case "TSHasOptionalTypeAnnotation":
-        throw new Error("unprintable type: " + JSON.stringify(n.type));
+      throw new Error("unprintable type: " + JSON.stringify(n.type));
 
     case "CommentBlock": // Babel block comment.
     case "Block": // Esprima block comment.
-        return concat(["/*", fromString(n.value, options), "*/"]);
+      return concat(["/*", fromString(n.value, options), "*/"]);
 
     case "CommentLine": // Babel line comment.
     case "Line": // Esprima line comment.
-        return concat(["//", fromString(n.value, options)]);
+      return concat(["//", fromString(n.value, options)]);
 
     // Type Annotations for Facebook Flow, typically stripped out or
     // transformed away before printing.
     case "TypeAnnotation":
-        if (n.typeAnnotation) {
-            if (n.typeAnnotation.type !== "FunctionTypeAnnotation") {
-                parts.push(": ");
-            }
-            parts.push(path.call(print, "typeAnnotation"));
-            return concat(parts);
+      if (n.typeAnnotation) {
+        if (n.typeAnnotation.type !== "FunctionTypeAnnotation") {
+          parts.push(": ");
         }
+        parts.push(path.call(print, "typeAnnotation"));
+        return concat(parts);
+      }
 
-        return fromString("");
+      return fromString("");
 
     case "ExistentialTypeParam":
     case "ExistsTypeAnnotation":
-        return fromString("*", options);
+      return fromString("*", options);
 
     case "EmptyTypeAnnotation":
-        return fromString("empty", options);
+      return fromString("empty", options);
 
     case "AnyTypeAnnotation":
-        return fromString("any", options);
+      return fromString("any", options);
 
     case "MixedTypeAnnotation":
-        return fromString("mixed", options);
+      return fromString("mixed", options);
 
     case "ArrayTypeAnnotation":
-        return concat([
-            path.call(print, "elementType"),
-            "[]"
-        ]);
+      return concat([path.call(print, "elementType"), "[]"]);
 
     case "TupleTypeAnnotation":
-        var printed = path.map(print, "types");
-        var joined = fromString(", ").join(printed);
-        var oneLine = joined.getLineLength(1) <= options.wrapColumn;
-        if (oneLine) {
-          if (options.arrayBracketSpacing) {
-            parts.push("[ ");
+      var printed = path.map(print, "types");
+      var joined = fromString(", ").join(printed);
+      var oneLine = joined.getLineLength(1) <= options.wrapColumn;
+      if (oneLine) {
+        if (options.arrayBracketSpacing) {
+          parts.push("[ ");
+        } else {
+          parts.push("[");
+        }
+      } else {
+        parts.push("[\n");
+      }
+
+      path.each(function(elemPath: any) {
+        const i = elemPath.getName();
+        const elem = elemPath.getValue();
+        if (!elem) {
+          // If the array expression ends with a hole, that hole
+          // will be ignored by the interpreter, but if it ends with
+          // two (or more) holes, we need to write out two (or more)
+          // commas so that the resulting code is interpreted with
+          // both (all) of the holes.
+          parts.push(",");
+        } else {
+          let lines = printed[i];
+          if (oneLine) {
+            if (i > 0) parts.push(" ");
           } else {
-            parts.push("[");
+            lines = lines.indent(options.tabWidth);
           }
-        } else {
-          parts.push("[\n");
+          parts.push(lines);
+          if (
+            i < n.types.length - 1 ||
+            (!oneLine && util.isTrailingCommaEnabled(options, "arrays"))
+          )
+            parts.push(",");
+          if (!oneLine) parts.push("\n");
         }
+      }, "types");
 
-        path.each(function(elemPath: any) {
-            const i = elemPath.getName();
-            const elem = elemPath.getValue();
-            if (!elem) {
-                // If the array expression ends with a hole, that hole
-                // will be ignored by the interpreter, but if it ends with
-                // two (or more) holes, we need to write out two (or more)
-                // commas so that the resulting code is interpreted with
-                // both (all) of the holes.
-                parts.push(",");
-            } else {
-                let lines = printed[i];
-                if (oneLine) {
-                    if (i > 0)
-                        parts.push(" ");
-                } else {
-                    lines = lines.indent(options.tabWidth);
-                }
-                parts.push(lines);
-                if (i < n.types.length - 1 || (!oneLine && util.isTrailingCommaEnabled(options, "arrays")))
-                    parts.push(",");
-                if (!oneLine)
-                    parts.push("\n");
-            }
-        }, "types");
+      if (oneLine && options.arrayBracketSpacing) {
+        parts.push(" ]");
+      } else {
+        parts.push("]");
+      }
 
-        if (oneLine && options.arrayBracketSpacing) {
-          parts.push(" ]");
-        } else {
-          parts.push("]");
-        }
-
-        return concat(parts);
+      return concat(parts);
 
     case "BooleanTypeAnnotation":
-        return fromString("boolean", options);
+      return fromString("boolean", options);
 
     case "BooleanLiteralTypeAnnotation":
-        assert.strictEqual(typeof n.value, "boolean");
-        return fromString("" + n.value, options);
+      assert.strictEqual(typeof n.value, "boolean");
+      return fromString("" + n.value, options);
 
     case "InterfaceTypeAnnotation":
-        parts.push("interface");
-        if (n.extends && n.extends.length > 0) {
-            parts.push(
-                " extends ",
-                fromString(", ").join(path.map(print, "extends"))
-            );
-        }
-        parts.push(" ", path.call(print, "body"));
-        return concat(parts);
+      parts.push("interface");
+      if (n.extends && n.extends.length > 0) {
+        parts.push(
+          " extends ",
+          fromString(", ").join(path.map(print, "extends"))
+        );
+      }
+      parts.push(" ", path.call(print, "body"));
+      return concat(parts);
 
     case "DeclareClass":
-        return printFlowDeclaration(path, [
-            "class ",
-            path.call(print, "id"),
-            " ",
-            path.call(print, "body"),
-        ]);
+      return printFlowDeclaration(path, [
+        "class ",
+        path.call(print, "id"),
+        " ",
+        path.call(print, "body")
+      ]);
 
     case "DeclareFunction":
-        return printFlowDeclaration(path, [
-            "function ",
-            path.call(print, "id"),
-            ";"
-        ]);
+      return printFlowDeclaration(path, [
+        "function ",
+        path.call(print, "id"),
+        ";"
+      ]);
 
     case "DeclareModule":
-        return printFlowDeclaration(path, [
-            "module ",
-            path.call(print, "id"),
-            " ",
-            path.call(print, "body"),
-        ]);
+      return printFlowDeclaration(path, [
+        "module ",
+        path.call(print, "id"),
+        " ",
+        path.call(print, "body")
+      ]);
 
     case "DeclareModuleExports":
-        return printFlowDeclaration(path, [
-            "module.exports",
-            path.call(print, "typeAnnotation"),
-        ]);
+      return printFlowDeclaration(path, [
+        "module.exports",
+        path.call(print, "typeAnnotation")
+      ]);
 
     case "DeclareVariable":
-        return printFlowDeclaration(path, [
-            "var ",
-            path.call(print, "id"),
-            ";"
-        ]);
+      return printFlowDeclaration(path, ["var ", path.call(print, "id"), ";"]);
 
     case "DeclareExportDeclaration":
     case "DeclareExportAllDeclaration":
-        return concat([
-            "declare ",
-            printExportDeclaration(path, options, print)
-        ]);
+      return concat(["declare ", printExportDeclaration(path, options, print)]);
 
     case "InferredPredicate":
-        return fromString("%checks", options);
+      return fromString("%checks", options);
 
     case "DeclaredPredicate":
-        return concat([
-            "%checks(",
-            path.call(print, "value"),
-            ")"
-        ]);
+      return concat(["%checks(", path.call(print, "value"), ")"]);
 
     case "FunctionTypeAnnotation":
-        // FunctionTypeAnnotation is ambiguous:
-        // declare function(a: B): void; OR
-        // var A: (a: B) => void;
-        var parent = path.getParentNode(0);
-        var isArrowFunctionTypeAnnotation = !(
-            namedTypes.ObjectTypeCallProperty.check(parent) ||
-            (namedTypes.ObjectTypeInternalSlot.check(parent) && parent.method) ||
-            namedTypes.DeclareFunction.check(path.getParentNode(2))
-        );
+      // FunctionTypeAnnotation is ambiguous:
+      // declare function(a: B): void; OR
+      // var A: (a: B) => void;
+      var parent = path.getParentNode(0);
+      var isArrowFunctionTypeAnnotation = !(
+        namedTypes.ObjectTypeCallProperty.check(parent) ||
+        (namedTypes.ObjectTypeInternalSlot.check(parent) && parent.method) ||
+        namedTypes.DeclareFunction.check(path.getParentNode(2))
+      );
 
-        var needsColon =
-            isArrowFunctionTypeAnnotation &&
-            !namedTypes.FunctionTypeParam.check(parent);
+      var needsColon =
+        isArrowFunctionTypeAnnotation &&
+        !namedTypes.FunctionTypeParam.check(parent);
 
-        if (needsColon) {
-            parts.push(": ");
-        }
+      if (needsColon) {
+        parts.push(": ");
+      }
 
+      parts.push("(", printFunctionParams(path, options, print), ")");
+
+      // The returnType is not wrapped in a TypeAnnotation, so the colon
+      // needs to be added separately.
+      if (n.returnType) {
         parts.push(
-            "(",
-            printFunctionParams(path, options, print),
-            ")",
+          isArrowFunctionTypeAnnotation ? " => " : ": ",
+          path.call(print, "returnType")
         );
+      }
 
-        // The returnType is not wrapped in a TypeAnnotation, so the colon
-        // needs to be added separately.
-        if (n.returnType) {
-            parts.push(
-                isArrowFunctionTypeAnnotation ? " => " : ": ",
-                path.call(print, "returnType")
-            );
-        }
-
-        return concat(parts);
+      return concat(parts);
 
     case "FunctionTypeParam":
-        return concat([
-            path.call(print, "name"),
-            n.optional ? '?' : '',
-            ": ",
-            path.call(print, "typeAnnotation"),
-        ]);
+      return concat([
+        path.call(print, "name"),
+        n.optional ? "?" : "",
+        ": ",
+        path.call(print, "typeAnnotation")
+      ]);
 
     case "GenericTypeAnnotation":
-        return concat([
-            path.call(print, "id"),
-            path.call(print, "typeParameters")
-        ]);
+      return concat([
+        path.call(print, "id"),
+        path.call(print, "typeParameters")
+      ]);
 
     case "DeclareInterface":
-        parts.push("declare ");
-        // Fall through to InterfaceDeclaration...
+      parts.push("declare ");
+    // Fall through to InterfaceDeclaration...
 
     case "InterfaceDeclaration":
     case "TSInterfaceDeclaration":
-        if (n.declare) {
-            parts.push("declare ");
-        }
+      if (n.declare) {
+        parts.push("declare ");
+      }
 
+      parts.push(
+        "interface ",
+        path.call(print, "id"),
+        path.call(print, "typeParameters"),
+        " "
+      );
+
+      if (n["extends"] && n["extends"].length > 0) {
         parts.push(
-            "interface ",
-            path.call(print, "id"),
-            path.call(print, "typeParameters"),
-            " "
+          "extends ",
+          fromString(", ").join(path.map(print, "extends")),
+          " "
         );
+      }
 
-        if (n["extends"] && n["extends"].length > 0) {
-            parts.push(
-                "extends ",
-                fromString(", ").join(path.map(print, "extends")),
-                " "
-            );
-        }
+      if (n.body) {
+        parts.push(path.call(print, "body"));
+      }
 
-        if (n.body) {
-            parts.push(path.call(print, "body"));
-        }
-
-        return concat(parts);
+      return concat(parts);
 
     case "ClassImplements":
     case "InterfaceExtends":
-        return concat([
-            path.call(print, "id"),
-            path.call(print, "typeParameters")
-        ]);
+      return concat([
+        path.call(print, "id"),
+        path.call(print, "typeParameters")
+      ]);
 
     case "IntersectionTypeAnnotation":
-        return fromString(" & ").join(path.map(print, "types"));
+      return fromString(" & ").join(path.map(print, "types"));
 
     case "NullableTypeAnnotation":
-        return concat([
-            "?",
-            path.call(print, "typeAnnotation")
-        ]);
+      return concat(["?", path.call(print, "typeAnnotation")]);
 
     case "NullLiteralTypeAnnotation":
-        return fromString("null", options);
+      return fromString("null", options);
 
     case "ThisTypeAnnotation":
-        return fromString("this", options);
+      return fromString("this", options);
 
     case "NumberTypeAnnotation":
-        return fromString("number", options);
+      return fromString("number", options);
 
     case "ObjectTypeCallProperty":
-        return path.call(print, "value");
+      return path.call(print, "value");
 
     case "ObjectTypeIndexer":
-        return concat([
-            printVariance(path, print),
-            "[",
-            path.call(print, "id"),
-            ": ",
-            path.call(print, "key"),
-            "]: ",
-            path.call(print, "value")
-        ]);
+      return concat([
+        printVariance(path, print),
+        "[",
+        path.call(print, "id"),
+        ": ",
+        path.call(print, "key"),
+        "]: ",
+        path.call(print, "value")
+      ]);
 
     case "ObjectTypeProperty":
-        return concat([
-            printVariance(path, print),
-            path.call(print, "key"),
-            n.optional ? "?" : "",
-            ": ",
-            path.call(print, "value")
-        ]);
+      return concat([
+        printVariance(path, print),
+        path.call(print, "key"),
+        n.optional ? "?" : "",
+        ": ",
+        path.call(print, "value")
+      ]);
 
     case "ObjectTypeInternalSlot":
-        return concat([
-            n.static ? "static " : "",
-            "[[",
-            path.call(print, "id"),
-            "]]",
-            n.optional ? "?" : "",
-            n.value.type !== "FunctionTypeAnnotation" ? ": " : "",
-            path.call(print, "value")
-        ]);
+      return concat([
+        n.static ? "static " : "",
+        "[[",
+        path.call(print, "id"),
+        "]]",
+        n.optional ? "?" : "",
+        n.value.type !== "FunctionTypeAnnotation" ? ": " : "",
+        path.call(print, "value")
+      ]);
 
     case "QualifiedTypeIdentifier":
-        return concat([
-            path.call(print, "qualification"),
-            ".",
-            path.call(print, "id")
-        ]);
+      return concat([
+        path.call(print, "qualification"),
+        ".",
+        path.call(print, "id")
+      ]);
 
     case "StringLiteralTypeAnnotation":
-        return fromString(nodeStr(n.value, options), options);
+      return fromString(nodeStr(n.value, options), options);
 
     case "NumberLiteralTypeAnnotation":
     case "NumericLiteralTypeAnnotation":
-        assert.strictEqual(typeof n.value, "number");
-        return fromString(JSON.stringify(n.value), options);
+      assert.strictEqual(typeof n.value, "number");
+      return fromString(JSON.stringify(n.value), options);
 
     case "StringTypeAnnotation":
-        return fromString("string", options);
+      return fromString("string", options);
 
     case "DeclareTypeAlias":
-        parts.push("declare ");
-        // Fall through to TypeAlias...
+      parts.push("declare ");
+    // Fall through to TypeAlias...
 
     case "TypeAlias":
-        return concat([
-            "type ",
-            path.call(print, "id"),
-            path.call(print, "typeParameters"),
-            " = ",
-            path.call(print, "right"),
-            ";"
-        ]);
+      return concat([
+        "type ",
+        path.call(print, "id"),
+        path.call(print, "typeParameters"),
+        " = ",
+        path.call(print, "right"),
+        ";"
+      ]);
 
     case "DeclareOpaqueType":
-        parts.push("declare ");
-        // Fall through to OpaqueType...
+      parts.push("declare ");
+    // Fall through to OpaqueType...
 
     case "OpaqueType":
-        parts.push(
-            "opaque type ",
-            path.call(print, "id"),
-            path.call(print, "typeParameters")
-        );
+      parts.push(
+        "opaque type ",
+        path.call(print, "id"),
+        path.call(print, "typeParameters")
+      );
 
-        if (n["supertype"]) {
-            parts.push(": ", path.call(print, "supertype"));
-        }
+      if (n["supertype"]) {
+        parts.push(": ", path.call(print, "supertype"));
+      }
 
-        if (n["impltype"]) {
-            parts.push(" = ", path.call(print, "impltype"));
-        }
+      if (n["impltype"]) {
+        parts.push(" = ", path.call(print, "impltype"));
+      }
 
-        parts.push(";");
+      parts.push(";");
 
-        return concat(parts);
+      return concat(parts);
 
     case "TypeCastExpression":
-        return concat([
-            "(",
-            path.call(print, "expression"),
-            path.call(print, "typeAnnotation"),
-            ")"
-        ]);
+      return concat([
+        "(",
+        path.call(print, "expression"),
+        path.call(print, "typeAnnotation"),
+        ")"
+      ]);
 
     case "TypeParameterDeclaration":
     case "TypeParameterInstantiation":
-        return concat([
-            "<",
-            fromString(", ").join(path.map(print, "params")),
-            ">"
-        ]);
+      return concat([
+        "<",
+        fromString(", ").join(path.map(print, "params")),
+        ">"
+      ]);
 
     case "Variance":
-        if (n.kind === "plus") {
-            return fromString("+");
-        }
+      if (n.kind === "plus") {
+        return fromString("+");
+      }
 
-        if (n.kind === "minus") {
-            return fromString("-");
-        }
+      if (n.kind === "minus") {
+        return fromString("-");
+      }
 
-        return fromString("");
+      return fromString("");
 
     case "TypeParameter":
-        if (n.variance) {
-            parts.push(printVariance(path, print));
-        }
+      if (n.variance) {
+        parts.push(printVariance(path, print));
+      }
 
-        parts.push(path.call(print, 'name'));
+      parts.push(path.call(print, "name"));
 
-        if (n.bound) {
-            parts.push(path.call(print, 'bound'));
-        }
+      if (n.bound) {
+        parts.push(path.call(print, "bound"));
+      }
 
-        if (n['default']) {
-            parts.push('=', path.call(print, 'default'));
-        }
+      if (n["default"]) {
+        parts.push("=", path.call(print, "default"));
+      }
 
-        return concat(parts);
+      return concat(parts);
 
     case "TypeofTypeAnnotation":
-        return concat([
-            fromString("typeof ", options),
-            path.call(print, "argument")
-        ]);
+      return concat([
+        fromString("typeof ", options),
+        path.call(print, "argument")
+      ]);
 
     case "UnionTypeAnnotation":
-        return fromString(" | ").join(path.map(print, "types"));
+      return fromString(" | ").join(path.map(print, "types"));
 
     case "VoidTypeAnnotation":
-        return fromString("void", options);
+      return fromString("void", options);
 
     case "NullTypeAnnotation":
-        return fromString("null", options);
+      return fromString("null", options);
 
     // Type Annotations for TypeScript (when using Babylon as parser)
     case "TSType":
-        throw new Error("unprintable type: " + JSON.stringify(n.type));
+      throw new Error("unprintable type: " + JSON.stringify(n.type));
 
     case "TSNumberKeyword":
-        return fromString("number", options);
+      return fromString("number", options);
 
     case "TSBigIntKeyword":
-        return fromString("bigint", options);
+      return fromString("bigint", options);
 
     case "TSObjectKeyword":
-        return fromString("object", options);
+      return fromString("object", options);
 
     case "TSBooleanKeyword":
-        return fromString("boolean", options);
+      return fromString("boolean", options);
 
     case "TSStringKeyword":
-        return fromString("string", options);
+      return fromString("string", options);
 
     case "TSSymbolKeyword":
-        return fromString("symbol", options);
+      return fromString("symbol", options);
 
     case "TSAnyKeyword":
-        return fromString("any", options);
+      return fromString("any", options);
 
     case "TSVoidKeyword":
-        return fromString("void", options);
+      return fromString("void", options);
 
     case "TSThisType":
-        return fromString("this", options);
+      return fromString("this", options);
 
     case "TSNullKeyword":
-        return fromString("null", options);
+      return fromString("null", options);
 
     case "TSUndefinedKeyword":
-        return fromString("undefined", options);
+      return fromString("undefined", options);
 
     case "TSUnknownKeyword":
-        return fromString("unknown", options);
+      return fromString("unknown", options);
 
     case "TSNeverKeyword":
-        return fromString("never", options);
+      return fromString("never", options);
 
     case "TSArrayType":
-        return concat([
-            path.call(print, "elementType"),
-            "[]"
-        ]);
+      return concat([path.call(print, "elementType"), "[]"]);
 
     case "TSLiteralType":
-        return path.call(print, "literal")
+      return path.call(print, "literal");
 
     case "TSUnionType":
-        return fromString(" | ").join(path.map(print, "types"));
+      return fromString(" | ").join(path.map(print, "types"));
 
     case "TSIntersectionType":
-        return fromString(" & ").join(path.map(print, "types"));
+      return fromString(" & ").join(path.map(print, "types"));
 
     case "TSConditionalType":
-        parts.push(
-            path.call(print, "checkType"),
-            " extends ",
-            path.call(print, "extendsType"),
-            " ? ",
-            path.call(print, "trueType"),
-            " : ",
-            path.call(print, "falseType")
-        );
+      parts.push(
+        path.call(print, "checkType"),
+        " extends ",
+        path.call(print, "extendsType"),
+        " ? ",
+        path.call(print, "trueType"),
+        " : ",
+        path.call(print, "falseType")
+      );
 
-        return concat(parts);
+      return concat(parts);
 
     case "TSInferType":
-        parts.push(
-            "infer ",
-            path.call(print, "typeParameter")
-        );
+      parts.push("infer ", path.call(print, "typeParameter"));
 
-        return concat(parts);
+      return concat(parts);
 
     case "TSParenthesizedType":
-        return concat([
-            "(",
-            path.call(print, "typeAnnotation"),
-            ")"
-        ]);
+      return concat(["(", path.call(print, "typeAnnotation"), ")"]);
 
     case "TSFunctionType":
-        return concat([
-            path.call(print, "typeParameters"),
-            "(",
-            printFunctionParams(path, options, print),
-            ")",
-            path.call(print, "typeAnnotation")
-        ]);
+      return concat([
+        path.call(print, "typeParameters"),
+        "(",
+        printFunctionParams(path, options, print),
+        ")",
+        path.call(print, "typeAnnotation")
+      ]);
 
     case "TSConstructorType":
-        return concat([
-            "new ",
-            path.call(print, 'typeParameters'),
-            "(",
-            printFunctionParams(path, options, print),
-            ")",
-            path.call(print, "typeAnnotation")
-        ]);
+      return concat([
+        "new ",
+        path.call(print, "typeParameters"),
+        "(",
+        printFunctionParams(path, options, print),
+        ")",
+        path.call(print, "typeAnnotation")
+      ]);
 
     case "TSMappedType": {
-        parts.push(
-            n.readonly ? "readonly " : "",
-            "[",
-            path.call(print, "typeParameter"),
-            "]",
-            n.optional ? "?" : ""
-        );
+      parts.push(
+        n.readonly ? "readonly " : "",
+        "[",
+        path.call(print, "typeParameter"),
+        "]",
+        n.optional ? "?" : ""
+      );
 
-        if (n.typeAnnotation) {
-            parts.push(": ", path.call(print, "typeAnnotation"), ";");
-        }
+      if (n.typeAnnotation) {
+        parts.push(": ", path.call(print, "typeAnnotation"), ";");
+      }
 
-        return concat([
-            "{\n",
-            concat(parts).indent(options.tabWidth),
-            "\n}",
-        ]);
+      return concat(["{\n", concat(parts).indent(options.tabWidth), "\n}"]);
     }
 
     case "TSTupleType":
-        return concat([
-            "[",
-            fromString(", ").join(path.map(print, "elementTypes")),
-            "]"
-        ]);
+      return concat([
+        "[",
+        fromString(", ").join(path.map(print, "elementTypes")),
+        "]"
+      ]);
 
     case "TSRestType":
-        return concat([
-            "...",
-            path.call(print, "typeAnnotation"),
-            "[]"
-        ]);
+      return concat(["...", path.call(print, "typeAnnotation"), "[]"]);
 
     case "TSOptionalType":
-        return concat([
-            path.call(print, "typeAnnotation"),
-            "?"
-        ]);
+      return concat([path.call(print, "typeAnnotation"), "?"]);
 
     case "TSIndexedAccessType":
-        return concat([
-            path.call(print, "objectType"),
-            "[",
-            path.call(print, "indexType"),
-            "]"
-        ]);
+      return concat([
+        path.call(print, "objectType"),
+        "[",
+        path.call(print, "indexType"),
+        "]"
+      ]);
 
     case "TSTypeOperator":
-        return concat([
-            path.call(print, "operator"),
-            " ",
-            path.call(print, "typeAnnotation")
-        ]);
+      return concat([
+        path.call(print, "operator"),
+        " ",
+        path.call(print, "typeAnnotation")
+      ]);
 
     case "TSTypeLiteral": {
-        const memberLines =
-            fromString(",\n").join(path.map(print, "members"));
+      const memberLines = fromString(",\n").join(path.map(print, "members"));
 
-        if (memberLines.isEmpty()) {
-            return fromString("{}", options);
-        }
+      if (memberLines.isEmpty()) {
+        return fromString("{}", options);
+      }
 
-        parts.push(
-            "{\n",
-            memberLines.indent(options.tabWidth),
-            "\n}"
-        );
+      parts.push("{\n", memberLines.indent(options.tabWidth), "\n}");
 
-        return concat(parts);
+      return concat(parts);
     }
 
     case "TSEnumMember":
-        parts.push(path.call(print, "id"));
-        if (n.initializer) {
-            parts.push(
-                " = ",
-                path.call(print, "initializer")
-            );
-        }
-        return concat(parts);
+      parts.push(path.call(print, "id"));
+      if (n.initializer) {
+        parts.push(" = ", path.call(print, "initializer"));
+      }
+      return concat(parts);
 
     case "TSTypeQuery":
-        return concat([
-            "typeof ",
-            path.call(print, "exprName"),
-        ]);
+      return concat(["typeof ", path.call(print, "exprName")]);
 
     case "TSParameterProperty":
-        if (n.accessibility) {
-            parts.push(n.accessibility, " ");
-        }
+      if (n.accessibility) {
+        parts.push(n.accessibility, " ");
+      }
 
-        if (n.export) {
-            parts.push("export ");
-        }
+      if (n.export) {
+        parts.push("export ");
+      }
 
-        if (n.static) {
-            parts.push("static ");
-        }
+      if (n.static) {
+        parts.push("static ");
+      }
 
-        if (n.readonly) {
-            parts.push("readonly ");
-        }
+      if (n.readonly) {
+        parts.push("readonly ");
+      }
 
-        parts.push(path.call(print, "parameter"));
+      parts.push(path.call(print, "parameter"));
 
-        return concat(parts);
+      return concat(parts);
 
     case "TSTypeReference":
-        return concat([
-            path.call(print, "typeName"),
-            path.call(print, "typeParameters")
-        ]);
+      return concat([
+        path.call(print, "typeName"),
+        path.call(print, "typeParameters")
+      ]);
 
     case "TSQualifiedName":
-        return concat([
-            path.call(print, "left"),
-            ".",
-            path.call(print, "right")
-        ]);
+      return concat([path.call(print, "left"), ".", path.call(print, "right")]);
 
     case "TSAsExpression": {
-        var withParens = n.extra && n.extra.parenthesized === true;
-        if (withParens) parts.push("(");
-        parts.push(
-            path.call(print, "expression"),
-            fromString(" as "),
-            path.call(print, "typeAnnotation")
-        );
-        if (withParens) parts.push(")");
+      var withParens = n.extra && n.extra.parenthesized === true;
+      if (withParens) parts.push("(");
+      parts.push(
+        path.call(print, "expression"),
+        fromString(" as "),
+        path.call(print, "typeAnnotation")
+      );
+      if (withParens) parts.push(")");
 
-        return concat(parts);
+      return concat(parts);
     }
 
     case "TSNonNullExpression":
-        return concat([
-            path.call(print, "expression"),
-            "!"
-        ]);
+      return concat([path.call(print, "expression"), "!"]);
 
     case "TSTypeAnnotation": {
-        // similar to flow's FunctionTypeAnnotation, this can be
-        // ambiguous: it can be prefixed by => or :
-        // in a type predicate, it takes the for u is U
-        var parent = path.getParentNode(0);
-        let prefix = ": ";
-        if (namedTypes.TSFunctionType.check(parent) || namedTypes.TSConstructorType.check(parent)) {
-            prefix = " => ";
-        }
+      // similar to flow's FunctionTypeAnnotation, this can be
+      // ambiguous: it can be prefixed by => or :
+      // in a type predicate, it takes the for u is U
+      var parent = path.getParentNode(0);
+      let prefix = ": ";
+      if (
+        namedTypes.TSFunctionType.check(parent) ||
+        namedTypes.TSConstructorType.check(parent)
+      ) {
+        prefix = " => ";
+      }
 
-        if (namedTypes.TSTypePredicate.check(parent)) {
-            prefix = " is ";
-        }
+      if (namedTypes.TSTypePredicate.check(parent)) {
+        prefix = " is ";
+      }
 
-        return concat([
-            prefix,
-            path.call(print, "typeAnnotation")
-        ]);
+      return concat([prefix, path.call(print, "typeAnnotation")]);
     }
 
     case "TSIndexSignature":
-        return concat([
-            n.readonly ? "readonly " : "",
-            "[",
-            path.map(print, "parameters"),
-            "]",
-            path.call(print, "typeAnnotation")
-        ]);
+      return concat([
+        n.readonly ? "readonly " : "",
+        "[",
+        path.map(print, "parameters"),
+        "]",
+        path.call(print, "typeAnnotation")
+      ]);
 
     case "TSPropertySignature":
-        parts.push(
-            printVariance(path, print),
-            n.readonly ? "readonly " : ""
-        );
+      parts.push(printVariance(path, print), n.readonly ? "readonly " : "");
 
-        if (n.computed) {
-            parts.push(
-                "[",
-                path.call(print, "key"),
-                "]"
-            );
-        } else {
-            parts.push(path.call(print, "key"));
-        }
+      if (n.computed) {
+        parts.push("[", path.call(print, "key"), "]");
+      } else {
+        parts.push(path.call(print, "key"));
+      }
 
-        parts.push(
-            n.optional ? "?" : "",
-            path.call(print, "typeAnnotation")
-        );
+      parts.push(n.optional ? "?" : "", path.call(print, "typeAnnotation"));
 
-        return concat(parts);
+      return concat(parts);
 
     case "TSMethodSignature":
-        if (n.computed) {
-            parts.push(
-                "[",
-                path.call(print, "key"),
-                "]"
-            );
-        } else {
-            parts.push(path.call(print, "key"));
-        }
+      if (n.computed) {
+        parts.push("[", path.call(print, "key"), "]");
+      } else {
+        parts.push(path.call(print, "key"));
+      }
 
-        if (n.optional) {
-            parts.push("?");
-        }
+      if (n.optional) {
+        parts.push("?");
+      }
 
-        parts.push(
-            path.call(print, "typeParameters"),
-            "(",
-            printFunctionParams(path, options, print),
-            ")",
-            path.call(print, "typeAnnotation")
-        );
+      parts.push(
+        path.call(print, "typeParameters"),
+        "(",
+        printFunctionParams(path, options, print),
+        ")",
+        path.call(print, "typeAnnotation")
+      );
 
-        return concat(parts);
+      return concat(parts);
 
     case "TSTypePredicate":
-        return concat([
-            path.call(print, "parameterName"),
-            path.call(print, "typeAnnotation")
-        ]);
+      return concat([
+        path.call(print, "parameterName"),
+        path.call(print, "typeAnnotation")
+      ]);
 
     case "TSCallSignatureDeclaration":
-        return concat([
-            path.call(print, "typeParameters"),
-            "(",
-            printFunctionParams(path, options, print),
-            ")",
-            path.call(print, "typeAnnotation")
-        ]);
+      return concat([
+        path.call(print, "typeParameters"),
+        "(",
+        printFunctionParams(path, options, print),
+        ")",
+        path.call(print, "typeAnnotation")
+      ]);
 
     case "TSConstructSignatureDeclaration":
-        if (n.typeParameters) {
-            parts.push(
-                "new",
-                path.call(print, "typeParameters")
-            );
-        } else {
-            parts.push("new ");
-        }
+      if (n.typeParameters) {
+        parts.push("new", path.call(print, "typeParameters"));
+      } else {
+        parts.push("new ");
+      }
 
-        parts.push(
-            "(",
-            printFunctionParams(path, options, print),
-            ")",
-            path.call(print, "typeAnnotation")
-        );
+      parts.push(
+        "(",
+        printFunctionParams(path, options, print),
+        ")",
+        path.call(print, "typeAnnotation")
+      );
 
-        return concat(parts);
+      return concat(parts);
 
     case "TSTypeAliasDeclaration":
-        return concat([
-            n.declare ? "declare " : "",
-            "type ",
-            path.call(print, "id"),
-            path.call(print, "typeParameters"),
-            " = ",
-            path.call(print, "typeAnnotation"),
-            ";"
-        ]);
+      return concat([
+        n.declare ? "declare " : "",
+        "type ",
+        path.call(print, "id"),
+        path.call(print, "typeParameters"),
+        " = ",
+        path.call(print, "typeAnnotation"),
+        ";"
+      ]);
 
     case "TSTypeParameter":
-        parts.push(path.call(print, "name"));
+      parts.push(path.call(print, "name"));
 
-        // ambiguous because of TSMappedType
-        var parent = path.getParentNode(0);
-        var isInMappedType = namedTypes.TSMappedType.check(parent);
+      // ambiguous because of TSMappedType
+      var parent = path.getParentNode(0);
+      var isInMappedType = namedTypes.TSMappedType.check(parent);
 
-        if (n.constraint) {
-            parts.push(
-                isInMappedType ? " in " : " extends ",
-                path.call(print, "constraint")
-            );
-        }
+      if (n.constraint) {
+        parts.push(
+          isInMappedType ? " in " : " extends ",
+          path.call(print, "constraint")
+        );
+      }
 
-        if (n["default"]) {
-            parts.push(" = ", path.call(print, "default"));
-        }
+      if (n["default"]) {
+        parts.push(" = ", path.call(print, "default"));
+      }
 
-        return concat(parts);
+      return concat(parts);
 
     case "TSTypeAssertion":
-        var withParens = n.extra && n.extra.parenthesized === true;
-        if (withParens) {
-            parts.push("(");
-        }
+      var withParens = n.extra && n.extra.parenthesized === true;
+      if (withParens) {
+        parts.push("(");
+      }
 
-        parts.push(
-            "<",
-            path.call(print, "typeAnnotation"),
-            "> ",
-            path.call(print, "expression")
-        );
+      parts.push(
+        "<",
+        path.call(print, "typeAnnotation"),
+        "> ",
+        path.call(print, "expression")
+      );
 
-        if (withParens) {
-            parts.push(")");
-        }
+      if (withParens) {
+        parts.push(")");
+      }
 
-        return concat(parts);
+      return concat(parts);
 
     case "TSTypeParameterDeclaration":
     case "TSTypeParameterInstantiation":
-        return concat([
-            "<",
-            fromString(", ").join(path.map(print, "params")),
-            ">"
-        ]);
+      return concat([
+        "<",
+        fromString(", ").join(path.map(print, "params")),
+        ">"
+      ]);
 
     case "TSEnumDeclaration":
-        parts.push(
-            n.declare ? "declare " : "",
-            n.const ? "const " : "",
-            "enum ",
-            path.call(print, "id")
-        );
+      parts.push(
+        n.declare ? "declare " : "",
+        n.const ? "const " : "",
+        "enum ",
+        path.call(print, "id")
+      );
 
-        const memberLines =
-            fromString(",\n").join(path.map(print, "members"));
+      const memberLines = fromString(",\n").join(path.map(print, "members"));
 
-        if (memberLines.isEmpty()) {
-            parts.push(" {}");
-        } else {
-            parts.push(
-                " {\n",
-                memberLines.indent(options.tabWidth),
-                "\n}"
-            );
-        }
+      if (memberLines.isEmpty()) {
+        parts.push(" {}");
+      } else {
+        parts.push(" {\n", memberLines.indent(options.tabWidth), "\n}");
+      }
 
-        return concat(parts);
+      return concat(parts);
 
     case "TSExpressionWithTypeArguments":
-        return concat([
-            path.call(print, "expression"),
-            path.call(print, "typeParameters")
-        ]);
+      return concat([
+        path.call(print, "expression"),
+        path.call(print, "typeParameters")
+      ]);
 
     case "TSInterfaceBody":
-        var lines = fromString(";\n").join(path.map(print, "body"));
-        if (lines.isEmpty()) {
-            return fromString("{}", options);
-        }
+      var lines = fromString(";\n").join(path.map(print, "body"));
+      if (lines.isEmpty()) {
+        return fromString("{}", options);
+      }
 
-        return concat([
-            "{\n",
-            lines.indent(options.tabWidth), ";",
-            "\n}",
-        ]);
+      return concat(["{\n", lines.indent(options.tabWidth), ";", "\n}"]);
 
     case "TSImportType":
-        parts.push("import(", path.call(print, "argument"), ")");
+      parts.push("import(", path.call(print, "argument"), ")");
 
-        if (n.qualifier) {
-            parts.push(".", path.call(print, "qualifier"));
-        }
+      if (n.qualifier) {
+        parts.push(".", path.call(print, "qualifier"));
+      }
 
-        if (n.typeParameters) {
-            parts.push(path.call(print, "typeParameters"));
-        }
+      if (n.typeParameters) {
+        parts.push(path.call(print, "typeParameters"));
+      }
 
-        return concat(parts);
+      return concat(parts);
 
     case "TSImportEqualsDeclaration":
-        if (n.isExport) {
-            parts.push("export ");
-        }
+      if (n.isExport) {
+        parts.push("export ");
+      }
 
-        parts.push(
-            "import ",
-            path.call(print, "id"),
-            " = ",
-            path.call(print, "moduleReference")
-        );
+      parts.push(
+        "import ",
+        path.call(print, "id"),
+        " = ",
+        path.call(print, "moduleReference")
+      );
 
-        return maybeAddSemicolon(concat(parts));
+      return maybeAddSemicolon(concat(parts));
 
     case "TSExternalModuleReference":
       return concat(["require(", path.call(print, "expression"), ")"]);
 
     case "TSModuleDeclaration": {
-        const parent = path.getParentNode();
+      const parent = path.getParentNode();
 
-        if (parent.type === "TSModuleDeclaration") {
-            parts.push(".");
-        } else {
-            if (n.declare) {
-                parts.push("declare ");
-            }
-
-            if (! n.global) {
-                const isExternal = n.id.type === "StringLiteral" ||
-                    (n.id.type === "Literal" &&
-                     typeof n.id.value === "string");
-
-                if (isExternal) {
-                    parts.push("module ");
-
-                } else if (n.loc &&
-                           n.loc.lines &&
-                           n.id.loc) {
-                    const prefix = n.loc.lines.sliceString(
-                        n.loc.start,
-                        n.id.loc.start
-                    );
-
-                    // These keywords are fundamentally ambiguous in the
-                    // Babylon parser, and not reflected in the AST, so
-                    // the best we can do is to match the original code,
-                    // when possible.
-                    if (prefix.indexOf("module") >= 0) {
-                        parts.push("module ");
-                    } else {
-                        parts.push("namespace ");
-                    }
-
-                } else {
-                    parts.push("namespace ");
-                }
-            }
+      if (parent.type === "TSModuleDeclaration") {
+        parts.push(".");
+      } else {
+        if (n.declare) {
+          parts.push("declare ");
         }
 
-        parts.push(path.call(print, "id"));
+        if (!n.global) {
+          const isExternal =
+            n.id.type === "StringLiteral" ||
+            (n.id.type === "Literal" && typeof n.id.value === "string");
 
-        if (n.body && n.body.type === "TSModuleDeclaration") {
-            parts.push(path.call(print, "body"));
-        } else if (n.body) {
-            const bodyLines = path.call(print, "body");
-            if (bodyLines.isEmpty()) {
-                parts.push(" {}");
+          if (isExternal) {
+            parts.push("module ");
+          } else if (n.loc && n.loc.lines && n.id.loc) {
+            const prefix = n.loc.lines.sliceString(n.loc.start, n.id.loc.start);
+
+            // These keywords are fundamentally ambiguous in the
+            // Babylon parser, and not reflected in the AST, so
+            // the best we can do is to match the original code,
+            // when possible.
+            if (prefix.indexOf("module") >= 0) {
+              parts.push("module ");
             } else {
-                parts.push(
-                    " {\n",
-                    bodyLines.indent(options.tabWidth),
-                    "\n}"
-                );
+              parts.push("namespace ");
             }
+          } else {
+            parts.push("namespace ");
+          }
         }
+      }
 
-        return concat(parts);
+      parts.push(path.call(print, "id"));
+
+      if (n.body && n.body.type === "TSModuleDeclaration") {
+        parts.push(path.call(print, "body"));
+      } else if (n.body) {
+        const bodyLines = path.call(print, "body");
+        if (bodyLines.isEmpty()) {
+          parts.push(" {}");
+        } else {
+          parts.push(" {\n", bodyLines.indent(options.tabWidth), "\n}");
+        }
+      }
+
+      return concat(parts);
     }
 
     case "TSModuleBlock":
-        return path.call(function (bodyPath: any) {
-            return printStatementSequence(bodyPath, options, print);
-        }, "body");
+      return path.call(function(bodyPath: any) {
+        return printStatementSequence(bodyPath, options, print);
+      }, "body");
 
     // Unhandled types below. If encountered, nodes of these types should
     // be either left alone or desugared into AST types that are fully
@@ -2501,498 +2402,495 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     case "XMLComment":
     case "XMLProcessingInstruction":
     default:
-        debugger;
-        throw new Error("unknown type: " + JSON.stringify(n.type));
-    }
+      debugger;
+      throw new Error("unknown type: " + JSON.stringify(n.type));
+  }
 }
 
 function printDecorators(path: any, printPath: any) {
-    const parts: any[] = [];
-    const node = path.getValue();
+  const parts: any[] = [];
+  const node = path.getValue();
 
-    if (node.decorators &&
-        node.decorators.length > 0 &&
-        // If the parent node is an export declaration, it will be
-        // responsible for printing node.decorators.
-        ! util.getParentExportDeclaration(path)) {
+  if (
+    node.decorators &&
+    node.decorators.length > 0 &&
+    // If the parent node is an export declaration, it will be
+    // responsible for printing node.decorators.
+    !util.getParentExportDeclaration(path)
+  ) {
+    path.each(function(decoratorPath: any) {
+      parts.push(printPath(decoratorPath), "\n");
+    }, "decorators");
+  } else if (
+    util.isExportDeclaration(node) &&
+    node.declaration &&
+    node.declaration.decorators
+  ) {
+    // Export declarations are responsible for printing any decorators
+    // that logically apply to node.declaration.
+    path.each(
+      function(decoratorPath: any) {
+        parts.push(printPath(decoratorPath), "\n");
+      },
+      "declaration",
+      "decorators"
+    );
+  }
 
-        path.each(function(decoratorPath: any) {
-            parts.push(printPath(decoratorPath), "\n");
-        }, "decorators");
-
-    } else if (util.isExportDeclaration(node) &&
-               node.declaration &&
-               node.declaration.decorators) {
-        // Export declarations are responsible for printing any decorators
-        // that logically apply to node.declaration.
-        path.each(function(decoratorPath: any) {
-            parts.push(printPath(decoratorPath), "\n");
-        }, "declaration", "decorators");
-    }
-
-    return concat(parts);
+  return concat(parts);
 }
 
 function printStatementSequence(path: any, options: any, print: any) {
-    const filtered: any[] = [];
-    let sawComment = false;
-    let sawStatement = false;
+  const filtered: any[] = [];
+  let sawComment = false;
+  let sawStatement = false;
 
-    path.each(function(stmtPath: any) {
-        const stmt = stmtPath.getValue();
+  path.each(function(stmtPath: any) {
+    const stmt = stmtPath.getValue();
 
-        // Just in case the AST has been modified to contain falsy
-        // "statements," it's safer simply to skip them.
-        if (!stmt) {
-            return;
-        }
-
-        // Skip printing EmptyStatement nodes to avoid leaving stray
-        // semicolons lying around.
-        if (stmt.type === "EmptyStatement" &&
-            ! (stmt.comments && stmt.comments.length > 0)) {
-            return;
-        }
-
-        if (namedTypes.Comment.check(stmt)) {
-            // The pretty printer allows a dangling Comment node to act as
-            // a Statement when the Comment can't be attached to any other
-            // non-Comment node in the tree.
-            sawComment = true;
-        } else if (namedTypes.Statement.check(stmt)) {
-            sawStatement = true;
-        } else {
-            // When the pretty printer encounters a string instead of an
-            // AST node, it just prints the string. This behavior can be
-            // useful for fine-grained formatting decisions like inserting
-            // blank lines.
-            isString.assert(stmt);
-        }
-
-        // We can't hang onto stmtPath outside of this function, because
-        // it's just a reference to a mutable FastPath object, so we have
-        // to go ahead and print it here.
-        filtered.push({
-            node: stmt,
-            printed: print(stmtPath)
-        });
-    });
-
-    if (sawComment) {
-        assert.strictEqual(
-            sawStatement, false,
-            "Comments may appear as statements in otherwise empty statement " +
-                "lists, but may not coexist with non-Comment nodes."
-        );
+    // Just in case the AST has been modified to contain falsy
+    // "statements," it's safer simply to skip them.
+    if (!stmt) {
+      return;
     }
 
-    let prevTrailingSpace: any = null;
-    const len = filtered.length;
-    const parts: any[] = [];
+    // Skip printing EmptyStatement nodes to avoid leaving stray
+    // semicolons lying around.
+    if (
+      stmt.type === "EmptyStatement" &&
+      !(stmt.comments && stmt.comments.length > 0)
+    ) {
+      return;
+    }
 
-    filtered.forEach(function(info, i) {
-        const printed = info.printed;
-        const stmt = info.node;
-        const multiLine = printed.length > 1;
-        const notFirst = i > 0;
-        const notLast = i < len - 1;
-        let leadingSpace;
-        let trailingSpace;
-        const lines = stmt && stmt.loc && stmt.loc.lines;
-        const trueLoc = lines && options.reuseWhitespace &&
-            util.getTrueLoc(stmt, lines);
+    if (namedTypes.Comment.check(stmt)) {
+      // The pretty printer allows a dangling Comment node to act as
+      // a Statement when the Comment can't be attached to any other
+      // non-Comment node in the tree.
+      sawComment = true;
+    } else if (namedTypes.Statement.check(stmt)) {
+      sawStatement = true;
+    } else {
+      // When the pretty printer encounters a string instead of an
+      // AST node, it just prints the string. This behavior can be
+      // useful for fine-grained formatting decisions like inserting
+      // blank lines.
+      isString.assert(stmt);
+    }
 
-        if (notFirst) {
-            if (trueLoc) {
-                const beforeStart = lines.skipSpaces(trueLoc.start, true);
-                const beforeStartLine = beforeStart ? beforeStart.line : 1;
-                const leadingGap = trueLoc.start.line - beforeStartLine;
-                leadingSpace = Array(leadingGap + 1).join("\n");
-            } else {
-                leadingSpace = multiLine ? "\n\n" : "\n";
-            }
-        } else {
-            leadingSpace = "";
-        }
-
-        if (notLast) {
-            if (trueLoc) {
-                const afterEnd = lines.skipSpaces(trueLoc.end);
-                const afterEndLine = afterEnd ? afterEnd.line : lines.length;
-                const trailingGap = afterEndLine - trueLoc.end.line;
-                trailingSpace = Array(trailingGap + 1).join("\n");
-            } else {
-                trailingSpace = multiLine ? "\n\n" : "\n";
-            }
-        } else {
-            trailingSpace = "";
-        }
-
-        parts.push(
-            maxSpace(prevTrailingSpace, leadingSpace),
-            printed
-        );
-
-        if (notLast) {
-            prevTrailingSpace = trailingSpace;
-        } else if (trailingSpace) {
-            parts.push(trailingSpace);
-        }
+    // We can't hang onto stmtPath outside of this function, because
+    // it's just a reference to a mutable FastPath object, so we have
+    // to go ahead and print it here.
+    filtered.push({
+      node: stmt,
+      printed: print(stmtPath)
     });
+  });
 
-    return concat(parts);
+  if (sawComment) {
+    assert.strictEqual(
+      sawStatement,
+      false,
+      "Comments may appear as statements in otherwise empty statement " +
+        "lists, but may not coexist with non-Comment nodes."
+    );
+  }
+
+  let prevTrailingSpace: any = null;
+  const len = filtered.length;
+  const parts: any[] = [];
+
+  filtered.forEach(function(info, i) {
+    const printed = info.printed;
+    const stmt = info.node;
+    const multiLine = printed.length > 1;
+    const notFirst = i > 0;
+    const notLast = i < len - 1;
+    let leadingSpace;
+    let trailingSpace;
+    const lines = stmt && stmt.loc && stmt.loc.lines;
+    const trueLoc =
+      lines && options.reuseWhitespace && util.getTrueLoc(stmt, lines);
+
+    if (notFirst) {
+      if (trueLoc) {
+        const beforeStart = lines.skipSpaces(trueLoc.start, true);
+        const beforeStartLine = beforeStart ? beforeStart.line : 1;
+        const leadingGap = trueLoc.start.line - beforeStartLine;
+        leadingSpace = Array(leadingGap + 1).join("\n");
+      } else {
+        leadingSpace = multiLine ? "\n\n" : "\n";
+      }
+    } else {
+      leadingSpace = "";
+    }
+
+    if (notLast) {
+      if (trueLoc) {
+        const afterEnd = lines.skipSpaces(trueLoc.end);
+        const afterEndLine = afterEnd ? afterEnd.line : lines.length;
+        const trailingGap = afterEndLine - trueLoc.end.line;
+        trailingSpace = Array(trailingGap + 1).join("\n");
+      } else {
+        trailingSpace = multiLine ? "\n\n" : "\n";
+      }
+    } else {
+      trailingSpace = "";
+    }
+
+    parts.push(maxSpace(prevTrailingSpace, leadingSpace), printed);
+
+    if (notLast) {
+      prevTrailingSpace = trailingSpace;
+    } else if (trailingSpace) {
+      parts.push(trailingSpace);
+    }
+  });
+
+  return concat(parts);
 }
 
 function maxSpace(s1: any, s2: any) {
-    if (!s1 && !s2) {
-        return fromString("");
-    }
+  if (!s1 && !s2) {
+    return fromString("");
+  }
 
-    if (!s1) {
-        return fromString(s2);
-    }
+  if (!s1) {
+    return fromString(s2);
+  }
 
-    if (!s2) {
-        return fromString(s1);
-    }
+  if (!s2) {
+    return fromString(s1);
+  }
 
-    const spaceLines1 = fromString(s1);
-    const spaceLines2 = fromString(s2);
+  const spaceLines1 = fromString(s1);
+  const spaceLines2 = fromString(s2);
 
-    if (spaceLines2.length > spaceLines1.length) {
-        return spaceLines2;
-    }
+  if (spaceLines2.length > spaceLines1.length) {
+    return spaceLines2;
+  }
 
-    return spaceLines1;
+  return spaceLines1;
 }
 
 function printMethod(path: any, options: any, print: any) {
-    const node = path.getNode();
-    const kind = node.kind;
-    const parts = [];
+  const node = path.getNode();
+  const kind = node.kind;
+  const parts = [];
 
-    let nodeValue = node.value;
-    if (! namedTypes.FunctionExpression.check(nodeValue)) {
-        nodeValue = node;
-    }
+  let nodeValue = node.value;
+  if (!namedTypes.FunctionExpression.check(nodeValue)) {
+    nodeValue = node;
+  }
 
-    const access = node.accessibility || node.access;
-    if (typeof access === "string") {
-        parts.push(access, " ");
-    }
+  const access = node.accessibility || node.access;
+  if (typeof access === "string") {
+    parts.push(access, " ");
+  }
 
-    if (node.static) {
-        parts.push("static ");
-    }
+  if (node.static) {
+    parts.push("static ");
+  }
 
-    if (node.abstract) {
-        parts.push("abstract ");
-    }
+  if (node.abstract) {
+    parts.push("abstract ");
+  }
 
-    if (node.readonly) {
-        parts.push("readonly ");
-    }
+  if (node.readonly) {
+    parts.push("readonly ");
+  }
 
-    if (nodeValue.async) {
-        parts.push("async ");
-    }
+  if (nodeValue.async) {
+    parts.push("async ");
+  }
 
-    if (nodeValue.generator) {
-        parts.push("*");
-    }
+  if (nodeValue.generator) {
+    parts.push("*");
+  }
 
-    if (kind === "get" || kind === "set") {
-        parts.push(kind, " ");
-    }
+  if (kind === "get" || kind === "set") {
+    parts.push(kind, " ");
+  }
 
-    let key = path.call(print, "key");
-    if (node.computed) {
-        key = concat(["[", key, "]"]);
-    }
+  let key = path.call(print, "key");
+  if (node.computed) {
+    key = concat(["[", key, "]"]);
+  }
 
-    parts.push(key);
+  parts.push(key);
 
-    if (node.optional) {
-        parts.push("?");
-    }
+  if (node.optional) {
+    parts.push("?");
+  }
 
-    if (node === nodeValue) {
-        parts.push(
-            path.call(print, "typeParameters"),
-            "(",
-            printFunctionParams(path, options, print),
-            ")",
-            path.call(print, "returnType")
-        );
+  if (node === nodeValue) {
+    parts.push(
+      path.call(print, "typeParameters"),
+      "(",
+      printFunctionParams(path, options, print),
+      ")",
+      path.call(print, "returnType")
+    );
 
-        if (node.body) {
-            parts.push(" ", path.call(print, "body"));
-        } else {
-            parts.push(";");
-        }
-
+    if (node.body) {
+      parts.push(" ", path.call(print, "body"));
     } else {
-        parts.push(
-            path.call(print, "value", "typeParameters"),
-            "(",
-            path.call(function(valuePath: any) {
-                return printFunctionParams(valuePath, options, print);
-            }, "value"),
-            ")",
-            path.call(print, "value", "returnType")
-        );
-
-        if (nodeValue.body) {
-            parts.push(" ", path.call(print, "value", "body"));
-        } else {
-            parts.push(";");
-        }
+      parts.push(";");
     }
+  } else {
+    parts.push(
+      path.call(print, "value", "typeParameters"),
+      "(",
+      path.call(function(valuePath: any) {
+        return printFunctionParams(valuePath, options, print);
+      }, "value"),
+      ")",
+      path.call(print, "value", "returnType")
+    );
 
-    return concat(parts);
+    if (nodeValue.body) {
+      parts.push(" ", path.call(print, "value", "body"));
+    } else {
+      parts.push(";");
+    }
+  }
+
+  return concat(parts);
 }
 
 function printArgumentsList(path: any, options: any, print: any) {
-    const printed = path.map(print, "arguments");
-    const trailingComma = util.isTrailingCommaEnabled(options, "parameters");
+  const printed = path.map(print, "arguments");
+  const trailingComma = util.isTrailingCommaEnabled(options, "parameters");
 
-    let joined = fromString(", ").join(printed);
-    if (joined.getLineLength(1) > options.wrapColumn) {
-        joined = fromString(",\n").join(printed);
-        return concat([
-            "(\n",
-            joined.indent(options.tabWidth),
-            trailingComma ? ",\n)" : "\n)"
-        ]);
-    }
+  let joined = fromString(", ").join(printed);
+  if (joined.getLineLength(1) > options.wrapColumn) {
+    joined = fromString(",\n").join(printed);
+    return concat([
+      "(\n",
+      joined.indent(options.tabWidth),
+      trailingComma ? ",\n)" : "\n)"
+    ]);
+  }
 
-    return concat(["(", joined, ")"]);
+  return concat(["(", joined, ")"]);
 }
 
 function printFunctionParams(path: any, options: any, print: any) {
-    const fun = path.getValue();
+  const fun = path.getValue();
 
-    if (fun.params) {
-        var params = fun.params;
-        var printed = path.map(print, "params");
-    } else if (fun.parameters) {
-        params = fun.parameters;
-        printed = path.map(print, "parameters");
+  if (fun.params) {
+    var params = fun.params;
+    var printed = path.map(print, "params");
+  } else if (fun.parameters) {
+    params = fun.parameters;
+    printed = path.map(print, "parameters");
+  }
+
+  if (fun.defaults) {
+    path.each(function(defExprPath: any) {
+      const i = defExprPath.getName();
+      const p = printed[i];
+      if (p && defExprPath.getValue()) {
+        printed[i] = concat([p, " = ", print(defExprPath)]);
+      }
+    }, "defaults");
+  }
+
+  if (fun.rest) {
+    printed.push(concat(["...", path.call(print, "rest")]));
+  }
+
+  let joined = fromString(", ").join(printed);
+  if (joined.length > 1 || joined.getLineLength(1) > options.wrapColumn) {
+    joined = fromString(",\n").join(printed);
+    if (
+      util.isTrailingCommaEnabled(options, "parameters") &&
+      !fun.rest &&
+      params[params.length - 1].type !== "RestElement"
+    ) {
+      joined = concat([joined, ",\n"]);
+    } else {
+      joined = concat([joined, "\n"]);
     }
+    return concat(["\n", joined.indent(options.tabWidth)]);
+  }
 
-    if (fun.defaults) {
-        path.each(function(defExprPath: any) {
-            const i = defExprPath.getName();
-            const p = printed[i];
-            if (p && defExprPath.getValue()) {
-                printed[i] = concat([p, " = ", print(defExprPath)]);
-            }
-        }, "defaults");
-    }
-
-    if (fun.rest) {
-        printed.push(concat(["...", path.call(print, "rest")]));
-    }
-
-    let joined = fromString(", ").join(printed);
-    if (joined.length > 1 ||
-        joined.getLineLength(1) > options.wrapColumn) {
-        joined = fromString(",\n").join(printed);
-        if (util.isTrailingCommaEnabled(options, "parameters") &&
-            !fun.rest &&
-            params[params.length - 1].type !== 'RestElement') {
-            joined = concat([joined, ",\n"]);
-        } else {
-            joined = concat([joined, "\n"]);
-        }
-        return concat(["\n", joined.indent(options.tabWidth)]);
-    }
-
-    return joined;
+  return joined;
 }
 
 function printExportDeclaration(path: any, options: any, print: any) {
-    const decl = path.getValue();
-    const parts: (string | Lines)[] = ["export "];
-    if (decl.exportKind && decl.exportKind !== "value") {
-        parts.push(decl.exportKind + " ");
-    }
-    const shouldPrintSpaces = options.objectCurlySpacing;
+  const decl = path.getValue();
+  const parts: (string | Lines)[] = ["export "];
+  if (decl.exportKind && decl.exportKind !== "value") {
+    parts.push(decl.exportKind + " ");
+  }
+  const shouldPrintSpaces = options.objectCurlySpacing;
 
-    namedTypes.Declaration.assert(decl);
+  namedTypes.Declaration.assert(decl);
 
-    if (decl["default"] ||
-        decl.type === "ExportDefaultDeclaration") {
-        parts.push("default ");
-    }
+  if (decl["default"] || decl.type === "ExportDefaultDeclaration") {
+    parts.push("default ");
+  }
 
-    if (decl.declaration) {
-        parts.push(path.call(print, "declaration"));
+  if (decl.declaration) {
+    parts.push(path.call(print, "declaration"));
+  } else if (decl.specifiers) {
+    if (
+      decl.specifiers.length === 1 &&
+      decl.specifiers[0].type === "ExportBatchSpecifier"
+    ) {
+      parts.push("*");
+    } else if (decl.specifiers.length === 0) {
+      parts.push("{}");
+    } else if (decl.specifiers[0].type === "ExportDefaultSpecifier") {
+      const unbracedSpecifiers: any[] = [];
+      const bracedSpecifiers: any[] = [];
 
-    } else if (decl.specifiers) {
-
-        if (decl.specifiers.length === 1 &&
-            decl.specifiers[0].type === "ExportBatchSpecifier") {
-            parts.push("*");
-
-        } else if (decl.specifiers.length === 0) {
-            parts.push("{}");
-
-        } else if (decl.specifiers[0].type === 'ExportDefaultSpecifier') {
-            const unbracedSpecifiers: any[] = [];
-            const bracedSpecifiers: any[] = [];
-
-            path.each(function (specifierPath: any) {
-                const spec = specifierPath.getValue();
-                if (spec.type === "ExportDefaultSpecifier") {
-                    unbracedSpecifiers.push(print(specifierPath));
-                } else {
-                    bracedSpecifiers.push(print(specifierPath));
-                }
-            }, "specifiers");
-
-            unbracedSpecifiers.forEach((lines, i) => {
-                if (i > 0) {
-                    parts.push(", ");
-                }
-                parts.push(lines);
-            });
-
-            if (bracedSpecifiers.length > 0) {
-                let lines = fromString(", ").join(bracedSpecifiers);
-                if (lines.getLineLength(1) > options.wrapColumn) {
-                    lines = concat([
-                        fromString(",\n").join(
-                            bracedSpecifiers
-                        ).indent(options.tabWidth),
-                        ","
-                    ]);
-                }
-
-                if (unbracedSpecifiers.length > 0) {
-                    parts.push(", ");
-                }
-
-                if (lines.length > 1) {
-                    parts.push("{\n", lines, "\n}");
-                } else if (options.objectCurlySpacing) {
-                    parts.push("{ ", lines, " }");
-                } else {
-                    parts.push("{", lines, "}");
-                }
-            }
-
+      path.each(function(specifierPath: any) {
+        const spec = specifierPath.getValue();
+        if (spec.type === "ExportDefaultSpecifier") {
+          unbracedSpecifiers.push(print(specifierPath));
         } else {
-            parts.push(
-                shouldPrintSpaces ? "{ " : "{",
-                fromString(", ").join(path.map(print, "specifiers")),
-                shouldPrintSpaces ? " }" : "}"
-            );
+          bracedSpecifiers.push(print(specifierPath));
+        }
+      }, "specifiers");
+
+      unbracedSpecifiers.forEach((lines, i) => {
+        if (i > 0) {
+          parts.push(", ");
+        }
+        parts.push(lines);
+      });
+
+      if (bracedSpecifiers.length > 0) {
+        let lines = fromString(", ").join(bracedSpecifiers);
+        if (lines.getLineLength(1) > options.wrapColumn) {
+          lines = concat([
+            fromString(",\n")
+              .join(bracedSpecifiers)
+              .indent(options.tabWidth),
+            ","
+          ]);
         }
 
-        if (decl.source) {
-            parts.push(" from ", path.call(print, "source"));
+        if (unbracedSpecifiers.length > 0) {
+          parts.push(", ");
         }
+
+        if (lines.length > 1) {
+          parts.push("{\n", lines, "\n}");
+        } else if (options.objectCurlySpacing) {
+          parts.push("{ ", lines, " }");
+        } else {
+          parts.push("{", lines, "}");
+        }
+      }
+    } else {
+      parts.push(
+        shouldPrintSpaces ? "{ " : "{",
+        fromString(", ").join(path.map(print, "specifiers")),
+        shouldPrintSpaces ? " }" : "}"
+      );
     }
 
-    let lines = concat(parts);
-    if (lastNonSpaceCharacter(lines) !== ";" &&
-        ! (decl.declaration &&
-           (decl.declaration.type === "FunctionDeclaration" ||
-            decl.declaration.type === "ClassDeclaration" ||
-            decl.declaration.type === "TSModuleDeclaration" ||
-            decl.declaration.type === "TSInterfaceDeclaration" ||
-            decl.declaration.type === "TSEnumDeclaration"))) {
-        lines = concat([lines, ";"]);
+    if (decl.source) {
+      parts.push(" from ", path.call(print, "source"));
     }
-    return lines;
+  }
+
+  let lines = concat(parts);
+  if (
+    lastNonSpaceCharacter(lines) !== ";" &&
+    !(
+      decl.declaration &&
+      (decl.declaration.type === "FunctionDeclaration" ||
+        decl.declaration.type === "ClassDeclaration" ||
+        decl.declaration.type === "TSModuleDeclaration" ||
+        decl.declaration.type === "TSInterfaceDeclaration" ||
+        decl.declaration.type === "TSEnumDeclaration")
+    )
+  ) {
+    lines = concat([lines, ";"]);
+  }
+  return lines;
 }
 
 function printFlowDeclaration(path: any, parts: any) {
-    const parentExportDecl = util.getParentExportDeclaration(path);
+  const parentExportDecl = util.getParentExportDeclaration(path);
 
-    if (parentExportDecl) {
-        assert.strictEqual(
-            parentExportDecl.type,
-            "DeclareExportDeclaration"
-        );
-    } else {
-        // If the parent node has type DeclareExportDeclaration, then it
-        // will be responsible for printing the "declare" token. Otherwise
-        // it needs to be printed with this non-exported declaration node.
-        parts.unshift("declare ");
-    }
+  if (parentExportDecl) {
+    assert.strictEqual(parentExportDecl.type, "DeclareExportDeclaration");
+  } else {
+    // If the parent node has type DeclareExportDeclaration, then it
+    // will be responsible for printing the "declare" token. Otherwise
+    // it needs to be printed with this non-exported declaration node.
+    parts.unshift("declare ");
+  }
 
-    return concat(parts);
+  return concat(parts);
 }
 
 function printVariance(path: any, print: any) {
-    return path.call(function (variancePath: any) {
-        const value = variancePath.getValue();
+  return path.call(function(variancePath: any) {
+    const value = variancePath.getValue();
 
-        if (value) {
-            if (value === "plus") {
-                return fromString("+");
-            }
+    if (value) {
+      if (value === "plus") {
+        return fromString("+");
+      }
 
-            if (value === "minus") {
-                return fromString("-");
-            }
+      if (value === "minus") {
+        return fromString("-");
+      }
 
-            return print(variancePath);
-        }
+      return print(variancePath);
+    }
 
-        return fromString("");
-    }, "variance");
+    return fromString("");
+  }, "variance");
 }
 
 function adjustClause(clause: any, options: any) {
-    if (clause.length > 1)
-        return concat([" ", clause]);
+  if (clause.length > 1) return concat([" ", clause]);
 
-    return concat([
-        "\n",
-        maybeAddSemicolon(clause).indent(options.tabWidth)
-    ]);
+  return concat(["\n", maybeAddSemicolon(clause).indent(options.tabWidth)]);
 }
 
 function lastNonSpaceCharacter(lines: any) {
-    const pos = lines.lastPos();
-    do {
-        const ch = lines.charAt(pos);
-        if (/\S/.test(ch))
-            return ch;
-    } while (lines.prevPos(pos));
+  const pos = lines.lastPos();
+  do {
+    const ch = lines.charAt(pos);
+    if (/\S/.test(ch)) return ch;
+  } while (lines.prevPos(pos));
 }
 
 function endsWithBrace(lines: any) {
-    return lastNonSpaceCharacter(lines) === "}";
+  return lastNonSpaceCharacter(lines) === "}";
 }
 
 function swapQuotes(str: string) {
-    return str.replace(/['"]/g, function(m) {
-        return m === '"' ? '\'' : '"';
-    });
+  return str.replace(/['"]/g, function(m) {
+    return m === '"' ? "'" : '"';
+  });
 }
 
 function nodeStr(str: string, options: any) {
-    isString.assert(str);
-    switch (options.quote) {
+  isString.assert(str);
+  switch (options.quote) {
     case "auto":
-        var double = JSON.stringify(str);
-        var single = swapQuotes(JSON.stringify(swapQuotes(str)));
-        return double.length > single.length ? single : double;
+      var double = JSON.stringify(str);
+      var single = swapQuotes(JSON.stringify(swapQuotes(str)));
+      return double.length > single.length ? single : double;
     case "single":
-        return swapQuotes(JSON.stringify(swapQuotes(str)));
+      return swapQuotes(JSON.stringify(swapQuotes(str)));
     case "double":
     default:
-        return JSON.stringify(str);
-    }
+      return JSON.stringify(str);
+  }
 }
 
 function maybeAddSemicolon(lines: any) {
-    const eoc = lastNonSpaceCharacter(lines);
-    if (!eoc || "\n};".indexOf(eoc) < 0)
-        return concat([lines, ";"]);
-    return lines;
+  const eoc = lastNonSpaceCharacter(lines);
+  if (!eoc || "\n};".indexOf(eoc) < 0) return concat([lines, ";"]);
+  return lines;
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -27,7 +27,7 @@ export function getUnionOfKeys(...args: any[]) {
 }
 
 export function comparePos(pos1: any, pos2: any) {
-  return (pos1.line - pos2.line) || (pos1.column - pos2.column);
+  return pos1.line - pos2.line || pos1.column - pos2.column;
 }
 
 export function copyPos(pos: any) {
@@ -84,7 +84,7 @@ export function composeSourceMaps(formerMap: any, latterMap: any) {
   });
 
   return (smg as any).toJSON();
-};
+}
 
 export function getTrueLoc(node: any, lines: any) {
   // It's possible that node is newly-created (not parsed by Esprima),
@@ -107,9 +107,11 @@ export function getTrueLoc(node: any, lines: any) {
   // If the node is an export declaration and its .declaration has any
   // decorators, their locations might contribute to the true start/end
   // positions of the export declaration node.
-  if (node.declaration &&
-      node.declaration.decorators &&
-      isExportDeclaration(node)) {
+  if (
+    node.declaration &&
+    node.declaration.decorators &&
+    isExportDeclaration(node)
+  ) {
     node.declaration.decorators.forEach(include);
   }
 
@@ -133,7 +135,7 @@ export function getTrueLoc(node: any, lines: any) {
   }
 
   return result;
-};
+}
 
 function expandLoc(parentLoc: any, childLoc: any) {
   if (parentLoc && childLoc) {
@@ -172,10 +174,9 @@ export function fixFaultyLocations(node: any, lines: any) {
   if (loc && node.decorators) {
     // Expand the .loc of the node responsible for printing the decorators
     // (here, the decorated node) so that it includes node.decorators.
-    node.decorators.forEach(function (decorator: any) {
+    node.decorators.forEach(function(decorator: any) {
       expandLoc(loc, decorator.loc);
     });
-
   } else if (node.declaration && isExportDeclaration(node)) {
     // Nullify .loc information for the child declaration so that we never
     // try to reprint it without also reprinting the export declaration.
@@ -185,13 +186,14 @@ export function fixFaultyLocations(node: any, lines: any) {
     // (here, the export declaration) so that it includes node.decorators.
     const decorators = node.declaration.decorators;
     if (decorators) {
-      decorators.forEach(function (decorator: any) {
+      decorators.forEach(function(decorator: any) {
         expandLoc(loc, decorator.loc);
       });
     }
-
-  } else if ((n.MethodDefinition && n.MethodDefinition.check(node)) ||
-             (n.Property.check(node) && (node.method || node.shorthand))) {
+  } else if (
+    (n.MethodDefinition && n.MethodDefinition.check(node)) ||
+    (n.Property.check(node) && (node.method || node.shorthand))
+  ) {
     // If the node is a MethodDefinition or a .method or .shorthand
     // Property, then the location information stored in
     // node.value.loc is very likely untrustworthy (just the {body}
@@ -205,14 +207,12 @@ export function fixFaultyLocations(node: any, lines: any) {
       // because their .id fields are ignored anyway.
       node.value.id = null;
     }
-
   } else if (node.type === "ObjectTypeProperty") {
     var loc = node.loc;
     let end = loc && loc.end;
     if (end) {
       end = copyPos(end);
-      if (lines.prevPos(end) &&
-          lines.charAt(end) === ",") {
+      if (lines.prevPos(end) && lines.charAt(end) === ",") {
         // Some parsers accidentally include trailing commas in the
         // .loc.end information for ObjectTypeProperty nodes.
         if ((end = lines.skipSpaces(end, true, true))) {
@@ -221,7 +221,7 @@ export function fixFaultyLocations(node: any, lines: any) {
       }
     }
   }
-};
+}
 
 function fixForLoopHead(node: any, lines: any) {
   if (node.type !== "ForStatement") {
@@ -259,7 +259,7 @@ function fixTemplateLiteral(node: any, lines: any) {
     // If there are no quasi elements, then there is nothing to fix.
     return;
   }
-  
+
   // node.loc is not present when using export default with a template literal
   if (node.loc) {
     // First we need to exclude the opening ` from the .loc of the first
@@ -285,16 +285,18 @@ function fixTemplateLiteral(node: any, lines: any) {
 
   // Now we need to exclude ${ and } characters from the .loc's of all
   // quasi elements, since some parsers accidentally include them.
-  node.expressions.forEach(function (expr: any, i: any) {
+  node.expressions.forEach(function(expr: any, i: any) {
     // Rewind from expr.loc.start over any whitespace and the ${ that
     // precedes the expression. The position of the $ should be the same
     // as the .loc.end of the preceding quasi element, but some parsers
     // accidentally include the ${ in the .loc of the quasi element.
     const dollarCurlyPos = lines.skipSpaces(expr.loc.start, true, false);
-    if (lines.prevPos(dollarCurlyPos) &&
-        lines.charAt(dollarCurlyPos) === "{" &&
-        lines.prevPos(dollarCurlyPos) &&
-        lines.charAt(dollarCurlyPos) === "$") {
+    if (
+      lines.prevPos(dollarCurlyPos) &&
+      lines.charAt(dollarCurlyPos) === "{" &&
+      lines.prevPos(dollarCurlyPos) &&
+      lines.charAt(dollarCurlyPos) === "$"
+    ) {
       const quasiBefore = node.quasis[i];
       if (comparePos(dollarCurlyPos, quasiBefore.loc.end) < 0) {
         quasiBefore.loc.end = dollarCurlyPos;
@@ -316,28 +318,28 @@ function fixTemplateLiteral(node: any, lines: any) {
 }
 
 export function isExportDeclaration(node: any) {
-  if (node) switch (node.type) {
-  case "ExportDeclaration":
-  case "ExportDefaultDeclaration":
-  case "ExportDefaultSpecifier":
-  case "DeclareExportDeclaration":
-  case "ExportNamedDeclaration":
-  case "ExportAllDeclaration":
-    return true;
-  }
+  if (node)
+    switch (node.type) {
+      case "ExportDeclaration":
+      case "ExportDefaultDeclaration":
+      case "ExportDefaultSpecifier":
+      case "DeclareExportDeclaration":
+      case "ExportNamedDeclaration":
+      case "ExportAllDeclaration":
+        return true;
+    }
 
   return false;
-};
+}
 
 export function getParentExportDeclaration(path: any) {
   const parentNode = path.getParentNode();
-  if (path.getName() === "declaration" &&
-      isExportDeclaration(parentNode)) {
+  if (path.getName() === "declaration" && isExportDeclaration(parentNode)) {
     return parentNode;
   }
 
   return null;
-};
+}
 
 export function isTrailingCommaEnabled(options: any, context: any) {
   const trailingComma = options.trailingComma;
@@ -345,4 +347,4 @@ export function isTrailingCommaEnabled(options: any, context: any) {
     return !!trailingComma[context];
   }
   return !!trailingComma;
-};
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1629,6 +1629,11 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
   "scripts": {
     "mocha": "test/run.sh",
     "debug": "test/run.sh --inspect-brk",
-    "test": "npm run build && npm run mocha",
+    "test": "npm run build && npm run mocha && npm run format:check",
     "build": "npm run clean && tsc",
     "clean": "ts-emit-clean",
     "prepack": "npm run build",
-    "postpack": "npm run clean"
+    "postpack": "npm run clean",
+    "format:check": "prettier --check lib/*.ts",
+    "format": "prettier --write lib/*.ts"
   },
   "browser": {
     "fs": false
@@ -36,6 +38,7 @@
   "dependencies": {
     "ast-types": "0.13.2",
     "esprima": "~4.0.0",
+    "prettier": "^1.18.2",
     "private": "^0.1.8",
     "source-map": "~0.6.1"
   },

--- a/test/babel.ts
+++ b/test/babel.ts
@@ -5,7 +5,7 @@ const b = recast.types.builders;
 import { EOL as eol } from "os";
 const nodeMajorVersion = parseInt(process.versions.node, 10);
 
-describe("Babel", function () {
+describe("Babel", function() {
   // Babel no longer supports Node 4 or 5.
   if (nodeMajorVersion < 6) {
     return;
@@ -17,7 +17,7 @@ describe("Babel", function () {
     parser: require("../parsers/babel")
   };
 
-  it("basic printing", function () {
+  it("basic printing", function() {
     function check(lines: any) {
       const code = lines.join(eol);
       const ast = recast.parse(code, parseOptions);
@@ -28,172 +28,142 @@ describe("Babel", function () {
     check([
       '"use strict";', // Directive, DirectiveLiteral in Program
       '"use strict";', // Directive, DirectiveLiteral in BlockStatement
-      'function a() {',
+      "function a() {",
       '  "use strict";',
-      '}',
+      "}"
     ]);
 
-    check([
-      'function a() {',
-      '  "use strict";',
-      '  b;',
-      '}',
-    ]);
+    check(["function a() {", '  "use strict";', "  b;", "}"]);
+
+    check(["() => {", '  "use strict";', "};"]);
+
+    check(["() => {", '  "use strict";', "  b;", "};"]);
+
+    check(["var a = function a() {", '  "use strict";', "};"]);
+
+    check(["var a = function a() {", '  "use strict";', "  b;", "};"]);
 
     check([
-      '() => {',
-      '  "use strict";',
-      '};',
-    ]);
-
-    check([
-      '() => {',
-      '  "use strict";',
-      '  b;',
-      '};',
-    ]);
-
-    check([
-      'var a = function a() {',
-      '  "use strict";',
-      '};',
-    ]);
-
-    check([
-      'var a = function a() {',
-      '  "use strict";',
-      '  b;',
-      '};',
-    ]);
-
-    check([
-      'null;', // NullLiteral
+      "null;", // NullLiteral
       '"asdf";', // StringLiteral
-      '/a/;', // RegExpLiteral
-      'false;', // BooleanLiteral
-      '1;', // NumericLiteral
-      'const find2 = <X>() => {};', // typeParameters
+      "/a/;", // RegExpLiteral
+      "false;", // BooleanLiteral
+      "1;", // NumericLiteral
+      "const find2 = <X>() => {};" // typeParameters
     ]);
 
     check([
-      'class A<T> {',
-      '  a;',
-      '  a = 1;',
-      '  [a] = 1;', // computed in ClassProperty
-      '}',
+      "class A<T> {",
+      "  a;",
+      "  a = 1;",
+      "  [a] = 1;", // computed in ClassProperty
+      "}"
     ]);
 
     check([
-      'function f<T>(x: empty): T {', // EmptyTypeAnnotation
-      '  return x;',
-      '}',
+      "function f<T>(x: empty): T {", // EmptyTypeAnnotation
+      "  return x;",
+      "}"
     ]);
 
     check([
-      'var a: {| numVal: number |};', // exact
-      'const bar1 = (x: number): string => {};',
-      'declare module.exports: { foo: string }', // DeclareModuleExports
-      'type Maybe<T> = _Maybe<T, *>;', // ExistentialTypeParam
+      "var a: {| numVal: number |};", // exact
+      "const bar1 = (x: number): string => {};",
+      "declare module.exports: { foo: string }", // DeclareModuleExports
+      "type Maybe<T> = _Maybe<T, *>;", // ExistentialTypeParam
       // 'declare class B { foo: () => number }', // interesting failure ref https://github.com/babel/babel/pull/3663
-      'declare function foo(): number;',
-      'var A: (a: B) => void;',
+      "declare function foo(): number;",
+      "var A: (a: B) => void;"
     ]);
 
     check([
-      'async function* a() {', // async in Function
-      '  for await (let x of y) {', // ForAwaitStatement
-      '    x;',
-      '  }',
-      '}',
+      "async function* a() {", // async in Function
+      "  for await (let x of y) {", // ForAwaitStatement
+      "    x;",
+      "  }",
+      "}"
     ]);
 
     check([
-      'class C2<+T, -U> {', // variance
-      '  +p: T = e;',
-      '}',
+      "class C2<+T, -U> {", // variance
+      "  +p: T = e;",
+      "}"
+    ]);
+
+    check(["type T = { -p: T };", "type U = { +[k: K]: V };"]);
+
+    check([
+      "class A {",
+      "  static async *z(a, b): number {", // ClassMethod
+      "    b;",
+      "  }",
+      "",
+      "  static get y(): number {",
+      "    return 1;",
+      "  }",
+      "",
+      "  static set x(a): void {",
+      "    return 1;",
+      "  }",
+      "",
+      "  static async *[d](a, b): number {",
+      "    return 1;",
+      "  }",
+      "}"
     ]);
 
     check([
-      'type T = { -p: T };',
-      'type U = { +[k: K]: V };',
-    ]);
-
-    check([
-      'class A {',
-      '  static async *z(a, b): number {', // ClassMethod
-      '    b;',
-      '  }',
-      '',
-      '  static get y(): number {',
-      '    return 1;',
-      '  }',
-      '',
-      '  static set x(a): void {',
-      '    return 1;',
-      '  }',
-      '',
-      '  static async *[d](a, b): number {',
-      '    return 1;',
-      '  }',
-      '}',
-    ]);
-
-    check([
-      '({',
-      '  async *a() {', // ObjectMethod
-      '    b;',
-      '  },',
-      '',
-      '  get a() {',
-      '    return 1;',
-      '  },',
-      '',
-      '  set a(b) {',
-      '    return 1;',
-      '  },',
-      '',
-      '  async *[d](c) {',
-      '    return 1;',
-      '  },',
-      '',
-      '  a: 3,',
-      '  [a]: 3,',
-      '  1: 3,',
+      "({",
+      "  async *a() {", // ObjectMethod
+      "    b;",
+      "  },",
+      "",
+      "  get a() {",
+      "    return 1;",
+      "  },",
+      "",
+      "  set a(b) {",
+      "    return 1;",
+      "  },",
+      "",
+      "  async *[d](c) {",
+      "    return 1;",
+      "  },",
+      "",
+      "  a: 3,",
+      "  [a]: 3,",
+      "  1: 3,",
       '  "1": 3,',
-      '  1() {},',
+      "  1() {},",
       '  "1"() {}',
-      '});',
+      "});"
     ]);
   });
 
-  it("babel 6: should not wrap IIFE when reusing nodes", function () {
-    const code = [
-      '(function(...c) {',
-      '  c();',
-      '})();',
-    ].join(eol);
+  it("babel 6: should not wrap IIFE when reusing nodes", function() {
+    const code = ["(function(...c) {", "  c();", "})();"].join(eol);
 
     const ast = recast.parse(code, parseOptions);
     const output = recast.print(ast, { tabWidth: 2 }).code;
     assert.strictEqual(output, code);
   });
 
-  it("should not disappear when surrounding code changes", function () {
+  it("should not disappear when surrounding code changes", function() {
     const code = [
       'import foo from "foo";',
       'import React from "react";',
-      '',
-      '@component',
+      "",
+      "@component",
       '@callExpression({foo: "bar"})',
-      'class DebugPanel extends React.Component {',
-      '  render() {',
-      '    return (',
-      '      <div> test </div>',
-      '    );',
-      '  }',
-      '}',
-      '',
-      'export default DebugPanel;',
+      "class DebugPanel extends React.Component {",
+      "  render() {",
+      "    return (",
+      "      <div> test </div>",
+      "    );",
+      "  }",
+      "}",
+      "",
+      "export default DebugPanel;"
     ].join(eol);
 
     const ast = recast.parse(code, parseOptions);
@@ -214,29 +184,32 @@ describe("Babel", function () {
 
     assert.strictEqual(
       reprinted,
-      code.split(eol).filter(function (line) {
-        return ! line.match(/^import React from/);
-      }).join(eol)
+      code
+        .split(eol)
+        .filter(function(line) {
+          return !line.match(/^import React from/);
+        })
+        .join(eol)
     );
   });
 
-  it("should not disappear when an import is added and `export` is used inline", function () {
+  it("should not disappear when an import is added and `export` is used inline", function() {
     const code = [
       'import foo from "foo";',
       'import React from "react";',
-      '',
-      '@component',
+      "",
+      "@component",
       '@callExpression({foo: "bar"})',
-      '@callExpressionMultiLine({',
+      "@callExpressionMultiLine({",
       '  foo: "bar",',
-      '})',
-      'export class DebugPanel extends React.Component {',
-      '  render() {',
-      '    return (',
-      '      <div> test </div>',
-      '    );',
-      '  }',
-      '}',
+      "})",
+      "export class DebugPanel extends React.Component {",
+      "  render() {",
+      "    return (",
+      "      <div> test </div>",
+      "    );",
+      "  }",
+      "}"
     ].join(eol);
 
     const ast = recast.parse(code, parseOptions);
@@ -247,9 +220,12 @@ describe("Babel", function () {
     const body = root.get("program", "body");
 
     // add a new import statement
-    body.unshift(b.importDeclaration([
-      b.importDefaultSpecifier(b.identifier('x')),
-    ], b.literal('x')));
+    body.unshift(
+      b.importDeclaration(
+        [b.importDefaultSpecifier(b.identifier("x"))],
+        b.literal("x")
+      )
+    );
 
     const reprinted = recast.print(ast).code;
 
@@ -262,23 +238,23 @@ describe("Babel", function () {
     );
   });
 
-  it("should not disappear when an import is added and `export default` is used inline", function () {
+  it("should not disappear when an import is added and `export default` is used inline", function() {
     const code = [
       'import foo from "foo";',
       'import React from "react";',
-      '',
-      '@component',
+      "",
+      "@component",
       '@callExpression({foo: "bar"})',
-      '@callExpressionMultiLine({',
+      "@callExpressionMultiLine({",
       '  foo: "bar",',
-      '})',
-      'export default class DebugPanel extends React.Component {',
-      '  render() {',
-      '    return (',
-      '      <div> test </div>',
-      '    );',
-      '  }',
-      '}',
+      "})",
+      "export default class DebugPanel extends React.Component {",
+      "  render() {",
+      "    return (",
+      "      <div> test </div>",
+      "    );",
+      "  }",
+      "}"
     ].join(eol);
 
     const ast = recast.parse(code, parseOptions);
@@ -289,9 +265,12 @@ describe("Babel", function () {
     const body = root.get("program", "body");
 
     // add a new import statement
-    body.unshift(b.importDeclaration([
-      b.importDefaultSpecifier(b.identifier('x')),
-    ], b.literal('x')));
+    body.unshift(
+      b.importDeclaration(
+        [b.importDefaultSpecifier(b.identifier("x"))],
+        b.literal("x")
+      )
+    );
 
     const reprinted = recast.print(ast).code;
 
@@ -304,76 +283,56 @@ describe("Babel", function () {
     );
   });
 
-  it("should not print delimiters with type annotations", function () {
-    const code = [
-      'type X = {',
-      '  a: number,',
-      '  b: number,',
-      '};',
-    ].join('\n');
+  it("should not print delimiters with type annotations", function() {
+    const code = ["type X = {", "  a: number,", "  b: number,", "};"].join(
+      "\n"
+    );
 
     const ast = recast.parse(code, parseOptions);
     const root = new recast.types.NodePath(ast);
 
-    root.get('program', 'body', 0, 'right', 'properties', 0).prune();
+    root.get("program", "body", 0, "right", "properties", 0).prune();
 
-    assert.strictEqual(
-      recast.print(ast).code,
-      "type X = { b: number };"
-    );
+    assert.strictEqual(recast.print(ast).code, "type X = { b: number };");
   });
 
   function parseExpression(code: any) {
     return recast.parse(code, parseOptions).program.body[0].expression;
   }
 
-  it("should parenthesize ** operator arguments when lower precedence", function () {
-    const ast = recast.parse('a ** b;', parseOptions);
+  it("should parenthesize ** operator arguments when lower precedence", function() {
+    const ast = recast.parse("a ** b;", parseOptions);
 
-    ast.program.body[0].expression.left = parseExpression('x + y');
-    ast.program.body[0].expression.right = parseExpression('x || y');
+    ast.program.body[0].expression.left = parseExpression("x + y");
+    ast.program.body[0].expression.right = parseExpression("x || y");
 
-    assert.strictEqual(
-      recast.print(ast).code,
-      '(x + y) ** (x || y);'
-    );
+    assert.strictEqual(recast.print(ast).code, "(x + y) ** (x || y);");
   });
 
-  it("should parenthesize ** operator arguments as needed when same precedence", function () {
-    const ast = recast.parse('a ** b;', parseOptions);
+  it("should parenthesize ** operator arguments as needed when same precedence", function() {
+    const ast = recast.parse("a ** b;", parseOptions);
 
-    ast.program.body[0].expression.left = parseExpression('x * y');
-    ast.program.body[0].expression.right = parseExpression('x / y');
+    ast.program.body[0].expression.left = parseExpression("x * y");
+    ast.program.body[0].expression.right = parseExpression("x / y");
 
-    assert.strictEqual(
-      recast.print(ast).code,
-      'x * y ** (x / y);'
-    );
+    assert.strictEqual(recast.print(ast).code, "x * y ** (x / y);");
   });
 
-  it("should be able to replace top-level statements with leading empty lines", function () {
-    const code = [
-      '',
-      'if (test) {',
-      '  console.log(test);',
-      '}',
-    ].join('\n');
+  it("should be able to replace top-level statements with leading empty lines", function() {
+    const code = ["", "if (test) {", "  console.log(test);", "}"].join("\n");
 
     const ast = recast.parse(code, parseOptions);
 
     const replacement = b.expressionStatement(
-      b.callExpression(
-        b.identifier('fn'),
-        [b.identifier('test'), b.literal(true)]
-      )
+      b.callExpression(b.identifier("fn"), [
+        b.identifier("test"),
+        b.literal(true)
+      ])
     );
 
     ast.program.body[0] = replacement;
 
-    assert.strictEqual(
-      recast.print(ast).code,
-      '\nfn(test, true);'
-    );
+    assert.strictEqual(recast.print(ast).code, "\nfn(test, true);");
 
     recast.types.visit(ast, {
       visitIfStatement: function(path: any) {
@@ -382,26 +341,20 @@ describe("Babel", function () {
       }
     });
 
-    assert.strictEqual(
-      recast.print(ast).code,
-      '\nfn(test, true);'
-    );
+    assert.strictEqual(recast.print(ast).code, "\nfn(test, true);");
   });
 
-  it("should parse and print dynamic import(...)", function () {
+  it("should parse and print dynamic import(...)", function() {
     const code = 'wait(import("oyez"));';
-  const ast = recast.parse(code, parseOptions);
-    assert.strictEqual(
-      recast.prettyPrint(ast).code,
-      code
-    );
+    const ast = recast.parse(code, parseOptions);
+    assert.strictEqual(recast.prettyPrint(ast).code, code);
   });
 
-  it("tolerates circular references", function () {
+  it("tolerates circular references", function() {
     const code = "function foo(bar = true) {}";
     recast.parse(code, {
       parser: {
-        parse: function (source: any) {
+        parse: function(source: any) {
           return babelTransform(source, {
             code: false,
             ast: true,
@@ -415,10 +368,10 @@ describe("Babel", function () {
 
   it("prints numbers in bases other than 10 without converting them", function() {
     const code = [
-      'let decimal = 6;',
-      'let hex = 0xf00d;',
-      'let binary = 0b1010;',
-      'let octal = 0o744;'
+      "let decimal = 6;",
+      "let hex = 0xf00d;",
+      "let binary = 0b1010;",
+      "let octal = 0o744;"
     ].join(eol);
 
     const ast = recast.parse(code, parseOptions);
@@ -426,40 +379,40 @@ describe("Babel", function () {
     assert.strictEqual(output, code);
   });
 
-  it("prints the export-default-from syntax", function () {
+  it("prints the export-default-from syntax", function() {
     const code = [
       'export { default as foo, bar } from "foo";',
       'export { default as veryLongIdentifier1, veryLongIdentifier2, veryLongIdentifier3, veryLongIdentifier4, veryLongIdentifier5 } from "long-identifiers";'
     ].join(eol);
     const ast = recast.parse(code, parseOptions);
 
-    const replacement1 = b.exportDefaultSpecifier(b.identifier('foo'));
+    const replacement1 = b.exportDefaultSpecifier(b.identifier("foo"));
     const replacement2 = b.exportDefaultSpecifier(
-      b.identifier('veryLongIdentifier1')
+      b.identifier("veryLongIdentifier1")
     );
     ast.program.body[0].specifiers[0] = replacement1;
     ast.program.body[1].specifiers[0] = replacement2;
     assert.strictEqual(
-        recast.print(ast).code,
-        [
-          'export foo, { bar } from "foo";',
-          'export veryLongIdentifier1, {',
-          '  veryLongIdentifier2,',
-          '  veryLongIdentifier3,',
-          '  veryLongIdentifier4,',
-          '  veryLongIdentifier5,',
-          '} from "long-identifiers";'
-        ].join(eol)
+      recast.print(ast).code,
+      [
+        'export foo, { bar } from "foo";',
+        "export veryLongIdentifier1, {",
+        "  veryLongIdentifier2,",
+        "  veryLongIdentifier3,",
+        "  veryLongIdentifier4,",
+        "  veryLongIdentifier5,",
+        '} from "long-identifiers";'
+      ].join(eol)
     );
   });
 
   // https://github.com/codemod-js/codemod/issues/157
   it("avoids extra semicolons on mutated blocks containing a 'use strict' directive", function() {
     const code = [
-      '(function () {',
+      "(function () {",
       '  "use strict";',
-      '  hello;',
-      '})();'
+      "  hello;",
+      "})();"
     ].join(eol);
     const ast = recast.parse(code, parseOptions);
 
@@ -467,12 +420,8 @@ describe("Babel", function () {
     ast.program.body[0].expression.callee.body.body.splice(0);
 
     assert.strictEqual(
-        recast.print(ast).code,
-        [
-          '(function () {',
-          '  "use strict";',
-          '})();'
-        ].join(eol)
+      recast.print(ast).code,
+      ["(function () {", '  "use strict";', "})();"].join(eol)
     );
   });
 });

--- a/test/comments.ts
+++ b/test/comments.ts
@@ -21,20 +21,19 @@ const annotated = [
 const nodeMajorVersion = parseInt(process.versions.node, 10);
 
 describe("comments", function() {
-  ["../parsers/acorn",
-   "../parsers/babel",
-   "../parsers/esprima",
-   "../parsers/flow",
-   "../parsers/typescript",
+  [
+    "../parsers/acorn",
+    "../parsers/babel",
+    "../parsers/esprima",
+    "../parsers/flow",
+    "../parsers/typescript"
   ].forEach(runTestsForParser);
 });
 
 function runTestsForParser(parserId: any) {
   if (nodeMajorVersion < 6) {
     const parser = parserId.split("/").pop();
-    if (parser === "babel" ||
-        parser === "flow" ||
-        parser === "typescript") {
+    if (parser === "babel" || parser === "flow" || parser === "typescript") {
       // Babel 7 no longer supports Node 4 and 5.
       return;
     }
@@ -60,15 +59,9 @@ function runTestsForParser(parserId: any) {
     assert.strictEqual(recast.print(ast.program).code, code);
     assert.strictEqual(recast.print(dup).code, code);
 
-    assert.strictEqual(
-      recast.print(dup.params[0]).code,
-      "/* string */ s"
-    );
+    assert.strictEqual(recast.print(dup.params[0]).code, "/* string */ s");
 
-    assert.strictEqual(
-      recast.print(dup.params[1]).code,
-      "/* int */ n"
-    );
+    assert.strictEqual(recast.print(dup.params[1]).code, "/* int */ n");
 
     assert.strictEqual(
       recast.print(dup.body).code,
@@ -81,10 +74,7 @@ function runTestsForParser(parserId: any) {
     const indented = annotated.slice(3, 6).join(eol);
     const flush = fromString(indented).indent(-2);
 
-    assert.strictEqual(
-      recast.print(retStmt).code,
-      flush.toString()
-    );
+    assert.strictEqual(recast.print(retStmt).code, flush.toString());
 
     const join = retStmt.argument;
     n.CallExpression.assert(join);
@@ -92,10 +82,10 @@ function runTestsForParser(parserId: any) {
     const one = join.callee.object.arguments[0].right;
     n.Literal.assert(one);
     assert.strictEqual(one.value, 1);
-    assert.strictEqual(recast.print(one).code, [
-      "/*",
-      " * off-by-*/ 1"
-    ].join(eol));
+    assert.strictEqual(
+      recast.print(one).code,
+      ["/*", " * off-by-*/ 1"].join(eol)
+    );
   });
 
   const trailing = [
@@ -198,17 +188,15 @@ function runTestsForParser(parserId: any) {
     const props = assign.right.properties;
     info.Property.arrayOf().assert(props);
 
-    props.push(info.propBuilder(
-      b.identifier("extra"),
-      info.literalBuilder("property")
-    ));
+    props.push(
+      info.propBuilder(b.identifier("extra"), info.literalBuilder("property"))
+    );
 
     const quxVal = props[2].value;
     n.ObjectExpression.assert(quxVal);
-    quxVal.properties.push(info.propBuilder(
-      b.identifier("asdf"),
-      info.literalBuilder(43)
-    ));
+    quxVal.properties.push(
+      info.propBuilder(b.identifier("asdf"), info.literalBuilder(43))
+    );
 
     const actual = recast.print(ast, { tabWidth: 2 }).code;
     const expected = trailingExpected.join(eol);
@@ -309,8 +297,9 @@ function runTestsForParser(parserId: any) {
     const block = ast.program.body[0].consequent;
     n.BlockStatement.assert(block);
 
-    block.body.unshift(b.expressionStatement(
-      b.callExpression(b.identifier("e"), [])));
+    block.body.unshift(
+      b.expressionStatement(b.callExpression(b.identifier("e"), []))
+    );
 
     const actual = recast.print(ast, { tabWidth: 2 }).code;
     const expected = statementTrailingExpected.join(eol);
@@ -350,10 +339,7 @@ function runTestsForParser(parserId: any) {
     assert.strictEqual(barComment.leading, true);
     assert.strictEqual(barComment.trailing, false);
 
-    assert.strictEqual(
-      barComment.value,
-      " Comment about the bar method."
-    );
+    assert.strictEqual(barComment.value, " Comment about the bar method.");
   });
 
   const conciseMethods = [
@@ -361,7 +347,7 @@ function runTestsForParser(parserId: any) {
     "  a(/*before*/ param) {},",
     "  b(param /*after*/) {},",
     "  c(param) /*body*/ {}",
-    "};",
+    "};"
   ];
 
   pit("should correctly attach to concise methods", function() {
@@ -384,10 +370,7 @@ function runTestsForParser(parserId: any) {
     assert.ok(aComment.type.endsWith("Block"));
     assert.strictEqual(aComment.value, "before");
 
-    assert.strictEqual(
-      recast.print(a).code,
-      "a(/*before*/ param) {}"
-    );
+    assert.strictEqual(recast.print(a).code, "a(/*before*/ param) {}");
 
     const b = objExpr.properties[1];
     n.Identifier.assert(b.key);
@@ -402,10 +385,7 @@ function runTestsForParser(parserId: any) {
     assert.ok(bComment.type.endsWith("Block"));
     assert.strictEqual(bComment.value, "after");
 
-    assert.strictEqual(
-      recast.print(b).code,
-      "b(param /*after*/) {}"
-    );
+    assert.strictEqual(recast.print(b).code, "b(param /*after*/) {}");
 
     const c = objExpr.properties[2];
     n.Identifier.assert(c.key);
@@ -420,24 +400,17 @@ function runTestsForParser(parserId: any) {
     assert.ok(cComment.type.endsWith("Block"));
     assert.strictEqual(cComment.value, "body");
 
-    assert.strictEqual(
-      recast.print(c).code,
-      "c(param) /*body*/ {}"
-    );
+    assert.strictEqual(recast.print(c).code, "c(param) /*body*/ {}");
   });
 
   pit("should attach comments as configurable", function() {
     // Given
-    const simpleCommentedCode = [
-      "// A comment",
-      "var obj = {",
-      "};",
-    ];
+    const simpleCommentedCode = ["// A comment", "var obj = {", "};"];
     const code = simpleCommentedCode.join(eol);
     const ast = recast.parse(code, { parser });
 
     // When
-    Object.defineProperty(ast.program, 'comments', {
+    Object.defineProperty(ast.program, "comments", {
       value: undefined,
       enumerable: false
     });
@@ -447,11 +420,7 @@ function runTestsForParser(parserId: any) {
   });
 
   pit("should be reprinted when modified", function() {
-    const code = [
-      "foo;",
-      "// bar",
-      "bar;"
-    ].join(eol);
+    const code = ["foo;", "// bar", "bar;"].join(eol);
 
     const ast = recast.parse(code, { parser });
 
@@ -462,98 +431,96 @@ function runTestsForParser(parserId: any) {
     assert.strictEqual(comment.value, " bar");
 
     comment.value = " barbara";
-    assert.strictEqual(recast.print(ast).code, [
-      "foo;",
-      "// barbara",
-      "bar;"
-    ].join(eol));
+    assert.strictEqual(
+      recast.print(ast).code,
+      ["foo;", "// barbara", "bar;"].join(eol)
+    );
 
     ast.program.body[0].comments = comments;
     delete ast.program.body[1].comments;
-    assert.strictEqual(recast.print(ast).code, [
-      "// barbara",
-      "foo;",
-      "bar;"
-    ].join(eol));
+    assert.strictEqual(
+      recast.print(ast).code,
+      ["// barbara", "foo;", "bar;"].join(eol)
+    );
 
-    ast.program.body[0] = b.blockStatement([
-      ast.program.body[0]
-    ]);
-    assert.strictEqual(recast.print(ast).code, [
-      "{",
-      "  // barbara",
-      "  foo;",
-      "}",
-      "",
-      "bar;"
-    ].join(eol));
+    ast.program.body[0] = b.blockStatement([ast.program.body[0]]);
+    assert.strictEqual(
+      recast.print(ast).code,
+      ["{", "  // barbara", "  foo;", "}", "", "bar;"].join(eol)
+    );
 
     var comment = ast.program.body[0].body[0].comments[0];
     comment.type = "Block";
-    assert.strictEqual(recast.print(ast).code, [
-      "{",
-      "  /* barbara*/",
-      "  foo;",
-      "}",
-      "",
-      "bar;"
-    ].join(eol));
+    assert.strictEqual(
+      recast.print(ast).code,
+      ["{", "  /* barbara*/", "  foo;", "}", "", "bar;"].join(eol)
+    );
 
     comment.value += "\n * babar\n ";
-    assert.strictEqual(recast.print(ast).code, [
-      "{",
-      "  /* barbara",
-      "   * babar",
-      "   */",
-      "  foo;",
-      "}",
-      "",
-      "bar;"
-    ].join(eol));
+    assert.strictEqual(
+      recast.print(ast).code,
+      [
+        "{",
+        "  /* barbara",
+        "   * babar",
+        "   */",
+        "  foo;",
+        "}",
+        "",
+        "bar;"
+      ].join(eol)
+    );
 
     ast.program.body[1].comments = [comment];
-    assert.strictEqual(recast.print(ast).code, [
-      "{",
-      "  /* barbara",
-      "   * babar",
-      "   */",
-      "  foo;",
-      "}",
-      "",
-      "/* barbara",
-      " * babar",
-      " */",
-      "bar;"
-    ].join(eol));
+    assert.strictEqual(
+      recast.print(ast).code,
+      [
+        "{",
+        "  /* barbara",
+        "   * babar",
+        "   */",
+        "  foo;",
+        "}",
+        "",
+        "/* barbara",
+        " * babar",
+        " */",
+        "bar;"
+      ].join(eol)
+    );
 
     delete ast.program.body[0].body[0].comments;
     ast.program.comments = [b.line(" program comment")];
-    assert.strictEqual(recast.print(ast).code, [
-      "// program comment",
-      "{",
-      "  foo;",
-      "}",
-      "",
-      "/* barbara",
-      " * babar",
-      " */",
-      "bar;"
-    ].join(eol));
-
-    ast.program.body.push(
-      ast.program.body.shift()
+    assert.strictEqual(
+      recast.print(ast).code,
+      [
+        "// program comment",
+        "{",
+        "  foo;",
+        "}",
+        "",
+        "/* barbara",
+        " * babar",
+        " */",
+        "bar;"
+      ].join(eol)
     );
-    assert.strictEqual(recast.print(ast).code, [
-      "// program comment",
-      "/* barbara",
-      " * babar",
-      " */",
-      "bar;",
-      "",
-      "{",
-      "  foo;",
-      "}"
-    ].join(eol));
+
+    ast.program.body.push(ast.program.body.shift());
+    assert.strictEqual(
+      recast.print(ast).code,
+      [
+        "// program comment",
+        "/* barbara",
+        " * babar",
+        " */",
+        "bar;",
+        "",
+        "{",
+        "  foo;",
+        "}"
+      ].join(eol)
+    );
 
     recast.visit(ast, {
       visitNode: function(path) {
@@ -561,19 +528,13 @@ function runTestsForParser(parserId: any) {
         this.traverse(path);
       }
     });
-    assert.strictEqual(recast.print(ast).code, [
-      "bar;",
-      "",
-      "{",
-      "  foo;",
-      "}"
-    ].join(eol));
+    assert.strictEqual(
+      recast.print(ast).code,
+      ["bar;", "", "{", "  foo;", "}"].join(eol)
+    );
 
     ast.program.body[1] = ast.program.body[1].body[0];
-    assert.strictEqual(recast.print(ast).code, [
-      "bar;",
-      "foo;"
-    ].join(eol));
+    assert.strictEqual(recast.print(ast).code, ["bar;", "foo;"].join(eol));
   });
 
   pit("should preserve stray non-comment syntax", function() {
@@ -592,16 +553,19 @@ function runTestsForParser(parserId: any) {
 
     const elems = ast.program.body[0].expression.elements;
     elems[0].comments.push(b.line(" line comment", true, false));
-    assert.strictEqual(recast.print(ast).code, [
-      "[",
-      "  // line comment",
-      "  foo /* comma */",
-      "  /* hole */",
-      "  ,",
-      "  , /* comma */",
-      "  bar",
-      "]"
-    ].join(eol));
+    assert.strictEqual(
+      recast.print(ast).code,
+      [
+        "[",
+        "  // line comment",
+        "  foo /* comma */",
+        "  /* hole */",
+        "  ,",
+        "  , /* comma */",
+        "  bar",
+        "]"
+      ].join(eol)
+    );
   });
 
   pit("should be reprinted even if dangling", function() {
@@ -615,7 +579,7 @@ function runTestsForParser(parserId: any) {
     function handleComment(comment: any) {
       if (comment.trailing) {
         trailingComment = comment;
-      } else if (! comment.leading) {
+      } else if (!comment.leading) {
         danglingComment = comment;
       }
     }
@@ -630,22 +594,21 @@ function runTestsForParser(parserId: any) {
     assert.strictEqual(trailingComment.trailing, true);
 
     danglingComment.value = " neither leading nor trailing ";
-    assert.strictEqual(recast.print(ast).code, [
-      "[/* neither leading nor trailing */] // array literal"
-    ].join(eol));
+    assert.strictEqual(
+      recast.print(ast).code,
+      ["[/* neither leading nor trailing */] // array literal"].join(eol)
+    );
 
     trailingComment.value = " trailing";
-    assert.strictEqual(recast.print(ast).code, [
-      "[/* neither leading nor trailing */] // trailing"
-    ].join(eol));
+    assert.strictEqual(
+      recast.print(ast).code,
+      ["[/* neither leading nor trailing */] // trailing"].join(eol)
+    );
 
     // Unfortuantely altering the elements of the array leads to
     // reprinting which blows away the dangling comment.
     array.elements.push(b.literal(1));
-    assert.strictEqual(
-      recast.print(ast).code,
-      "[1] // trailing"
-    );
+    assert.strictEqual(recast.print(ast).code, "[1] // trailing");
   });
 
   pit("should attach to program.body[0] instead of program", function() {
@@ -658,7 +621,7 @@ function runTestsForParser(parserId: any) {
       "  // comment 3",
       "  var c;",
       "}"
-    ].join('\n');
+    ].join("\n");
 
     const ast = recast.parse(code, { parser });
 
@@ -693,7 +656,7 @@ function runTestsForParser(parserId: any) {
       "    /*before*/ param",
       "  ) /*after*/ {",
       "  },",
-      "};",
+      "};"
     ].join(eol);
 
     const ast = recast.parse(code, { parser });
@@ -701,10 +664,7 @@ function runTestsForParser(parserId: any) {
       tabWidth: 2
     });
 
-    assert.strictEqual(
-      printer.print(ast).code,
-      code
-    );
+    assert.strictEqual(printer.print(ast).code, code);
   });
 
   pit("should be pretty-printable in illegal positions", function() {
@@ -726,69 +686,69 @@ function runTestsForParser(parserId: any) {
     funExp.params.push(comments.shift());
     funExp.body.body.push(comments.pop());
 
-    assert.strictEqual(
-      recast.print(ast).code,
-      code
-    );
+    assert.strictEqual(recast.print(ast).code, code);
   });
 
-  pit("should preserve correctness when a return expression has a comment", function () {
-    const code = [
-      "function f() {",
-      "  return 3;",
-      "}"
-    ].join(eol);
+  pit(
+    "should preserve correctness when a return expression has a comment",
+    function() {
+      const code = ["function f() {", "  return 3;", "}"].join(eol);
 
-    const ast = recast.parse(code, { parser });
-    ast.program.body[0].body.body[0].argument.comments = [b.line('Foo')];
+      const ast = recast.parse(code, { parser });
+      ast.program.body[0].body.body[0].argument.comments = [b.line("Foo")];
 
-    assert.strictEqual(recast.print(ast).code, [
-      "function f() {",
-      "  return (",
-      "    //Foo",
-      "    3",
-      "  );",
-      "}"
-    ].join(eol));
-  });
+      assert.strictEqual(
+        recast.print(ast).code,
+        [
+          "function f() {",
+          "  return (",
+          "    //Foo",
+          "    3",
+          "  );",
+          "}"
+        ].join(eol)
+      );
+    }
+  );
 
-  pit("should wrap in parens when the return expression has nested leftmost comment", function () {
-    const code = [
-      "function f() {",
-      "  return 1 + 2;",
-      "}"
-    ].join(eol);
+  pit(
+    "should wrap in parens when the return expression has nested leftmost comment",
+    function() {
+      const code = ["function f() {", "  return 1 + 2;", "}"].join(eol);
 
-    const ast = recast.parse(code, { parser });
-    ast.program.body[0].body.body[0].argument.left.comments = [b.line('Foo')];
+      const ast = recast.parse(code, { parser });
+      ast.program.body[0].body.body[0].argument.left.comments = [b.line("Foo")];
 
-    assert.strictEqual(recast.print(ast).code, [
-      "function f() {",
-      "  return (",
-      "    //Foo",
-      "    1 + 2",
-      "  );",
-      "}"
-    ].join(eol));
-  });
+      assert.strictEqual(
+        recast.print(ast).code,
+        [
+          "function f() {",
+          "  return (",
+          "    //Foo",
+          "    1 + 2",
+          "  );",
+          "}"
+        ].join(eol)
+      );
+    }
+  );
 
-  pit("should not wrap in parens when the return expression has an interior comment", function () {
-    const code = [
-      "function f() {",
-      "  return 1 + 2;",
-      "}"
-    ].join(eol);
+  pit(
+    "should not wrap in parens when the return expression has an interior comment",
+    function() {
+      const code = ["function f() {", "  return 1 + 2;", "}"].join(eol);
 
-    const ast = recast.parse(code, { parser });
-    ast.program.body[0].body.body[0].argument.right.comments = [b.line('Foo')];
+      const ast = recast.parse(code, { parser });
+      ast.program.body[0].body.body[0].argument.right.comments = [
+        b.line("Foo")
+      ];
 
-    assert.strictEqual(recast.print(ast).code, [
-      "function f() {",
-      "  return 1 + //Foo",
-      "  2;",
-      "}"
-    ].join(eol));
-  });
+      assert.strictEqual(
+        recast.print(ast).code,
+        ["function f() {", "  return 1 + //Foo", "  2;", "}"].join(eol)
+      );
+    }
+  );
 
   pit("should correctly handle a lonesome comment (alt 1)", function() {
     const code = ["", "// boo", ""].join(eol);
@@ -798,56 +758,63 @@ function runTestsForParser(parserId: any) {
     assert.strictEqual(recast.print(ast).code, ["", "// boo", ""].join(eol));
   });
 
-  pit("should correctly handle a not-so-lonesome comment (alt 2 - trailing whitespace)", function() {
-    const code = ["", "// boo ", ";"].join(eol);
+  pit(
+    "should correctly handle a not-so-lonesome comment (alt 2 - trailing whitespace)",
+    function() {
+      const code = ["", "// boo ", ";"].join(eol);
 
-    const ast = recast.parse(code);
+      const ast = recast.parse(code);
 
-    assert.strictEqual(
-      recast.print(ast).code,
-      ["", "// boo ", ";"].join(eol)
-    );
-  });
+      assert.strictEqual(
+        recast.print(ast).code,
+        ["", "// boo ", ";"].join(eol)
+      );
+    }
+  );
 
-  pit("should correctly handle a lonesome comment (alt 3 - trailing whitespace)", function() {
-    const code = ["", "// boo ", ""].join(eol);
+  pit(
+    "should correctly handle a lonesome comment (alt 3 - trailing whitespace)",
+    function() {
+      const code = ["", "// boo ", ""].join(eol);
 
-    const ast = recast.parse(code);
+      const ast = recast.parse(code);
 
-    assert.strictEqual(recast.print(ast).code, ["", "// boo ", ""].join(eol));
-  });
+      assert.strictEqual(recast.print(ast).code, ["", "// boo ", ""].join(eol));
+    }
+  );
 
-  pit("should not reformat a return statement that is not modified", function () {
-    const code = [
-      "function f() {",
-      "  return      {",
-      "    a:     1,",
-      "    b: 2,",
-      "  };",
-      "}"
-    ].join(eol);
+  pit(
+    "should not reformat a return statement that is not modified",
+    function() {
+      const code = [
+        "function f() {",
+        "  return      {",
+        "    a:     1,",
+        "    b: 2,",
+        "  };",
+        "}"
+      ].join(eol);
 
-    const ast = recast.parse(code, { parser });
+      const ast = recast.parse(code, { parser });
 
-    assert.strictEqual(recast.print(ast).code, code);
-  });
+      assert.strictEqual(recast.print(ast).code, code);
+    }
+  );
 
-  pit("should correctly handle a removing the argument from a return", function () {
-    const code = [
-      "function f() {",
-      "  return 'foo';",
-      "}"
-    ].join(eol);
+  pit(
+    "should correctly handle a removing the argument from a return",
+    function() {
+      const code = ["function f() {", "  return 'foo';", "}"].join(eol);
 
-    const ast = recast.parse(code, { parser });
-    ast.program.body[0].body.body[0].argument = null;
+      const ast = recast.parse(code, { parser });
+      ast.program.body[0].body.body[0].argument = null;
 
-    assert.strictEqual(recast.print(ast).code, [
-      "function f() {",
-      "  return;",
-      "}"
-    ].join(eol));
-  });
+      assert.strictEqual(
+        recast.print(ast).code,
+        ["function f() {", "  return;", "}"].join(eol)
+      );
+    }
+  );
 
   pit("should preserve comments attached to EmptyStatement", function() {
     const code = [
@@ -859,9 +826,9 @@ function runTestsForParser(parserId: any) {
     const ast = recast.parse(code, { parser });
     ast.program.body.shift();
 
-    assert.strictEqual(recast.print(ast).code, [
-      "// comment",
-      ";(function() {})();"
-    ].join(eol));
+    assert.strictEqual(
+      recast.print(ast).code,
+      ["// comment", ";(function() {})();"].join(eol)
+    );
   });
 }

--- a/test/es6tests.ts
+++ b/test/es6tests.ts
@@ -26,7 +26,7 @@ describe("ES6 Compatability", function() {
     const newES5MethodProperty = b.property(
       methodDecProperty.kind,
       methodDecProperty.key,
-      methodDecProperty.value,
+      methodDecProperty.value
     );
 
     const correctMethodProperty = b.property(
@@ -38,7 +38,7 @@ describe("ES6 Compatability", function() {
         methodDecProperty.value.body,
         methodDecProperty.value.generator,
         methodDecProperty.value.expression
-      ),
+      )
     );
 
     assert.strictEqual(
@@ -47,19 +47,20 @@ describe("ES6 Compatability", function() {
     );
   }
 
-  it("correctly converts from a shorthand method to ES5 function",
-     convertShorthandMethod);
+  it(
+    "correctly converts from a shorthand method to ES5 function",
+    convertShorthandMethod
+  );
 
   function respectDestructuringAssignment() {
     const printer = new Printer({ tabWidth: 2 });
-    const code = 'var {a} = {};';
+    const code = "var {a} = {};";
     const ast = parse(code);
     n.VariableDeclaration.assert(ast.program.body[0]);
     assert.strictEqual(printer.print(ast).code, code);
   }
 
-  it("respects destructuring assignments",
-     respectDestructuringAssignment);
+  it("respects destructuring assignments", respectDestructuringAssignment);
 });
 
 describe("import/export syntax", function() {
@@ -139,8 +140,9 @@ describe("import/export syntax", function() {
     function checkInvalid(source: string, expectedMessage: string) {
       try {
         parse(source);
-        throw new Error("Parsing should have failed: " +
-                        JSON.stringify(source));
+        throw new Error(
+          "Parsing should have failed: " + JSON.stringify(source)
+        );
       } catch (err) {
         assert.strictEqual(err.message, "Line 1: " + expectedMessage);
       }
@@ -153,82 +155,43 @@ describe("import/export syntax", function() {
     );
 
     // Unexpected token identifier, invalid named export syntax
-    checkInvalid(
-      "export foo;",
-      "Unexpected identifier"
-    );
+    checkInvalid("export foo;", "Unexpected identifier");
 
     // Unexpected token (, use a function declaration instead
-    checkInvalid(
-      "export function () {}",
-      "Unexpected token ("
-    );
+    checkInvalid("export function () {}", "Unexpected token (");
 
     // Unexpected token default
-    checkInvalid(
-      "export function default () {}",
-      "Unexpected token default"
-    );
+    checkInvalid("export function default () {}", "Unexpected token default");
 
     // Missing from after import
-    checkInvalid(
-      "import foo;",
-      "Unexpected token ;"
-    );
+    checkInvalid("import foo;", "Unexpected token ;");
 
     // Missing from after import
-    checkInvalid(
-      "import { foo, bar };",
-      "Unexpected token ;"
-    );
+    checkInvalid("import { foo, bar };", "Unexpected token ;");
 
     // Invalid module specifier
-    checkInvalid(
-      "import foo from bar;",
-      "Unexpected token"
-    );
+    checkInvalid("import foo from bar;", "Unexpected token");
 
     // Unexpected token default
-    checkInvalid(
-      "import default from 'foo';",
-      "Unexpected token default"
-    );
+    checkInvalid("import default from 'foo';", "Unexpected token default");
 
     // Unexpected token from
-    checkInvalid(
-      "export default from 'foo';",
-      "Unexpected token from"
-    );
+    checkInvalid("export default from 'foo';", "Unexpected token from");
 
     // Missing from after export
-    checkInvalid(
-      "export {default};",
-      "Unexpected token ;"
-    );
+    checkInvalid("export {default};", "Unexpected token ;");
 
     // Missing from after export
-    checkInvalid(
-      "export *;",
-      "Unexpected token ;"
-    );
+    checkInvalid("export *;", "Unexpected token ;");
 
     // Missing from after import
-    checkInvalid(
-      "import {default as foo};",
-      "Unexpected token ;"
-    );
+    checkInvalid("import {default as foo};", "Unexpected token ;");
 
     // Missing as after import *
-    checkInvalid(
-      "import * from 'foo';",
-      "Unexpected token"
-    );
+    checkInvalid("import * from 'foo';", "Unexpected token");
 
     // Unexpected token =
-    checkInvalid(
-      "export default = 42;",
-      "Unexpected token ="
-    );
+    checkInvalid("export default = 42;", "Unexpected token =");
 
     // Unexpected token default
     checkInvalid(
@@ -243,28 +206,16 @@ describe("import/export syntax", function() {
     );
 
     // Unexpected token ,
-    checkInvalid(
-      "import {bar}, foo from 'foo';",
-      "Unexpected token ,"
-    );
+    checkInvalid("import {bar}, foo from 'foo';", "Unexpected token ,");
 
     // Unexpected token ,
-    checkInvalid(
-      "import {bar}, * as foo from 'foo';",
-      "Unexpected token ,"
-    );
+    checkInvalid("import {bar}, * as foo from 'foo';", "Unexpected token ,");
 
     // Unexpected token ,
-    checkInvalid(
-      "import foo, {bar}, foo from 'foo';",
-      "Unexpected token ,"
-    );
+    checkInvalid("import foo, {bar}, foo from 'foo';", "Unexpected token ,");
 
     // Unexpected token ,
-    checkInvalid(
-      "import {bar}, {foo} from 'foo';",
-      "Unexpected token ,"
-    );
+    checkInvalid("import {bar}, {foo} from 'foo';", "Unexpected token ,");
 
     // Unexpected token ,
     checkInvalid(
@@ -276,8 +227,8 @@ describe("import/export syntax", function() {
   it("should pretty-print template strings with backticks", function() {
     const code = [
       'var noun = "fool";',
-      'var s = `I am a ${noun}`;',
-      'var t = tag`You said: ${s}!`;'
+      "var s = `I am a ${noun}`;",
+      "var t = tag`You said: ${s}!`;"
     ].join(eol);
 
     const ast = parse(code);

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -5,7 +5,11 @@ import * as types from "ast-types";
 import { EOL as eol } from "os";
 
 describe("type syntax", function() {
-  const printer = new Printer({ tabWidth: 2, quote: 'single', flowObjectCommas: false });
+  const printer = new Printer({
+    tabWidth: 2,
+    quote: "single",
+    flowObjectCommas: false
+  });
   const esprimaParserParseOptions = {
     parser: require("esprima-fb")
   };
@@ -57,20 +61,59 @@ describe("type syntax", function() {
     check("type A = B;");
     check("type A = B.C;");
     check("type A = { optionalNumber?: number };");
-    check("type A = {" + eol + "  ...B;" + eol + "  optionalNumber?: number;" + eol + "};", flowParserParseOptions);
+    check(
+      "type A = {" +
+        eol +
+        "  ...B;" +
+        eol +
+        "  optionalNumber?: number;" +
+        eol +
+        "};",
+      flowParserParseOptions
+    );
     check("type A = {| optionalNumber?: number |};", flowParserParseOptions);
-    check("type A = {|" + eol + "  ...B;" + eol + "  optionalNumber?: number;" + eol + "|};", flowParserParseOptions);
+    check(
+      "type A = {|" +
+        eol +
+        "  ...B;" +
+        eol +
+        "  optionalNumber?: number;" +
+        eol +
+        "|};",
+      flowParserParseOptions
+    );
 
     // Opaque types
     check("opaque type A = B;", flowParserParseOptions);
     check("opaque type A = B.C;", flowParserParseOptions);
-    check("opaque type A = { optionalNumber?: number };", flowParserParseOptions);
+    check(
+      "opaque type A = { optionalNumber?: number };",
+      flowParserParseOptions
+    );
     check("opaque type A: X = B;", flowParserParseOptions);
     check("opaque type A: X.Y = B.C;", flowParserParseOptions);
-    check("opaque type A: { stringProperty: string } = {" + eol + "  stringProperty: string;" + eol + "  optionalNumber?: number;" + eol + "};", flowParserParseOptions);
+    check(
+      "opaque type A: { stringProperty: string } = {" +
+        eol +
+        "  stringProperty: string;" +
+        eol +
+        "  optionalNumber?: number;" +
+        eol +
+        "};",
+      flowParserParseOptions
+    );
     check("opaque type A<T>: X<T> = B<T>;", flowParserParseOptions);
     check("opaque type A<T>: X.Y<T> = B.C<T>;", flowParserParseOptions);
-    check("opaque type A<T>: { optional?: T } = {" + eol + "  stringProperty: string;" + eol + "  optional?: T;" + eol + "};", flowParserParseOptions);
+    check(
+      "opaque type A<T>: { optional?: T } = {" +
+        eol +
+        "  stringProperty: string;" +
+        eol +
+        "  optional?: T;" +
+        eol +
+        "};",
+      flowParserParseOptions
+    );
 
     // Generic
     check("var a: Array<Foo>;");
@@ -81,10 +124,24 @@ describe("type syntax", function() {
     check("var a: () => X = fn;");
 
     // Object
-    check("var a: {" + eol + "  b: number;" + eol + "  x: { y: A };" + eol + "};");
-    check("var b: { [key: string]: number };")
-    check("var c: { (): number };")
-    check("var d: {" + eol + "  [key: string]: A;" + eol + "  [key: number]: B;" + eol + "  (): C;" + eol + "  a: D;" + eol + "};")
+    check(
+      "var a: {" + eol + "  b: number;" + eol + "  x: { y: A };" + eol + "};"
+    );
+    check("var b: { [key: string]: number };");
+    check("var c: { (): number };");
+    check(
+      "var d: {" +
+        eol +
+        "  [key: string]: A;" +
+        eol +
+        "  [key: number]: B;" +
+        eol +
+        "  (): C;" +
+        eol +
+        "  a: D;" +
+        eol +
+        "};"
+    );
 
     // Casts
     check("(1 + 1: number);");
@@ -97,12 +154,21 @@ describe("type syntax", function() {
     check("declare function foo(c: (e: Event) => void, b: B): void;");
     check("declare function foo(c: C, d?: Array<D>): void;");
     check("declare class C { x: string }");
-    check("declare module M {" + eol + "  declare function foo(c: C): void;" + eol + "}");
+    check(
+      "declare module M {" +
+        eol +
+        "  declare function foo(c: C): void;" +
+        eol +
+        "}"
+    );
 
     check("declare opaque type A;", flowParserParseOptions);
     check("declare opaque type A: X;", flowParserParseOptions);
     check("declare opaque type A: X.Y;", flowParserParseOptions);
-    check("declare opaque type A: { stringProperty: string };", flowParserParseOptions);
+    check(
+      "declare opaque type A: { stringProperty: string };",
+      flowParserParseOptions
+    );
     check("declare opaque type A<T>: X<T>;", flowParserParseOptions);
     check("declare opaque type A<T>: X.Y<T>;", flowParserParseOptions);
     check("declare opaque type A<T>: { property: T };", flowParserParseOptions);
@@ -127,22 +193,22 @@ describe("type syntax", function() {
     check("class A<T: number> {}");
 
     // Inexact object types
+    check("type InexactFoo = { foo: number; ... };", flowParserParseOptions);
     check(
-      "type InexactFoo = { foo: number; ... };",
-      flowParserParseOptions,
+      [
+        "type MultiLineInexact = {",
+        "  reallyLongPropertyNameOyezOyezOyezFiddlyFeeDiDumDeDoo: VeryLongTypeName<With, Generic, Type, Parameters>;",
+        "  somewhatShorterButStillNotVeryShortPropertyName: string;",
+        "  ...",
+        "};"
+      ].join(eol),
+      flowParserParseOptions
     );
-    check([
-      "type MultiLineInexact = {",
-      "  reallyLongPropertyNameOyezOyezOyezFiddlyFeeDiDumDeDoo: VeryLongTypeName<With, Generic, Type, Parameters>;",
-      "  somewhatShorterButStillNotVeryShortPropertyName: string;",
-      "  ...",
-      "};"
-    ].join(eol), flowParserParseOptions);
 
     // typeArguments
-    check('new A<string>();', flowParserParseOptions);
-    check('createPlugin<number>();', flowParserParseOptions);
+    check("new A<string>();", flowParserParseOptions);
+    check("createPlugin<number>();", flowParserParseOptions);
 
-    check('function myFunction([param1]: Params) {}', flowParserParseOptions);
+    check("function myFunction([param1]: Params) {}", flowParserParseOptions);
   });
 });

--- a/test/identity.ts
+++ b/test/identity.ts
@@ -7,38 +7,38 @@ import * as recast from "../main";
 const nodeMajorVersion = parseInt(process.versions.node, 10);
 
 function testFile(path: string, options: { parser?: any } = {}) {
-    fs.readFile(path, "utf-8", function(err, source) {
-        assert.equal(err, null);
-        assert.strictEqual(typeof source, "string");
+  fs.readFile(path, "utf-8", function(err, source) {
+    assert.equal(err, null);
+    assert.strictEqual(typeof source, "string");
 
-        const ast = recast.parse(source, options);
-        types.astNodesAreEquivalent.assert(ast.original, ast);
-        const code = recast.print(ast).code;
-        assert.strictEqual(source, code);
-    });
+    const ast = recast.parse(source, options);
+    types.astNodesAreEquivalent.assert(ast.original, ast);
+    const code = recast.print(ast).code;
+    assert.strictEqual(source, code);
+  });
 }
 
 function addTest(name: string) {
-    it(name, function() {
-        const filename = path.join(__dirname, "..", name);
+  it(name, function() {
+    const filename = path.join(__dirname, "..", name);
 
-        if (path.extname(filename) === ".ts") {
-            // Babel 7 no longer supports Node 4 and 5.
-            if (nodeMajorVersion >= 6) {
-                testFile(filename, { parser: require("../parsers/typescript") });
-            }
-        } else {
-            testFile(filename);
-        }
-    });
+    if (path.extname(filename) === ".ts") {
+      // Babel 7 no longer supports Node 4 and 5.
+      if (nodeMajorVersion >= 6) {
+        testFile(filename, { parser: require("../parsers/typescript") });
+      }
+    } else {
+      testFile(filename);
+    }
+  });
 }
 
 describe("identity", function() {
-    // Add more tests here as need be.
-    addTest("test/data/regexp-props.js");
-    addTest("test/data/empty.js");
-    addTest("test/data/backbone.js");
-    addTest("test/lines.ts");
-    addTest("lib/lines.ts");
-    addTest("lib/printer.ts");
+  // Add more tests here as need be.
+  addTest("test/data/regexp-props.js");
+  addTest("test/data/empty.js");
+  addTest("test/data/backbone.js");
+  addTest("test/lines.ts");
+  addTest("lib/lines.ts");
+  addTest("lib/printer.ts");
 });

--- a/test/jsx.ts
+++ b/test/jsx.ts
@@ -5,8 +5,7 @@ import { Printer } from "../lib/printer";
 import * as types from "ast-types";
 const nodeMajorVersion = parseInt(process.versions.node, 10);
 
-(nodeMajorVersion >= 6 ? describe : xdescribe)
-("JSX Compatability", function() {
+(nodeMajorVersion >= 6 ? describe : xdescribe)("JSX Compatability", function() {
   const printer = new Printer({ tabWidth: 2 });
   const parseOptions = {
     parser: require("../parsers/babel")
@@ -14,10 +13,7 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
 
   function check(source: string) {
     const ast1 = parse(source, parseOptions);
-    const ast2 = parse(
-      printer.printGenerically(ast1).code,
-      parseOptions
-    );
+    const ast2 = parse(printer.printGenerically(ast1).code, parseOptions);
     types.astNodesAreEquivalent.assert(ast1, ast2);
   }
 
@@ -32,7 +28,7 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
   });
 
   it("should parse and print literal attributes", function() {
-    check("<b className=\"hello\" />");
+    check('<b className="hello" />');
   });
 
   it("should parse and print expression attributes", function() {
@@ -56,11 +52,6 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
   });
 
   it("should parse and print fragments", function() {
-    check([
-      "<>",
-      "  <td>Hello</td>",
-      "  <td>world!</td>",
-      "</>",
-    ].join("\n"));
+    check(["<>", "  <td>Hello</td>", "  <td>world!</td>", "</>"].join("\n"));
   });
 });

--- a/test/lines.ts
+++ b/test/lines.ts
@@ -5,548 +5,563 @@ import { fromString, concat, countSpaces, Lines } from "../lib/lines";
 import { EOL as eol } from "os";
 
 function check(a: any, b: any) {
-    assert.strictEqual(a.toString({
-        lineTerminator: eol
-    }), b.toString({
-        lineTerminator: eol
-    }));
+  assert.strictEqual(
+    a.toString({
+      lineTerminator: eol
+    }),
+    b.toString({
+      lineTerminator: eol
+    })
+  );
 }
 
 describe("lines", function() {
-    describe('line terminators', function() {
-        const source = [
-            'foo;',
-            'bar;',
-        ];
+  describe("line terminators", function() {
+    const source = ["foo;", "bar;"];
 
-        const terminators = [
-            '\u000A',
-            '\u000D',
-            '\u2028',
-            '\u2029',
-            '\u000D\u000A',
-        ];
+    const terminators = [
+      "\u000A",
+      "\u000D",
+      "\u2028",
+      "\u2029",
+      "\u000D\u000A"
+    ];
 
-        terminators.forEach(function(t) {
-            it('can handle ' + escape(t) + ' as line terminator', function() {
-                const lines = fromString(source.join(t));
-                assert.strictEqual(lines.length, 2);
-                assert.strictEqual(lines.getLineLength(1), 4);
-            });
-        });
+    terminators.forEach(function(t) {
+      it("can handle " + escape(t) + " as line terminator", function() {
+        const lines = fromString(source.join(t));
+        assert.strictEqual(lines.length, 2);
+        assert.strictEqual(lines.getLineLength(1), 4);
+      });
     });
+  });
 
-    it("FromString", function() {
-        function checkIsCached(s: any) {
-            assert.strictEqual(fromString(s), fromString(s));
-            check(fromString(s), s);
-        }
-
-        checkIsCached("");
-        checkIsCached(",");
-        checkIsCached(eol);
-        checkIsCached("this");
-        checkIsCached(", ");
-        checkIsCached(": ");
-
-        const longer = "This is a somewhat longer string that we do not want to cache.";
-        assert.notStrictEqual(
-            fromString(longer),
-            fromString(longer));
-
-        // Since Lines objects are immutable, if one is passed to fromString,
-        // we can return it as-is without having to make a defensive copy.
-        const longerLines = fromString(longer);
-        assert.strictEqual(fromString(longerLines), longerLines);
-    });
-
-    it("ToString", function ToStringTest() {
-        const code = String(ToStringTest);
-        const lines = fromString(code);
-        check(lines, code);
-        check(lines.indentTail(5)
-                   .indentTail(-7)
-                   .indentTail(2),
-              code);
-    });
-
-    function testEachPosHelper(lines: any, code: any) {
-        check(lines, code);
-
-        const chars: any[] = [];
-        let emptyCount = 0;
-
-        function iterator(pos: any) {
-            const ch = lines.charAt(pos);
-            if (ch === "")
-                emptyCount += 1;
-            chars.push(ch);
-        }
-
-        lines.eachPos(iterator, null);
-
-        // The character at the position just past the end (as returned by
-        // lastPos) should be the only empty string.
-        assert.strictEqual(emptyCount, 1);
-
-        // Function.prototype.toString uses \r\n line endings on non-*NIX
-        // systems, so normalize those to \n characters.
-        code = code.replace(/\r\n/g, "\n");
-
-        let joined = chars.join("");
-        assert.strictEqual(joined.length, code.length);
-        assert.strictEqual(joined, code);
-
-        const withoutSpaces = code.replace(/\s+/g, "");
-        chars.length = emptyCount = 0;
-        lines.eachPos(iterator, null, true); // Skip spaces this time.
-        assert.strictEqual(emptyCount, 0);
-        joined = chars.join("");
-        assert.strictEqual(joined.length, withoutSpaces.length);
-        assert.strictEqual(joined, withoutSpaces);
+  it("FromString", function() {
+    function checkIsCached(s: any) {
+      assert.strictEqual(fromString(s), fromString(s));
+      check(fromString(s), s);
     }
 
-    it("EachPos", function EachPosTest() {
-        const code = String(EachPosTest);
-        let lines = fromString(code);
+    checkIsCached("");
+    checkIsCached(",");
+    checkIsCached(eol);
+    checkIsCached("this");
+    checkIsCached(", ");
+    checkIsCached(": ");
 
-        testEachPosHelper(lines, code);
+    const longer =
+      "This is a somewhat longer string that we do not want to cache.";
+    assert.notStrictEqual(fromString(longer), fromString(longer));
 
-        lines = lines.indentTail(5);
-        testEachPosHelper(lines, lines.toString());
+    // Since Lines objects are immutable, if one is passed to fromString,
+    // we can return it as-is without having to make a defensive copy.
+    const longerLines = fromString(longer);
+    assert.strictEqual(fromString(longerLines), longerLines);
+  });
 
-        lines = lines.indentTail(-9);
-        testEachPosHelper(lines, lines.toString());
+  it("ToString", function ToStringTest() {
+    const code = String(ToStringTest);
+    const lines = fromString(code);
+    check(lines, code);
+    check(
+      lines
+        .indentTail(5)
+        .indentTail(-7)
+        .indentTail(2),
+      code
+    );
+  });
 
-        lines = lines.indentTail(4);
-        testEachPosHelper(lines, code);
-    });
+  function testEachPosHelper(lines: any, code: any) {
+    check(lines, code);
 
-    it("CharAt", function CharAtTest() {
-        // Function.prototype.toString uses \r\n line endings on non-*NIX
-        // systems, so normalize those to \n characters.
-        const code = String(CharAtTest).replace(/\r\n/g, "\n");
-        const lines = fromString(code);
+    const chars: any[] = [];
+    let emptyCount = 0;
 
-        function compare(pos: any) {
-            assert.strictEqual(
-                lines.charAt(pos),
-                lines.bootstrapCharAt(pos));
-        }
-
-        lines.eachPos(compare);
-
-        // Try a bunch of crazy positions to verify equivalence for
-        // out-of-bounds input positions.
-        fromString(exports.testBasic).eachPos(compare);
-
-        let original = fromString("  ab" + eol + "  c"), indented = original.indentTail(4), reference = fromString("  ab" + eol + "      c");
-
-        function compareIndented(pos: any) {
-            const c = indented.charAt(pos);
-            check(c, reference.charAt(pos));
-            check(c, indented.bootstrapCharAt(pos));
-            check(c, reference.bootstrapCharAt(pos));
-        }
-
-        indented.eachPos(compareIndented);
-
-        indented = indented.indentTail(-4);
-        reference = original;
-
-        indented.eachPos(compareIndented);
-    });
-
-    it("Concat", function() {
-        const strings = ["asdf", "zcxv", "qwer"], lines = fromString(strings.join(eol)), indented = lines.indentTail(4);
-
-        assert.strictEqual(lines.length, 3);
-
-        check(indented, strings.join(eol + "    "));
-
-        assert.strictEqual(5, concat([lines, indented]).length);
-        assert.strictEqual(5, concat([indented, lines]).length);
-
-        check(concat([lines, indented]),
-              lines.toString() + indented.toString());
-
-        check(concat([lines, indented]).indentTail(4),
-              strings.join(eol + "    ") +
-              strings.join(eol + "        "));
-
-        check(concat([indented, lines]),
-              strings.join(eol + "    ") + lines.toString());
-
-        check(concat([lines, indented]),
-              lines.concat(indented));
-
-        check(concat([indented, lines]),
-              indented.concat(lines));
-
-        check(concat([]), fromString(""));
-        assert.strictEqual(concat([]), fromString(""));
-
-        check(fromString(" ").join([
-            fromString("var"),
-            fromString("foo")
-        ]), fromString("var foo"));
-
-        check(fromString(" ").join(["var", "foo"]),
-              fromString("var foo"));
-
-        check(concat([
-            fromString("var"),
-            fromString(" "),
-            fromString("foo")
-        ]), fromString("var foo"));
-
-        check(concat(["var", " ", "foo"]),
-              fromString("var foo"));
-
-        check(concat([
-            fromString("debugger"), ";"
-        ]), fromString("debugger;"));
-    });
-
-    it("Empty", function() {
-        function c(s: any) {
-            const lines = fromString(s);
-            check(lines, s);
-            assert.strictEqual(
-                lines.isEmpty(),
-                s.length === 0);
-
-            assert.ok(lines.trimLeft().isEmpty());
-            assert.ok(lines.trimRight().isEmpty());
-            assert.ok(lines.trim().isEmpty());
-        }
-
-        c("");
-        c(" ");
-        c("    ");
-        c(" " + eol);
-        c(eol + " ");
-        c(" " + eol + " ");
-        c(eol + " " + eol + " ");
-        c(" " + eol + eol + " ");
-        c(" " + eol + " " + eol + " ");
-        c(" " + eol + " " + eol + eol);
-    });
-
-    it("SingleLine", function() {
-        const string = "asdf", line = fromString(string);
-
-        check(line, string);
-        check(line.indentTail(4), string);
-        check(line.indentTail(-4), string);
-
-        // Single-line Lines objects are completely unchanged by indentTail.
-        assert.strictEqual(line.indentTail(10), line);
-
-        // Multi-line Lines objects are altered by indentTail, but only if the
-        // amount of the indentation is non-zero.
-        const twice = line.concat(eol, line);
-        assert.notStrictEqual(twice.indentTail(10), twice);
-        assert.strictEqual(twice.indentTail(0), twice);
-
-        check(line.concat(line), string + string);
-        check(line.indentTail(4).concat(line), string + string);
-        check(line.concat(line.indentTail(4)), string + string);
-        check(line.indentTail(8).concat(line.indentTail(4)), string + string);
-
-        line.eachPos(function(start) {
-            line.eachPos(function(end) {
-                check(line.slice(start, end),
-                      string.slice(start.column, end.column));
-            }, start);
-        });
-    });
-
-    it("Slice", function SliceTest() {
-        const code = String(SliceTest), lines = fromString(code);
-        checkAllSlices(lines);
-    });
-
-    function checkAllSlices(lines: any) {
-        lines.eachPos(function(start: any) {
-            lines.eachPos(function(end: any) {
-                check(lines.slice(start, end),
-                      lines.bootstrapSlice(start, end));
-                check(lines.sliceString(start, end),
-                      lines.bootstrapSliceString(start, end));
-            }, start);
-        });
+    function iterator(pos: any) {
+      const ch = lines.charAt(pos);
+      if (ch === "") emptyCount += 1;
+      chars.push(ch);
     }
 
-    function getSourceLocation(lines: any) {
-        return { start: lines.firstPos(),
-                 end: lines.lastPos() };
+    lines.eachPos(iterator, null);
+
+    // The character at the position just past the end (as returned by
+    // lastPos) should be the only empty string.
+    assert.strictEqual(emptyCount, 1);
+
+    // Function.prototype.toString uses \r\n line endings on non-*NIX
+    // systems, so normalize those to \n characters.
+    code = code.replace(/\r\n/g, "\n");
+
+    let joined = chars.join("");
+    assert.strictEqual(joined.length, code.length);
+    assert.strictEqual(joined, code);
+
+    const withoutSpaces = code.replace(/\s+/g, "");
+    chars.length = emptyCount = 0;
+    lines.eachPos(iterator, null, true); // Skip spaces this time.
+    assert.strictEqual(emptyCount, 0);
+    joined = chars.join("");
+    assert.strictEqual(joined.length, withoutSpaces.length);
+    assert.strictEqual(joined, withoutSpaces);
+  }
+
+  it("EachPos", function EachPosTest() {
+    const code = String(EachPosTest);
+    let lines = fromString(code);
+
+    testEachPosHelper(lines, code);
+
+    lines = lines.indentTail(5);
+    testEachPosHelper(lines, lines.toString());
+
+    lines = lines.indentTail(-9);
+    testEachPosHelper(lines, lines.toString());
+
+    lines = lines.indentTail(4);
+    testEachPosHelper(lines, code);
+  });
+
+  it("CharAt", function CharAtTest() {
+    // Function.prototype.toString uses \r\n line endings on non-*NIX
+    // systems, so normalize those to \n characters.
+    const code = String(CharAtTest).replace(/\r\n/g, "\n");
+    const lines = fromString(code);
+
+    function compare(pos: any) {
+      assert.strictEqual(lines.charAt(pos), lines.bootstrapCharAt(pos));
     }
 
-    it("GetSourceLocation", function GetSourceLocationTest() {
-        const code = String(GetSourceLocationTest), lines = fromString(code);
+    lines.eachPos(compare);
 
-        function verify(indent: any) {
-            const indented = lines.indentTail(indent), loc = getSourceLocation(indented), string = indented.toString(), strings = string.split(eol), lastLine = strings[strings.length - 1];
+    // Try a bunch of crazy positions to verify equivalence for
+    // out-of-bounds input positions.
+    fromString(exports.testBasic).eachPos(compare);
 
-            assert.strictEqual(loc.end.line, strings.length);
-            assert.strictEqual(loc.end.column, lastLine.length);
+    let original = fromString("  ab" + eol + "  c"),
+      indented = original.indentTail(4),
+      reference = fromString("  ab" + eol + "      c");
 
-            assert.deepEqual(loc, getSourceLocation(
-                indented.slice(loc.start, loc.end)));
-        }
+    function compareIndented(pos: any) {
+      const c = indented.charAt(pos);
+      check(c, reference.charAt(pos));
+      check(c, indented.bootstrapCharAt(pos));
+      check(c, reference.bootstrapCharAt(pos));
+    }
 
-        verify(0);
-        verify(4);
-        verify(-4);
+    indented.eachPos(compareIndented);
+
+    indented = indented.indentTail(-4);
+    reference = original;
+
+    indented.eachPos(compareIndented);
+  });
+
+  it("Concat", function() {
+    const strings = ["asdf", "zcxv", "qwer"],
+      lines = fromString(strings.join(eol)),
+      indented = lines.indentTail(4);
+
+    assert.strictEqual(lines.length, 3);
+
+    check(indented, strings.join(eol + "    "));
+
+    assert.strictEqual(5, concat([lines, indented]).length);
+    assert.strictEqual(5, concat([indented, lines]).length);
+
+    check(concat([lines, indented]), lines.toString() + indented.toString());
+
+    check(
+      concat([lines, indented]).indentTail(4),
+      strings.join(eol + "    ") + strings.join(eol + "        ")
+    );
+
+    check(
+      concat([indented, lines]),
+      strings.join(eol + "    ") + lines.toString()
+    );
+
+    check(concat([lines, indented]), lines.concat(indented));
+
+    check(concat([indented, lines]), indented.concat(lines));
+
+    check(concat([]), fromString(""));
+    assert.strictEqual(concat([]), fromString(""));
+
+    check(
+      fromString(" ").join([fromString("var"), fromString("foo")]),
+      fromString("var foo")
+    );
+
+    check(fromString(" ").join(["var", "foo"]), fromString("var foo"));
+
+    check(
+      concat([fromString("var"), fromString(" "), fromString("foo")]),
+      fromString("var foo")
+    );
+
+    check(concat(["var", " ", "foo"]), fromString("var foo"));
+
+    check(concat([fromString("debugger"), ";"]), fromString("debugger;"));
+  });
+
+  it("Empty", function() {
+    function c(s: any) {
+      const lines = fromString(s);
+      check(lines, s);
+      assert.strictEqual(lines.isEmpty(), s.length === 0);
+
+      assert.ok(lines.trimLeft().isEmpty());
+      assert.ok(lines.trimRight().isEmpty());
+      assert.ok(lines.trim().isEmpty());
+    }
+
+    c("");
+    c(" ");
+    c("    ");
+    c(" " + eol);
+    c(eol + " ");
+    c(" " + eol + " ");
+    c(eol + " " + eol + " ");
+    c(" " + eol + eol + " ");
+    c(" " + eol + " " + eol + " ");
+    c(" " + eol + " " + eol + eol);
+  });
+
+  it("SingleLine", function() {
+    const string = "asdf",
+      line = fromString(string);
+
+    check(line, string);
+    check(line.indentTail(4), string);
+    check(line.indentTail(-4), string);
+
+    // Single-line Lines objects are completely unchanged by indentTail.
+    assert.strictEqual(line.indentTail(10), line);
+
+    // Multi-line Lines objects are altered by indentTail, but only if the
+    // amount of the indentation is non-zero.
+    const twice = line.concat(eol, line);
+    assert.notStrictEqual(twice.indentTail(10), twice);
+    assert.strictEqual(twice.indentTail(0), twice);
+
+    check(line.concat(line), string + string);
+    check(line.indentTail(4).concat(line), string + string);
+    check(line.concat(line.indentTail(4)), string + string);
+    check(line.indentTail(8).concat(line.indentTail(4)), string + string);
+
+    line.eachPos(function(start) {
+      line.eachPos(function(end) {
+        check(line.slice(start, end), string.slice(start.column, end.column));
+      }, start);
     });
+  });
 
-    it("Trim", function() {
-        const string = "  xxx " + eol + " ";
-        const options = { tabWidth: 4 };
-        fromString(string);
+  it("Slice", function SliceTest() {
+    const code = String(SliceTest),
+      lines = fromString(code);
+    checkAllSlices(lines);
+  });
 
-        function test(string: string) {
-            const lines = fromString(string, options);
-            check(lines.trimLeft(), fromString(string.replace(/^\s+/, ""), options));
-            check(lines.trimRight(), fromString(string.replace(/\s+$/, ""), options));
-            check(lines.trim(), fromString(string.replace(/^\s+|\s+$/g, ""), options));
-        }
-
-        test("");
-        test(" ");
-        test("  xxx " + eol + " ");
-        test("  xxx");
-        test("xxx  ");
-        test(eol + "x" + eol + "x" + eol + "x" + eol);
-        test("\t" + eol + "x" + eol + "x" + eol + "x" + eol + "\t" + eol);
-        test("xxx");
+  function checkAllSlices(lines: any) {
+    lines.eachPos(function(start: any) {
+      lines.eachPos(function(end: any) {
+        check(lines.slice(start, end), lines.bootstrapSlice(start, end));
+        check(
+          lines.sliceString(start, end),
+          lines.bootstrapSliceString(start, end)
+        );
+      }, start);
     });
+  }
 
-    it("NoIndentEmptyLines", function() {
-        const lines = fromString("a" + eol + eol + "b"), indented = lines.indent(4), tailIndented = lines.indentTail(5);
+  function getSourceLocation(lines: any) {
+    return { start: lines.firstPos(), end: lines.lastPos() };
+  }
 
-        check(indented, fromString("    a" + eol + eol + "    b"));
-        check(tailIndented, fromString("a" + eol + eol + "     b"));
+  it("GetSourceLocation", function GetSourceLocationTest() {
+    const code = String(GetSourceLocationTest),
+      lines = fromString(code);
 
-        check(indented.indent(-4), lines);
-        check(tailIndented.indent(-5), lines);
+    function verify(indent: any) {
+      const indented = lines.indentTail(indent),
+        loc = getSourceLocation(indented),
+        string = indented.toString(),
+        strings = string.split(eol),
+        lastLine = strings[strings.length - 1];
+
+      assert.strictEqual(loc.end.line, strings.length);
+      assert.strictEqual(loc.end.column, lastLine.length);
+
+      assert.deepEqual(
+        loc,
+        getSourceLocation(indented.slice(loc.start, loc.end))
+      );
+    }
+
+    verify(0);
+    verify(4);
+    verify(-4);
+  });
+
+  it("Trim", function() {
+    const string = "  xxx " + eol + " ";
+    const options = { tabWidth: 4 };
+    fromString(string);
+
+    function test(string: string) {
+      const lines = fromString(string, options);
+      check(lines.trimLeft(), fromString(string.replace(/^\s+/, ""), options));
+      check(lines.trimRight(), fromString(string.replace(/\s+$/, ""), options));
+      check(
+        lines.trim(),
+        fromString(string.replace(/^\s+|\s+$/g, ""), options)
+      );
+    }
+
+    test("");
+    test(" ");
+    test("  xxx " + eol + " ");
+    test("  xxx");
+    test("xxx  ");
+    test(eol + "x" + eol + "x" + eol + "x" + eol);
+    test("\t" + eol + "x" + eol + "x" + eol + "x" + eol + "\t" + eol);
+    test("xxx");
+  });
+
+  it("NoIndentEmptyLines", function() {
+    const lines = fromString("a" + eol + eol + "b"),
+      indented = lines.indent(4),
+      tailIndented = lines.indentTail(5);
+
+    check(indented, fromString("    a" + eol + eol + "    b"));
+    check(tailIndented, fromString("a" + eol + eol + "     b"));
+
+    check(indented.indent(-4), lines);
+    check(tailIndented.indent(-5), lines);
+  });
+
+  it("CountSpaces", function() {
+    const count = countSpaces;
+
+    assert.strictEqual(count(""), 0);
+    assert.strictEqual(count(" "), 1);
+    assert.strictEqual(count("  "), 2);
+    assert.strictEqual(count("   "), 3);
+
+    function check(s: string, tabWidth: number, result: number) {
+      assert.strictEqual(count(s, tabWidth), result);
+    }
+
+    check("", 2, 0);
+    check("", 3, 0);
+    check("", 4, 0);
+
+    check(" ", 2, 1);
+    check("\t", 2, 2);
+    check("\t\t", 2, 4);
+    check(" \t\t", 2, 4);
+    check(" \t \t", 2, 4);
+    check("  \t \t", 2, 6);
+    check("  \t  \t", 2, 8);
+    check(" \t   \t", 2, 6);
+    check("   \t \t", 2, 6);
+
+    check(" ", 3, 1);
+    check("\t", 3, 3);
+    check("\t\t", 3, 6);
+    check(" \t\t", 3, 6);
+    check(" \t \t", 3, 6);
+    check("  \t \t", 3, 6);
+    check("  \t  \t", 3, 6);
+    check(" \t   \t", 3, 9);
+    check("   \t \t", 3, 9);
+
+    check("\t\t\t   ", 2, 9);
+    check("\t\t\t   ", 3, 12);
+    check("\t\t\t   ", 4, 15);
+
+    check("\r", 4, 0);
+    check("\r ", 4, 1);
+    check(" \r ", 4, 2);
+    check(" \r\r ", 4, 2);
+  });
+
+  it("IndentWithTabs", function() {
+    const tabWidth = 4;
+    const tabOpts = { tabWidth: tabWidth, useTabs: true };
+    const noTabOpts = { tabWidth: tabWidth, useTabs: false };
+
+    let code = ["function f() {", "\treturn this;", "}"].join(eol);
+
+    function checkUnchanged(lines: Lines, code: string) {
+      check(lines.toString(tabOpts), code);
+      check(lines.toString(noTabOpts), code);
+      check(
+        lines
+          .indent(3)
+          .indent(-5)
+          .indent(2)
+          .toString(tabOpts),
+        code
+      );
+      check(
+        lines
+          .indent(-3)
+          .indent(4)
+          .indent(-1)
+          .toString(noTabOpts),
+        code
+      );
+    }
+
+    let lines = fromString(code, tabOpts);
+    checkUnchanged(lines, code);
+
+    check(
+      lines.indent(1).toString(tabOpts),
+      [" function f() {", "\t return this;", " }"].join(eol)
+    );
+
+    check(
+      lines.indent(tabWidth).toString(tabOpts),
+      ["\tfunction f() {", "\t\treturn this;", "\t}"].join(eol)
+    );
+
+    check(
+      lines.indent(1).toString(noTabOpts),
+      [" function f() {", "     return this;", " }"].join(eol)
+    );
+
+    check(
+      lines.indent(tabWidth).toString(noTabOpts),
+      ["    function f() {", "        return this;", "    }"].join(eol)
+    );
+
+    const funkyCode = [
+      " function g() { \t ",
+      " \t\t  return this;  ",
+      "\t} "
+    ].join(eol);
+
+    const funky = fromString(funkyCode, tabOpts);
+    checkUnchanged(funky, funkyCode);
+
+    check(
+      funky.indent(1).toString(tabOpts),
+      ["  function g() { \t ", "\t\t   return this;  ", "\t } "].join(eol)
+    );
+
+    check(
+      funky.indent(2).toString(tabOpts),
+      ["   function g() { \t ", "\t\t\treturn this;  ", "\t  } "].join(eol)
+    );
+
+    check(
+      funky.indent(1).toString(noTabOpts),
+      ["  function g() { \t ", "           return this;  ", "     } "].join(eol)
+    );
+
+    check(
+      funky.indent(2).toString(noTabOpts),
+      ["   function g() { \t ", "            return this;  ", "      } "].join(
+        eol
+      )
+    );
+
+    // Test that '\v' characters are ignored for the purposes of indentation,
+    // but preserved when printing untouched lines.
+    code = ["\vfunction f() {\v", " \v   return \vthis;\v", "\v} \v "].join(
+      eol
+    );
+
+    lines = fromString(code, tabOpts);
+
+    checkUnchanged(lines, code);
+
+    check(
+      lines.indent(4).toString(noTabOpts),
+      ["    function f() {\v", "        return \vthis;\v", "    } \v "].join(
+        eol
+      )
+    );
+
+    check(
+      lines.indent(5).toString(tabOpts),
+      ["\t function f() {\v", "\t\t return \vthis;\v", "\t } \v "].join(eol)
+    );
+  });
+
+  it("GuessTabWidth", function GuessTabWidthTest(done) {
+    let lines;
+    lines = fromString(
+      ["function identity(x) {", "    return x;", "}"].join(eol)
+    );
+    assert.strictEqual(lines.guessTabWidth(), 4);
+
+    lines = fromString(
+      ["function identity(x) {", "  return x;", "}"].join(eol)
+    );
+    assert.strictEqual(lines.guessTabWidth(), 2);
+    assert.strictEqual(lines.indent(5).guessTabWidth(), 2);
+    assert.strictEqual(lines.indent(-4).guessTabWidth(), 2);
+
+    fs.readFile(__filename, "utf-8", function(err, source) {
+      assert.equal(err, null);
+      assert.strictEqual(fromString(source).guessTabWidth(), 4);
+
+      fs.readFile(path.join(__dirname, "..", "package.json"), "utf-8", function(
+        err,
+        source
+      ) {
+        assert.equal(err, null);
+        assert.strictEqual(fromString(source).guessTabWidth(), 2);
+
+        done();
+      });
     });
+  });
 
-    it("CountSpaces", function() {
-        const count = countSpaces;
+  it("ExoticWhitespace", function() {
+    let source = "";
+    const spacePattern = /^\s+$/;
 
-        assert.strictEqual(count(""), 0);
-        assert.strictEqual(count(" "), 1);
-        assert.strictEqual(count("  "), 2);
-        assert.strictEqual(count("   "), 3);
+    for (let i = 0; i < 0xffff; ++i) {
+      const ch = String.fromCharCode(i);
+      if (spacePattern.test(ch)) {
+        source += ch;
+      }
+    }
 
-        function check(s: string, tabWidth: number, result: number) {
-            assert.strictEqual(count(s, tabWidth), result);
-        }
+    source += "x";
 
-        check("", 2, 0);
-        check("", 3, 0);
-        check("", 4, 0);
+    const options = { tabWidth: 4 };
+    const lines = fromString(source, options);
 
-        check(" ", 2, 1);
-        check("\t", 2, 2);
-        check("\t\t", 2, 4);
-        check(" \t\t", 2, 4);
-        check(" \t \t", 2, 4);
-        check("  \t \t", 2, 6);
-        check("  \t  \t", 2, 8);
-        check(" \t   \t", 2, 6);
-        check("   \t \t", 2, 6);
+    assert.strictEqual(lines.length, 5);
+    assert.strictEqual(lines.getLineLength(1), options.tabWidth);
+    assert.strictEqual(lines.getIndentAt(1), options.tabWidth);
 
-        check(" ", 3, 1);
-        check("\t", 3, 3);
-        check("\t\t", 3, 6);
-        check(" \t\t", 3, 6);
-        check(" \t \t", 3, 6);
-        check("  \t \t", 3, 6);
-        check("  \t  \t", 3, 6);
-        check(" \t   \t", 3, 9);
-        check("   \t \t", 3, 9);
+    assert.strictEqual(
+      lines
+        .slice({
+          line: 5,
+          column: lines.getLineLength(5) - 1
+        })
+        .toString(options),
+      "x"
+    );
 
-        check("\t\t\t   ", 2, 9);
-        check("\t\t\t   ", 3, 12);
-        check("\t\t\t   ", 4, 15);
-
-        check("\r", 4, 0);
-        check("\r ", 4, 1);
-        check(" \r ", 4, 2);
-        check(" \r\r ", 4, 2);
-    });
-
-    it("IndentWithTabs", function() {
-        const tabWidth = 4;
-        const tabOpts = { tabWidth: tabWidth, useTabs: true };
-        const noTabOpts = { tabWidth: tabWidth, useTabs: false };
-
-        let code = [
-            "function f() {",
-            "\treturn this;",
-            "}"
-        ].join(eol);
-
-        function checkUnchanged(lines: Lines, code: string) {
-            check(lines.toString(tabOpts), code);
-            check(lines.toString(noTabOpts), code);
-            check(lines.indent(3).indent(-5).indent(2).toString(tabOpts), code);
-            check(lines.indent(-3).indent(4).indent(-1).toString(noTabOpts), code);
-        }
-
-        let lines = fromString(code, tabOpts);
-        checkUnchanged(lines, code);
-
-        check(lines.indent(1).toString(tabOpts), [
-            " function f() {",
-            "\t return this;",
-            " }"
-        ].join(eol));
-
-        check(lines.indent(tabWidth).toString(tabOpts), [
-            "\tfunction f() {",
-            "\t\treturn this;",
-            "\t}"
-        ].join(eol));
-
-        check(lines.indent(1).toString(noTabOpts), [
-            " function f() {",
-            "     return this;",
-            " }"
-        ].join(eol));
-
-        check(lines.indent(tabWidth).toString(noTabOpts), [
-            "    function f() {",
-            "        return this;",
-            "    }"
-        ].join(eol));
-
-        const funkyCode = [
-            " function g() { \t ",
-            " \t\t  return this;  ",
-            "\t} "
-        ].join(eol);
-
-        const funky = fromString(funkyCode, tabOpts);
-        checkUnchanged(funky, funkyCode);
-
-        check(funky.indent(1).toString(tabOpts), [
-            "  function g() { \t ",
-            "\t\t   return this;  ",
-            "\t } "
-        ].join(eol));
-
-        check(funky.indent(2).toString(tabOpts), [
-            "   function g() { \t ",
-            "\t\t\treturn this;  ",
-            "\t  } "
-        ].join(eol));
-
-        check(funky.indent(1).toString(noTabOpts), [
-            "  function g() { \t ",
-            "           return this;  ",
-            "     } "
-        ].join(eol));
-
-        check(funky.indent(2).toString(noTabOpts), [
-            "   function g() { \t ",
-            "            return this;  ",
-            "      } "
-        ].join(eol));
-
-        // Test that '\v' characters are ignored for the purposes of indentation,
-        // but preserved when printing untouched lines.
-        code = [
-            "\vfunction f() {\v",
-            " \v   return \vthis;\v",
-            "\v} \v "
-        ].join(eol);
-
-        lines = fromString(code, tabOpts);
-
-        checkUnchanged(lines, code);
-
-        check(lines.indent(4).toString(noTabOpts), [
-            "    function f() {\v",
-            "        return \vthis;\v",
-            "    } \v "
-        ].join(eol));
-
-        check(lines.indent(5).toString(tabOpts), [
-            "\t function f() {\v",
-            "\t\t return \vthis;\v",
-            "\t } \v "
-        ].join(eol));
-    });
-
-    it("GuessTabWidth", function GuessTabWidthTest(done) {
-        let lines;
-        lines = fromString([
-            "function identity(x) {",
-            "    return x;",
-            "}"
-        ].join(eol));
-        assert.strictEqual(lines.guessTabWidth(), 4);
-
-        lines = fromString([
-            "function identity(x) {",
-            "  return x;",
-            "}"
-        ].join(eol));
-        assert.strictEqual(lines.guessTabWidth(), 2);
-        assert.strictEqual(lines.indent(5).guessTabWidth(), 2);
-        assert.strictEqual(lines.indent(-4).guessTabWidth(), 2);
-
-        fs.readFile(__filename, "utf-8", function(err, source) {
-            assert.equal(err, null);
-            assert.strictEqual(fromString(source).guessTabWidth(), 4);
-
-            fs.readFile(path.join(
-                __dirname,
-                "..",
-                "package.json"
-            ), "utf-8", function(err, source) {
-                assert.equal(err, null);
-                assert.strictEqual(fromString(source).guessTabWidth(), 2);
-
-                done();
-            });
-        });
-    });
-
-    it("ExoticWhitespace", function() {
-        let source = "";
-        const spacePattern = /^\s+$/;
-
-        for (let i = 0; i < 0xffff; ++i) {
-            const ch = String.fromCharCode(i);
-            if (spacePattern.test(ch)) {
-                source += ch;
-            }
-        }
-
-        source += "x";
-
-        const options = { tabWidth: 4 };
-        const lines = fromString(source, options);
-
-        assert.strictEqual(lines.length, 5);
-        assert.strictEqual(lines.getLineLength(1), options.tabWidth);
-        assert.strictEqual(lines.getIndentAt(1), options.tabWidth);
-
-        assert.strictEqual(lines.slice({
+    assert.ok(
+      spacePattern.test(
+        lines
+          .slice(lines.firstPos(), {
             line: 5,
             column: lines.getLineLength(5) - 1
-        }).toString(options), "x");
-
-        assert.ok(spacePattern.test(
-            lines.slice(lines.firstPos(), {
-                line: 5,
-                column: lines.getLineLength(5) - 1
-            }).toString(options)
-        ));
-    });
+          })
+          .toString(options)
+      )
+    );
+  });
 });

--- a/test/mapping.ts
+++ b/test/mapping.ts
@@ -11,200 +11,198 @@ import { Printer } from "../lib/printer";
 import { EOL as eol } from "os";
 
 describe("source maps", function() {
-    it("should generate correct mappings", function() {
-        const code = [
-            "function foo(bar) {",
-            "  return 1 + bar;",
-            "}"
-        ].join(eol);
+  it("should generate correct mappings", function() {
+    const code = ["function foo(bar) {", "  return 1 + bar;", "}"].join(eol);
 
-        fromString(code);
-        const ast = parse(code, {
-            sourceFileName: "source.js"
-        });
+    fromString(code);
+    const ast = parse(code, {
+      sourceFileName: "source.js"
+    });
 
-        const path = new NodePath(ast);
-        const returnPath = path.get("program", "body", 0, "body", "body", 0);
-        n.ReturnStatement.assert(returnPath.value);
+    const path = new NodePath(ast);
+    const returnPath = path.get("program", "body", 0, "body", "body", 0);
+    n.ReturnStatement.assert(returnPath.value);
 
-        const leftPath = returnPath.get("argument", "left");
-        const leftValue = leftPath.value;
-        const rightPath = returnPath.get("argument", "right");
+    const leftPath = returnPath.get("argument", "left");
+    const leftValue = leftPath.value;
+    const rightPath = returnPath.get("argument", "right");
 
-        leftPath.replace(rightPath.value);
-        rightPath.replace(leftValue);
+    leftPath.replace(rightPath.value);
+    rightPath.replace(leftValue);
 
-        const sourceRoot = "path/to/source/root";
-        const printed = new Printer({
-            sourceMapName: "source.map.json",
-            sourceRoot: sourceRoot
-        }).print(ast);
+    const sourceRoot = "path/to/source/root";
+    const printed = new Printer({
+      sourceMapName: "source.map.json",
+      sourceRoot: sourceRoot
+    }).print(ast);
 
-        assert.ok(printed.map);
+    assert.ok(printed.map);
 
-        assert.strictEqual(
-            printed.map.file,
-            "source.map.json"
-        );
+    assert.strictEqual(printed.map.file, "source.map.json");
 
-        assert.strictEqual(
-            printed.map.sourceRoot,
-            sourceRoot
-        );
+    assert.strictEqual(printed.map.sourceRoot, sourceRoot);
 
-        const smc = new sourceMap.SourceMapConsumer(printed.map);
+    const smc = new sourceMap.SourceMapConsumer(printed.map);
 
-        function check(origLine: any, origCol: any, genLine: any, genCol: any, lastColumn: any) {
-            assert.deepEqual(smc.originalPositionFor({
-                line: genLine,
-                column: genCol
-            }), {
-                source: sourceRoot + "/source.js",
-                line: origLine,
-                column: origCol,
-                name: null
-            });
-
-            assert.deepEqual(smc.generatedPositionFor({
-                source: sourceRoot + "/source.js",
-                line: origLine,
-                column: origCol
-            }), {
-                line: genLine,
-                column: genCol,
-                lastColumn: lastColumn
-            });
+    function check(
+      origLine: any,
+      origCol: any,
+      genLine: any,
+      genCol: any,
+      lastColumn: any
+    ) {
+      assert.deepEqual(
+        smc.originalPositionFor({
+          line: genLine,
+          column: genCol
+        }),
+        {
+          source: sourceRoot + "/source.js",
+          line: origLine,
+          column: origCol,
+          name: null
         }
+      );
 
-        check(1, 0, 1, 0, null); // function
-        check(1, 18, 1, 18, null); // {
-        check(2, 13, 2, 9, null); // bar
-        check(2, 9, 2, 15, null); // 1
-        check(3, 0, 3, 0, null); // }
-    });
-
-    it("should compose with inputSourceMap", function() {
-        function addUseStrict(ast: any) {
-            return recast.visit(ast, {
-                visitFunction: function(path) {
-                    path.get("body", "body").unshift(
-                        b.expressionStatement(b.literal("use strict"))
-                    );
-                    this.traverse(path);
-                }
-            });
+      assert.deepEqual(
+        smc.generatedPositionFor({
+          source: sourceRoot + "/source.js",
+          line: origLine,
+          column: origCol
+        }),
+        {
+          line: genLine,
+          column: genCol,
+          lastColumn: lastColumn
         }
+      );
+    }
 
-        function stripConsole(ast: any) {
-            return recast.visit(ast, {
-                visitCallExpression: function(path) {
-                    const node = path.value;
-                    if (n.MemberExpression.check(node.callee) &&
-                        n.Identifier.check(node.callee.object) &&
-                        node.callee.object.name === "console") {
-                        n.ExpressionStatement.assert(path.parent.node);
-                        path.parent.replace();
-                        return false;
-                    }
-                    return;
-                }
-            });
+    check(1, 0, 1, 0, null); // function
+    check(1, 18, 1, 18, null); // {
+    check(2, 13, 2, 9, null); // bar
+    check(2, 9, 2, 15, null); // 1
+    check(3, 0, 3, 0, null); // }
+  });
+
+  it("should compose with inputSourceMap", function() {
+    function addUseStrict(ast: any) {
+      return recast.visit(ast, {
+        visitFunction: function(path) {
+          path
+            .get("body", "body")
+            .unshift(b.expressionStatement(b.literal("use strict")));
+          this.traverse(path);
         }
+      });
+    }
 
-        const code = [
-            "function add(a, b) {",
-            "  var sum = a + b;",
-            "  console.log(a, b);",
-            "  return sum;",
-            "}"
-        ].join(eol);
+    function stripConsole(ast: any) {
+      return recast.visit(ast, {
+        visitCallExpression: function(path) {
+          const node = path.value;
+          if (
+            n.MemberExpression.check(node.callee) &&
+            n.Identifier.check(node.callee.object) &&
+            node.callee.object.name === "console"
+          ) {
+            n.ExpressionStatement.assert(path.parent.node);
+            path.parent.replace();
+            return false;
+          }
+          return;
+        }
+      });
+    }
 
-        const ast = parse(code, {
-            sourceFileName: "original.js"
-        });
+    const code = [
+      "function add(a, b) {",
+      "  var sum = a + b;",
+      "  console.log(a, b);",
+      "  return sum;",
+      "}"
+    ].join(eol);
 
-        const useStrictResult = new Printer({
-            sourceMapName: "useStrict.map.json"
-        }).print(addUseStrict(ast));
-
-        const useStrictAst = parse(useStrictResult.code, {
-            sourceFileName: "useStrict.js"
-        });
-
-        const oneStepResult = new Printer({
-            sourceMapName: "oneStep.map.json"
-        }).print(stripConsole(ast));
-
-        const twoStepResult = new Printer({
-            sourceMapName: "twoStep.map.json",
-            inputSourceMap: useStrictResult.map
-        }).print(stripConsole(useStrictAst));
-
-        assert.strictEqual(
-            oneStepResult.code,
-            twoStepResult.code
-        );
-
-        const smc1 = new sourceMap.SourceMapConsumer(oneStepResult.map);
-        const smc2 = new sourceMap.SourceMapConsumer(twoStepResult.map);
-
-        smc1.eachMapping(function(mapping) {
-            const pos = {
-                line: mapping.generatedLine,
-                column: mapping.generatedColumn
-            };
-
-            const orig1 = smc1.originalPositionFor(pos);
-            const orig2 = smc2.originalPositionFor(pos);
-
-            // The composition of the source maps generated separately from
-            // the two transforms should be equivalent to the source map
-            // generated from the composition of the two transforms.
-            assert.deepEqual(orig1, orig2);
-
-            // Make sure the two-step source map refers back to the original
-            // source instead of the intermediate source.
-            assert.strictEqual(orig2.source, "original.js");
-        });
+    const ast = parse(code, {
+      sourceFileName: "original.js"
     });
 
-    it("should work when a child node becomes null", function() {
-        // https://github.com/facebook/regenerator/issues/103
-        const code = [
-            "for (var i = 0; false; i++)",
-            "  log(i);"
-        ].join(eol);
-        const ast = parse(code);
-        const path = new NodePath(ast);
+    const useStrictResult = new Printer({
+      sourceMapName: "useStrict.map.json"
+    }).print(addUseStrict(ast));
 
-        const updatePath = path.get("program", "body", 0, "update");
-        n.UpdateExpression.assert(updatePath.value);
-
-        updatePath.replace(null);
-
-        const printed = new Printer().print(ast);
-        assert.strictEqual(printed.code, [
-            "for (var i = 0; false; )",
-            "  log(i);"
-        ].join(eol));
+    const useStrictAst = parse(useStrictResult.code, {
+      sourceFileName: "useStrict.js"
     });
 
-    it("should tolerate programs that become empty", function() {
-        const source = "foo();";
-        const ast = recast.parse(source, {
-            sourceFileName: "foo.js"
-        });
+    const oneStepResult = new Printer({
+      sourceMapName: "oneStep.map.json"
+    }).print(stripConsole(ast));
 
-        assert.strictEqual(ast.program.body.length, 1);
-        ast.program.body.length = 0;
+    const twoStepResult = new Printer({
+      sourceMapName: "twoStep.map.json",
+      inputSourceMap: useStrictResult.map
+    }).print(stripConsole(useStrictAst));
 
-        const result = recast.print(ast, {
-            sourceMapName: "foo.map.json"
-        });
+    assert.strictEqual(oneStepResult.code, twoStepResult.code);
 
-        assert.strictEqual(result.map.file, "foo.map.json");
-        assert.deepEqual(result.map.sources, []);
-        assert.deepEqual(result.map.names, []);
-        assert.strictEqual(result.map.mappings, "");
+    const smc1 = new sourceMap.SourceMapConsumer(oneStepResult.map);
+    const smc2 = new sourceMap.SourceMapConsumer(twoStepResult.map);
+
+    smc1.eachMapping(function(mapping) {
+      const pos = {
+        line: mapping.generatedLine,
+        column: mapping.generatedColumn
+      };
+
+      const orig1 = smc1.originalPositionFor(pos);
+      const orig2 = smc2.originalPositionFor(pos);
+
+      // The composition of the source maps generated separately from
+      // the two transforms should be equivalent to the source map
+      // generated from the composition of the two transforms.
+      assert.deepEqual(orig1, orig2);
+
+      // Make sure the two-step source map refers back to the original
+      // source instead of the intermediate source.
+      assert.strictEqual(orig2.source, "original.js");
     });
+  });
+
+  it("should work when a child node becomes null", function() {
+    // https://github.com/facebook/regenerator/issues/103
+    const code = ["for (var i = 0; false; i++)", "  log(i);"].join(eol);
+    const ast = parse(code);
+    const path = new NodePath(ast);
+
+    const updatePath = path.get("program", "body", 0, "update");
+    n.UpdateExpression.assert(updatePath.value);
+
+    updatePath.replace(null);
+
+    const printed = new Printer().print(ast);
+    assert.strictEqual(
+      printed.code,
+      ["for (var i = 0; false; )", "  log(i);"].join(eol)
+    );
+  });
+
+  it("should tolerate programs that become empty", function() {
+    const source = "foo();";
+    const ast = recast.parse(source, {
+      sourceFileName: "foo.js"
+    });
+
+    assert.strictEqual(ast.program.body.length, 1);
+    ast.program.body.length = 0;
+
+    const result = recast.print(ast, {
+      sourceMapName: "foo.map.json"
+    });
+
+    assert.strictEqual(result.map.file, "foo.map.json");
+    assert.deepEqual(result.map.sources, []);
+    assert.deepEqual(result.map.names, []);
+    assert.strictEqual(result.map.mappings, "");
+  });
 });

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -5,12 +5,8 @@ import { Printer } from "../lib/printer";
 import * as types from "ast-types";
 import { EOL as eol } from "os";
 
-const printer = new Printer;
-const {
-  namedTypes: n,
-  builders: b,
-  NodePath,
-} = types;
+const printer = new Printer();
+const { namedTypes: n, builders: b, NodePath } = types;
 
 function parseExpression(expr: any) {
   let ast: any = esprima.parse(expr);
@@ -26,37 +22,49 @@ function check(expr: any) {
 
   const expressionAst = parseExpression(expr);
   const generic = printer.printGenerically(expressionAst).code;
-  types.astNodesAreEquivalent.assert(
-    expressionAst,
-    parseExpression(generic)
-  );
+  types.astNodesAreEquivalent.assert(expressionAst, parseExpression(generic));
 }
 
 const operators = [
-  "==", "!=", "===", "!==",
-  "<", "<=", ">", ">=",
-  "<<", ">>", ">>>",
-  "+", "-", "*", "/", "%",
+  "==",
+  "!=",
+  "===",
+  "!==",
+  "<",
+  "<=",
+  ">",
+  ">=",
+  "<<",
+  ">>",
+  ">>>",
+  "+",
+  "-",
+  "*",
+  "/",
+  "%",
   "&", // TODO Missing from the Parser API.
-  "|", "^", "in",
+  "|",
+  "^",
+  "in",
   "instanceof",
-  "&&", "||"
+  "&&",
+  "||"
 ];
 
-describe("parens", function () {
-  it("Arithmetic", function () {
+describe("parens", function() {
+  it("Arithmetic", function() {
     check("1 - 2");
     check("  2 +2 ");
 
-    operators.forEach(function (op1) {
-      operators.forEach(function (op2) {
+    operators.forEach(function(op1) {
+      operators.forEach(function(op2) {
         check("(a " + op1 + " b) " + op2 + " c");
         check("a " + op1 + " (b " + op2 + " c)");
       });
     });
   });
 
-  it("Unary", function () {
+  it("Unary", function() {
     check("(-a).b");
     check("(+a).b");
     check("(!a).b");
@@ -66,14 +74,14 @@ describe("parens", function () {
     check("(delete a.b).c");
   });
 
-  it("Binary", function () {
+  it("Binary", function() {
     check("(a && b)()");
     check("typeof (a && b)");
     check("(a && b)[c]");
     check("(a && b).c");
   });
 
-  it("Sequence", function () {
+  it("Sequence", function() {
     check("(a, b)()");
     check("a(b, (c, d), e)");
     check("!(a, b)");
@@ -86,7 +94,7 @@ describe("parens", function () {
     check("a = (1, 2)");
   });
 
-  it("NewExpression", function () {
+  it("NewExpression", function() {
     check("new (a.b())");
     check("new (a.b())(c)");
     check("new a.b(c)");
@@ -99,7 +107,7 @@ describe("parens", function () {
     check('(new Date)["getTime"]()');
   });
 
-  it("Numbers", function () {
+  it("Numbers", function() {
     check("(1).foo");
     check("(-1).foo");
     check("+0");
@@ -107,7 +115,7 @@ describe("parens", function () {
     check("(-Infinity).foo");
   });
 
-  it("Assign", function () {
+  it("Assign", function() {
     check("!(a = false)");
     check("a + (b = 2) + c");
     check("(a = fn)()");
@@ -116,7 +124,7 @@ describe("parens", function () {
     check("(a = b).c");
   });
 
-  it("Function", function () {
+  it("Function", function() {
     check("a(function (){}.bind(this))");
     check("(function (){}).apply(this, arguments)");
     check("function f() { (function (){}).call(this) }");
@@ -126,20 +134,19 @@ describe("parens", function () {
     check("a || ((x, y={z:1}) => x + y.z)");
   });
 
-  it("ObjectLiteral", function () {
+  it("ObjectLiteral", function() {
     check("a({b:c(d)}.b)");
     check("({a:b(c)}).a");
   });
 
-  it("ReprintedParens", function () {
+  it("ReprintedParens", function() {
     const code = "a(function g(){}.call(this));";
     const ast1 = parse(code);
     const body = ast1.program.body;
 
     // Copy the function from a position where it does not need
     // parentheses to a position where it does need parentheses.
-    body.push(b.expressionStatement(
-      body[0].expression.arguments[0]));
+    body.push(b.expressionStatement(body[0].expression.arguments[0]));
 
     const generic = printer.printGenerically(ast1).code;
     const ast2 = parse(generic);
@@ -174,78 +181,78 @@ describe("parens", function () {
     );
   });
 
-  it("don't reparenthesize valid IIFEs", function () {
+  it("don't reparenthesize valid IIFEs", function() {
     const iifeCode = "(function     spaces   () {        }.call()  )  ;";
     const iifeAst = parse(iifeCode);
     const iifeReprint = printer.print(iifeAst).code;
     assert.strictEqual(iifeReprint, iifeCode);
   });
 
-  it("don't reparenthesize valid object literals", function () {
+  it("don't reparenthesize valid object literals", function() {
     const objCode = "(  {    foo   :  42}.  foo )  ;";
     const objAst = parse(objCode);
     const objReprint = printer.print(objAst).code;
     assert.strictEqual(objReprint, objCode);
   });
 
-  it("don't parenthesize return statements with sequence expressions", function () {
+  it("don't parenthesize return statements with sequence expressions", function() {
     const objCode = "function foo() { return 1, 2; }";
     const objAst = parse(objCode);
     const objReprint = printer.print(objAst).code;
     assert.strictEqual(objReprint, objCode);
   });
 
-  it("NegatedLoopCondition", function () {
-    const ast = parse([
-      "for (var i = 0; i < 10; ++i) {",
-      "  console.log(i);",
-      "}"
-    ].join(eol));
+  it("NegatedLoopCondition", function() {
+    const ast = parse(
+      ["for (var i = 0; i < 10; ++i) {", "  console.log(i);", "}"].join(eol)
+    );
 
     const loop = ast.program.body[0];
     const test = loop.test;
     const negation = b.unaryExpression("!", test);
 
-    assert.strictEqual(
-      printer.print(negation).code,
-      "!(i < 10)"
-    );
+    assert.strictEqual(printer.print(negation).code, "!(i < 10)");
 
     loop.test = negation;
 
-    assert.strictEqual(printer.print(ast).code, [
-      "for (var i = 0; !(i < 10); ++i) {",
-      "  console.log(i);",
-      "}"
-    ].join(eol));
+    assert.strictEqual(
+      printer.print(ast).code,
+      ["for (var i = 0; !(i < 10); ++i) {", "  console.log(i);", "}"].join(eol)
+    );
   });
 
-  it("MisleadingExistingParens", function () {
-    const ast = parse([
-      // The key === "oyez" expression appears to have parentheses
-      // already, but those parentheses won't help us when we negate the
-      // condition with a !.
-      'if (key === "oyez") {',
-      "  throw new Error(key);",
-      "}"
-    ].join(eol));
+  it("MisleadingExistingParens", function() {
+    const ast = parse(
+      [
+        // The key === "oyez" expression appears to have parentheses
+        // already, but those parentheses won't help us when we negate the
+        // condition with a !.
+        'if (key === "oyez") {',
+        "  throw new Error(key);",
+        "}"
+      ].join(eol)
+    );
 
     const ifStmt = ast.program.body[0];
     ifStmt.test = b.unaryExpression("!", ifStmt.test);
 
     const binaryPath = new NodePath(ast).get(
-      "program", "body", 0, "test", "argument");
+      "program",
+      "body",
+      0,
+      "test",
+      "argument"
+    );
 
     assert.ok(binaryPath.needsParens());
 
-    assert.strictEqual(printer.print(ifStmt).code, [
-      'if (!(key === "oyez")) {',
-      "  throw new Error(key);",
-      "}"
-    ].join(eol));
+    assert.strictEqual(
+      printer.print(ifStmt).code,
+      ['if (!(key === "oyez")) {', "  throw new Error(key);", "}"].join(eol)
+    );
   });
 
-  it("DiscretionaryParens", function () {
+  it("DiscretionaryParens", function() {
     const code = [
       "if (info.line && (i > 0 || !skipFirstLine)) {",
       "  info = copyLineInfo(info);",
@@ -255,13 +262,18 @@ describe("parens", function () {
     const ast = parse(code);
 
     const rightPath = new NodePath(ast).get(
-      "program", "body", 0, "test", "right");
+      "program",
+      "body",
+      0,
+      "test",
+      "right"
+    );
 
     assert.ok(rightPath.needsParens());
     assert.strictEqual(printer.print(ast).code, code);
   });
 
-  it("should not be added to multiline boolean expressions", function () {
+  it("should not be added to multiline boolean expressions", function() {
     const code = [
       "function foo() {",
       "  return !(",
@@ -277,18 +289,15 @@ describe("parens", function () {
       tabWidth: 2
     });
 
-    assert.strictEqual(
-      printer.print(ast).code,
-      code
-    );
+    assert.strictEqual(printer.print(ast).code, code);
   });
 
-  it("should be added to callees that are function expressions", function () {
+  it("should be added to callees that are function expressions", function() {
     check("(()=>{})()");
     check("(function (){})()");
   });
 
-  it("issues #504 and #512", function () {
+  it("issues #504 and #512", function() {
     check("() => ({})['foo']");
     check("() => ({ foo: 123 }[foo] + 2) * 3");
     check("() => ({ foo: 123 }['foo'] + 1 - 2 - 10)");
@@ -296,17 +305,17 @@ describe("parens", function () {
     check("() => (function () { return 456 }())");
   });
 
-  it("should be added to bound arrow function expressions", function () {
+  it("should be added to bound arrow function expressions", function() {
     check("(()=>{}).bind(x)");
   });
 
-  it("should be added to object destructuring assignment expressions", function () {
+  it("should be added to object destructuring assignment expressions", function() {
     check("({x}={x:1})");
     // Issue #533
     check("({ foo } = bar)");
   });
 
-  it("regression test for issue #327", function () {
+  it("regression test for issue #327", function() {
     const expr = "(function(){}())";
     check(expr);
 
@@ -314,25 +323,16 @@ describe("parens", function () {
     const callExpression = ast.program.body[0].expression;
     assert.strictEqual(callExpression.type, "CallExpression");
     callExpression.callee.type = "ArrowFunctionExpression";
-    assert.strictEqual(
-      printer.print(ast).code,
-      "((() => {})())"
-    );
+    assert.strictEqual(printer.print(ast).code, "((() => {})())");
     // Print just the callExpression without its enclosing AST context.
-    assert.strictEqual(
-      printer.print(callExpression).code,
-      "(() => {})()"
-    );
+    assert.strictEqual(printer.print(callExpression).code, "(() => {})()");
     // Trigger pretty-printing of the callExpression to remove the outer
     // layer of parentheses.
     callExpression.original = null;
-    assert.strictEqual(
-      printer.print(ast).code,
-      "(() => {})();"
-    );
+    assert.strictEqual(printer.print(ast).code, "(() => {})();");
   });
 
-  it("regression test for issue #366", function () {
+  it("regression test for issue #366", function() {
     const code = "typeof a ? b : c";
     check(code);
 
@@ -341,9 +341,6 @@ describe("parens", function () {
     const callee = exprStmt.expression;
     exprStmt.expression = b.callExpression(callee, []);
 
-    assert.strictEqual(
-      printer.print(ast).code,
-      "(typeof a ? b : c)()"
-    );
+    assert.strictEqual(printer.print(ast).code, "(typeof a ? b : c)()");
   });
 });

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -13,11 +13,12 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
 // test functions with names and then export them later.
 
 describe("parser", function() {
-  ["../parsers/acorn",
-   "../parsers/babel",
-   "../parsers/esprima",
-   "../parsers/flow",
-   "../parsers/typescript",
+  [
+    "../parsers/acorn",
+    "../parsers/babel",
+    "../parsers/esprima",
+    "../parsers/flow",
+    "../parsers/typescript"
   ].forEach(runTestsForParser);
 
   it("AlternateParser", function() {
@@ -34,13 +35,10 @@ describe("parser", function() {
 
     function check(options?: any) {
       const ast = parse("ignored", options);
-      const printer = new Printer;
+      const printer = new Printer();
 
       types.namedTypes.File.assert(ast, true);
-      assert.strictEqual(
-        printer.printGenerically(ast).code,
-        "surprise;"
-      );
+      assert.strictEqual(printer.printGenerically(ast).code, "surprise;");
     }
 
     check({ esprima: parser });
@@ -51,10 +49,12 @@ describe("parser", function() {
 function runTestsForParser(parserId: string) {
   const parserName = parserId.split("/").pop();
 
-  if (nodeMajorVersion < 6 &&
-      (parserName === "babel" ||
-       parserName === "flow" ||
-       parserName === "typescript")) {
+  if (
+    nodeMajorVersion < 6 &&
+    (parserName === "babel" ||
+      parserName === "flow" ||
+      parserName === "typescript")
+  ) {
     // Babel 7 no longer supports Node 4 or 5.
     return;
   }
@@ -65,8 +65,8 @@ function runTestsForParser(parserId: string) {
 
   const parser = require(parserId);
 
-  it("[" + parserName + "] empty source", function () {
-    const printer = new Printer;
+  it("[" + parserName + "] empty source", function() {
+    const printer = new Printer();
 
     function check(code: string) {
       const ast = parse(code, { parser });
@@ -119,10 +119,7 @@ function runTestsForParser(parserId: string) {
 
     const firstComment = lastStatement.comments[0];
 
-    assert.strictEqual(
-      firstComment.type,
-      lineCommentTypes[parserName]
-    );
+    assert.strictEqual(firstComment.type, lineCommentTypes[parserName]);
 
     assert.strictEqual(firstComment.leading, true);
     assert.strictEqual(firstComment.trailing, false);
@@ -133,10 +130,7 @@ function runTestsForParser(parserId: string) {
 
     const secondComment = lastStatement.comments[1];
 
-    assert.strictEqual(
-      secondComment.type,
-      lineCommentTypes[parserName]
-    );
+    assert.strictEqual(secondComment.type, lineCommentTypes[parserName]);
 
     assert.strictEqual(secondComment.leading, true);
     assert.strictEqual(secondComment.trailing, false);
@@ -151,14 +145,9 @@ function runTestsForParser(parserId: string) {
   });
 
   it("[" + parserName + "] LocationFixer", function() {
-    const code = [
-      "function foo() {",
-      "    a()",
-      "    b()",
-      "}"
-    ].join(eol);
+    const code = ["function foo() {", "    a()", "    b()", "}"].join(eol);
     const ast = parse(code, { parser });
-    const printer = new Printer;
+    const printer = new Printer();
 
     types.visit(ast, {
       visitFunctionDeclaration: function(path) {
@@ -187,22 +176,25 @@ function runTestsForParser(parserId: string) {
         assert.strictEqual(s + "", sliced.toString());
       }
 
-      types.visit(parse(code, {
-        tabWidth: tabWidth,
-        parser,
-      }), {
-        visitIdentifier(path) {
-          const ident = path.node;
-          checkId(ident.name, ident.loc!);
-          this.traverse(path);
-        },
+      types.visit(
+        parse(code, {
+          tabWidth: tabWidth,
+          parser
+        }),
+        {
+          visitIdentifier(path) {
+            const ident = path.node;
+            checkId(ident.name, ident.loc!);
+            this.traverse(path);
+          },
 
-        visitLiteral(path) {
-          const lit = path.node;
-          checkId(lit.value, lit.loc!);
-          this.traverse(path);
+          visitLiteral(path) {
+            const lit = path.node;
+            checkId(lit.value, lit.loc!);
+            this.traverse(path);
+          }
         }
-      });
+      );
     }
 
     for (let tabWidth = 1; tabWidth <= 8; ++tabWidth) {
@@ -215,15 +207,12 @@ function runTestsForParser(parserId: string) {
     }
   });
 
-  it("[" + parserName + "] Only comment followed by space", function () {
-    const printer = new Printer;
+  it("[" + parserName + "] Only comment followed by space", function() {
+    const printer = new Printer();
 
     function check(code: string) {
       const ast = parse(code, { parser });
-      assert.strictEqual(
-        printer.print(ast).code,
-        code
-      );
+      assert.strictEqual(printer.print(ast).code, code);
     }
 
     check("// comment");

--- a/test/patcher.ts
+++ b/test/patcher.ts
@@ -27,7 +27,9 @@ function loc(sl: number, sc: number, el: number, ec: number) {
 
 describe("patcher", function() {
   it("Patcher", function() {
-    let lines = fromString(code.join(eol)), patcher = new Patcher(lines), selfLoc = loc(5, 9, 5, 13);
+    let lines = fromString(code.join(eol)),
+      patcher = new Patcher(lines),
+      selfLoc = loc(5, 9, 5, 13);
 
     assert.strictEqual(patcher.get(selfLoc).toString(), "this");
 
@@ -41,26 +43,27 @@ describe("patcher", function() {
     // Make sure comments are preserved.
     assert.ok(got.indexOf("// some") >= 0);
 
-    const oyezLoc = loc(2, 12, 6, 1), beforeOyez = patcher.get(oyezLoc).toString();
+    const oyezLoc = loc(2, 12, 6, 1),
+      beforeOyez = patcher.get(oyezLoc).toString();
     assert.strictEqual(beforeOyez.indexOf("exports"), -1);
     assert.ok(beforeOyez.indexOf("comment") >= 0);
 
     patcher.replace(oyezLoc, "oyez");
 
-    assert.strictEqual(patcher.get().toString(), [
-      "// file comment",
-      "exports.foo(oyez);"
-    ].join(eol));
+    assert.strictEqual(
+      patcher.get().toString(),
+      ["// file comment", "exports.foo(oyez);"].join(eol)
+    );
 
     // "Reset" the patcher.
     patcher = new Patcher(lines);
     patcher.replace(oyezLoc, "oyez");
     patcher.replace(selfLoc, "self");
 
-    assert.strictEqual(patcher.get().toString(), [
-      "// file comment",
-      "exports.foo(oyez);"
-    ].join(eol));
+    assert.strictEqual(
+      patcher.get().toString(),
+      ["// file comment", "exports.foo(oyez);"].join(eol)
+    );
   });
 
   const trickyCode = [
@@ -75,9 +78,15 @@ describe("patcher", function() {
     function check(indent: number) {
       const lines = fromString(trickyCode).indent(indent);
       const file = parse(lines.toString());
-      const reprinter = FastPath.from(file).call(function(bodyPath: any) {
-        return getReprinter(bodyPath);
-      }, "program", "body", 0, "body");
+      const reprinter = FastPath.from(file).call(
+        function(bodyPath: any) {
+          return getReprinter(bodyPath);
+        },
+        "program",
+        "body",
+        0,
+        "body"
+      );
 
       const reprintedLines = reprinter(function() {
         assert.ok(false, "should not have called print function");
@@ -87,11 +96,10 @@ describe("patcher", function() {
       assert.strictEqual(reprintedLines.getIndentAt(1), 0);
       assert.strictEqual(reprintedLines.getIndentAt(2), 4);
       assert.strictEqual(reprintedLines.getIndentAt(3), 0);
-      assert.strictEqual(reprintedLines.toString(), [
-        "{",
-        "    qux();",
-        "}"
-      ].join(eol));
+      assert.strictEqual(
+        reprintedLines.toString(),
+        ["{", "    qux();", "}"].join(eol)
+      );
     }
 
     for (let indent = -4; indent <= 4; ++indent) {
@@ -103,10 +111,7 @@ describe("patcher", function() {
     const strAST = parse('return"foo"');
     const returnStmt = strAST.program.body[0];
     n.ReturnStatement.assert(returnStmt);
-    assert.strictEqual(
-      recast.print(strAST).code,
-      'return"foo"'
-    );
+    assert.strictEqual(recast.print(strAST).code, 'return"foo"');
 
     returnStmt.argument = b.literal(null);
     assert.strictEqual(
@@ -117,10 +122,7 @@ describe("patcher", function() {
     const arrAST = parse("throw[1,2,3]");
     const throwStmt = arrAST.program.body[0];
     n.ThrowStatement.assert(throwStmt);
-    assert.strictEqual(
-      recast.print(arrAST).code,
-      "throw[1,2,3]"
-    );
+    assert.strictEqual(recast.print(arrAST).code, "throw[1,2,3]");
 
     throwStmt.argument = b.literal(false);
     assert.strictEqual(
@@ -137,10 +139,7 @@ describe("patcher", function() {
     n.Literal.assert(inExpr.left);
     assert.strictEqual(inExpr.left.value, "foo");
 
-    assert.strictEqual(
-      recast.print(inAST).code,
-      '"foo"in bar'
-    );
+    assert.strictEqual(recast.print(inAST).code, '"foo"in bar');
 
     inExpr.left = b.identifier("x");
     assert.strictEqual(
@@ -152,7 +151,7 @@ describe("patcher", function() {
   it("should not add spaces to the beginnings of lines", function() {
     const twoLineCode = [
       "return", // Because of ASI rules, these two lines will
-      'xxx'     // parse as separate statements.
+      "xxx" // parse as separate statements.
     ].join(eol);
 
     const twoLineAST = parse(twoLineCode);
@@ -163,28 +162,25 @@ describe("patcher", function() {
     n.Identifier.assert(xxx.expression);
     assert.strictEqual(xxx.expression.name, "xxx");
 
-    assert.strictEqual(
-      recast.print(twoLineAST).code,
-      twoLineCode
-    );
+    assert.strictEqual(recast.print(twoLineAST).code, twoLineCode);
 
     xxx.expression = b.identifier("expression");
 
     const withExpression = recast.print(twoLineAST).code;
-    assert.strictEqual(withExpression, [
-      "return",
-      "expression" // The key is that no space should be added to the
-      // beginning of this line.
-    ].join(eol));
+    assert.strictEqual(
+      withExpression,
+      [
+        "return",
+        "expression" // The key is that no space should be added to the
+        // beginning of this line.
+      ].join(eol)
+    );
 
     twoLineAST.program.body[1] = b.expressionStatement(
       b.callExpression(b.identifier("foo"), [])
     );
 
     const withFooCall = recast.print(twoLineAST).code;
-    assert.strictEqual(withFooCall, [
-      "return",
-      "foo()"
-    ].join(eol));
+    assert.strictEqual(withFooCall, ["return", "foo()"].join(eol));
   });
 });

--- a/test/perf.ts
+++ b/test/perf.ts
@@ -3,30 +3,30 @@ import fs from "fs";
 import * as recast from "../main";
 
 const source = fs.readFileSync(
-    path.join(__dirname, "data", "backbone.js"),
-    "utf8"
+  path.join(__dirname, "data", "backbone.js"),
+  "utf8"
 );
 
-const start = +new Date;
+const start = +new Date();
 const ast = recast.parse(source);
 const types = Object.create(null);
 
-const parseTime = +new Date - start;
+const parseTime = +new Date() - start;
 console.log("parse", parseTime, "ms");
 
 recast.visit(ast, {
-    visitNode: function(path) {
-        types[path.value.type] = true;
-        this.traverse(path);
-    }
+  visitNode: function(path) {
+    types[path.value.type] = true;
+    this.traverse(path);
+  }
 });
 
-const visitTime = +new Date - start - parseTime;
+const visitTime = +new Date() - start - parseTime;
 console.log("visit", visitTime, "ms");
 
 recast.prettyPrint(ast).code;
 
-const printTime = +new Date - start - visitTime - parseTime;
+const printTime = +new Date() - start - visitTime - parseTime;
 console.log("print", printTime, "ms");
 
-console.log("total", +new Date - start, "ms");
+console.log("total", +new Date() - start, "ms");

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -14,7 +14,7 @@ describe("printer", function() {
   it("Printer", function testPrinter(done) {
     const code = testPrinter + "";
     const ast = parse(code);
-    const printer = new Printer;
+    const printer = new Printer();
 
     assert.strictEqual(typeof printer.print, "function");
     assert.strictEqual(printer.print(null).code, "");
@@ -32,13 +32,13 @@ describe("printer", function() {
   });
 
   const uselessSemicolons = [
-    'function a() {',
+    "function a() {",
     '  return "a";',
-    '};',
-    '',
-    'function b() {',
+    "};",
+    "",
+    "function b() {",
     '  return "b";',
-    '};'
+    "};"
   ].join(eol);
 
   it("EmptyStatements", function() {
@@ -69,8 +69,8 @@ describe("printer", function() {
     assert.strictEqual(reprinted, importantSemicolons);
   });
 
-  const arrayExprWithTrailingComma = '[1, 2,];';
-  const arrayExprWithoutTrailingComma = '[1, 2];';
+  const arrayExprWithTrailingComma = "[1, 2,];";
+  const arrayExprWithoutTrailingComma = "[1, 2];";
 
   it("ArrayExpressionWithTrailingComma", function() {
     const ast = parse(arrayExprWithTrailingComma);
@@ -84,20 +84,14 @@ describe("printer", function() {
     const arrayExprOrig = arrayExpr.original;
     arrayExpr.original = null;
 
-    assert.strictEqual(
-      printer.print(ast).code,
-      arrayExprWithoutTrailingComma
-    );
+    assert.strictEqual(printer.print(ast).code, arrayExprWithoutTrailingComma);
 
     arrayExpr.original = arrayExprOrig;
 
-    assert.strictEqual(
-      printer.print(ast).code,
-      arrayExprWithTrailingComma
-    );
+    assert.strictEqual(printer.print(ast).code, arrayExprWithTrailingComma);
   });
 
-  const arrayExprWithHoles = '[,,];';
+  const arrayExprWithHoles = "[,,];";
 
   it("ArrayExpressionWithHoles", function() {
     const ast = parse(arrayExprWithHoles);
@@ -111,21 +105,16 @@ describe("printer", function() {
     const arrayExprOrig = arrayExpr.original;
     arrayExpr.original = null;
 
-    assert.strictEqual(
-      printer.print(ast).code,
-      arrayExprWithHoles
-    );
+    assert.strictEqual(printer.print(ast).code, arrayExprWithHoles);
 
     arrayExpr.original = arrayExprOrig;
 
-    assert.strictEqual(
-      printer.print(ast).code,
-      arrayExprWithHoles
-    );
+    assert.strictEqual(printer.print(ast).code, arrayExprWithHoles);
   });
 
-  const objectExprWithTrailingComma = '({x: 1, y: 2,});';
-  const objectExprWithoutTrailingComma = '({' + eol + '  x: 1,' + eol + '  y: 2' + eol + '});';
+  const objectExprWithTrailingComma = "({x: 1, y: 2,});";
+  const objectExprWithoutTrailingComma =
+    "({" + eol + "  x: 1," + eol + "  y: 2" + eol + "});";
 
   it("ArrayExpressionWithTrailingComma", function() {
     const ast = parse(objectExprWithTrailingComma);
@@ -139,17 +128,11 @@ describe("printer", function() {
     const objectExprOrig = objectExpr.original;
     objectExpr.original = null;
 
-    assert.strictEqual(
-      printer.print(ast).code,
-      objectExprWithoutTrailingComma
-    );
+    assert.strictEqual(printer.print(ast).code, objectExprWithoutTrailingComma);
 
     objectExpr.original = objectExprOrig;
 
-    assert.strictEqual(
-      printer.print(ast).code,
-      objectExprWithTrailingComma
-    );
+    assert.strictEqual(printer.print(ast).code, objectExprWithTrailingComma);
   });
 
   const switchCase = [
@@ -159,7 +142,7 @@ describe("printer", function() {
     "",
     "  case b:",
     "    break;",
-    "}",
+    "}"
   ].join(eol);
 
   const switchCaseReprinted = [
@@ -198,29 +181,17 @@ describe("printer", function() {
 
     body[0] = b.ifStatement(
       b.identifier("test"),
-      b.blockStatement([
-        switchStmt
-      ])
+      b.blockStatement([switchStmt])
     );
 
-    assert.strictEqual(
-      printer.print(ast).code,
-      switchCaseReprinted
-    );
+    assert.strictEqual(printer.print(ast).code, switchCaseReprinted);
 
-    assert.strictEqual(
-      printer.printGenerically(ast).code,
-      switchCaseGeneric
-    );
+    assert.strictEqual(printer.printGenerically(ast).code, switchCaseGeneric);
   });
 
-  const tryCatch = [
-    "try {",
-    "  a();",
-    "} catch (e) {",
-    "  b(e);",
-    "}"
-  ].join(eol);
+  const tryCatch = ["try {", "  a();", "} catch (e) {", "  b(e);", "}"].join(
+    eol
+  );
 
   it("IndentTryCatch", function() {
     const ast = parse(tryCatch);
@@ -271,10 +242,7 @@ describe("printer", function() {
     // Trigger reprinting of the class body.
     cb.body.push(cb.body[0]);
 
-    assert.strictEqual(
-      printer.print(ast).code,
-      classBodyExpected.join(eol)
-    );
+    assert.strictEqual(printer.print(ast).code, classBodyExpected.join(eol));
   });
 
   const multiLineParams = [
@@ -339,10 +307,7 @@ describe("printer", function() {
     varDecl.declarations.pop();
     varDecl.declarations.push(z);
 
-    assert.strictEqual(
-      printer.print(b.program([varDecl])).code,
-      "var x, z;"
-    );
+    assert.strictEqual(printer.print(b.program([varDecl])).code, "var x, z;");
   });
 
   it("MultiLineVarPrinting", function() {
@@ -358,13 +323,10 @@ describe("printer", function() {
       b.variableDeclarator(b.identifier("z"), null)
     ]);
 
-    assert.strictEqual(printer.print(b.program([varDecl])).code, [
-      "var x,",
-      "    y = {",
-      "      why: \"not\"",
-      "    },",
-      "    z;"
-    ].join(eol));
+    assert.strictEqual(
+      printer.print(b.program([varDecl])).code,
+      ["var x,", "    y = {", '      why: "not"', "    },", "    z;"].join(eol)
+    );
   });
 
   it("ForLoopPrinting", function() {
@@ -382,8 +344,7 @@ describe("printer", function() {
 
     assert.strictEqual(
       printer.print(loop).code,
-      "for (var i = 0; i < 3; i++)" + eol +
-        "  log(i);"
+      "for (var i = 0; i < 3; i++)" + eol + "  log(i);"
     );
   });
 
@@ -400,8 +361,7 @@ describe("printer", function() {
 
     assert.strictEqual(
       printer.print(loop).code,
-      "for (var i = 0; i < 3; i++)" + eol +
-        "  ;"
+      "for (var i = 0; i < 3; i++)" + eol + "  ;"
     );
   });
 
@@ -414,22 +374,17 @@ describe("printer", function() {
       b.identifier("obj"),
       b.expressionStatement(
         b.callExpression(b.identifier("log"), [b.identifier("key")])
-      ),
+      )
     );
 
     assert.strictEqual(
       printer.print(loop).code,
-      "for (var key in obj)" + eol +
-        "  log(key);"
+      "for (var key in obj)" + eol + "  log(key);"
     );
   });
 
   it("GuessTabWidth", function() {
-    const code = [
-      "function identity(x) {",
-      "  return x;",
-      "}"
-    ].join(eol);
+    const code = ["function identity(x) {", "  return x;", "}"].join(eol);
 
     const guessedTwo = [
       "function identity(x) {",
@@ -454,17 +409,11 @@ describe("printer", function() {
 
     funBody.unshift(
       b.expressionStatement(
-        b.callExpression(
-          b.identifier("log"),
-          funDecl.params
-        )
+        b.callExpression(b.identifier("log"), funDecl.params)
       )
     );
 
-    assert.strictEqual(
-      new Printer().print(ast).code,
-      guessedTwo
-    );
+    assert.strictEqual(new Printer().print(ast).code, guessedTwo);
 
     assert.strictEqual(
       new Printer({
@@ -477,15 +426,15 @@ describe("printer", function() {
   it("FunctionDefaultsAndRest", function() {
     const printer = new Printer();
     const funExpr = b.functionExpression(
-      b.identifier('a'),
-      [b.identifier('b'), b.identifier('c')],
+      b.identifier("a"),
+      [b.identifier("b"), b.identifier("c")],
       b.blockStatement([]),
       false,
-      false,
+      false
     );
 
     funExpr.defaults = [null, b.literal(1)];
-    funExpr.rest = b.identifier('d');
+    funExpr.rest = b.identifier("d");
 
     assert.strictEqual(
       printer.print(funExpr).code,
@@ -493,12 +442,13 @@ describe("printer", function() {
     );
 
     const arrowFunExpr = b.arrowFunctionExpression(
-      [b.identifier('b'), b.identifier('c')],
+      [b.identifier("b"), b.identifier("c")],
       b.blockStatement([]),
-      false);
+      false
+    );
 
     arrowFunExpr.defaults = [null, b.literal(1)];
-    arrowFunExpr.rest = b.identifier('d');
+    arrowFunExpr.rest = b.identifier("d");
 
     assert.strictEqual(
       printer.print(arrowFunExpr).code,
@@ -558,14 +508,7 @@ describe("printer", function() {
   it("export default of IIFE", function() {
     const printer = new Printer();
     let ast = b.exportDefaultDeclaration(
-      b.callExpression(
-        b.functionExpression(
-          null,
-          [],
-          b.blockStatement([])
-        ),
-        []
-      )
+      b.callExpression(b.functionExpression(null, [], b.blockStatement([])), [])
     );
     const code = printer.print(ast).code;
     ast = parse(code);
@@ -617,10 +560,7 @@ describe("printer", function() {
     ast.program.body.unshift(debugStmt);
     ast.program.body.push(debugStmt);
 
-    assert.strictEqual(
-      printer.print(ast).code,
-      stmtListSpacesExpected
-    );
+    assert.strictEqual(printer.print(ast).code, stmtListSpacesExpected);
 
     const funDecl = b.functionDeclaration(
       b.identifier("foo"),
@@ -630,23 +570,21 @@ describe("printer", function() {
 
     assert.strictEqual(
       printer.print(funDecl).code,
-      linesModule.concat([
-        "function foo() {" + eol,
-        linesModule.fromString(
-          stmtListSpacesExpected.replace(/^\s+|\s+$/g, "")
-        ).indent(2),
-        eol + "}"
-      ]).toString()
+      linesModule
+        .concat([
+          "function foo() {" + eol,
+          linesModule
+            .fromString(stmtListSpacesExpected.replace(/^\s+|\s+$/g, ""))
+            .indent(2),
+          eol + "}"
+        ])
+        .toString()
     );
   });
 
   it("should print static methods with the static keyword", function() {
     const printer = new Printer({ tabWidth: 4 });
-    const ast = parse([
-      "class A {",
-      "  static foo() {}",
-      "}"
-    ].join(eol));
+    const ast = parse(["class A {", "  static foo() {}", "}"].join(eol));
 
     const classBody = ast.program.body[0].body;
     n.ClassBody.assert(classBody);
@@ -658,63 +596,87 @@ describe("printer", function() {
 
     foo.key.name = "formerlyFoo";
 
-    assert.strictEqual(printer.print(ast).code, [
-      "class A {",
-      "    static formerlyFoo() {}",
-      "    static formerlyFoo() {}",
-      "}"
-    ].join(eol));
+    assert.strictEqual(
+      printer.print(ast).code,
+      [
+        "class A {",
+        "    static formerlyFoo() {}",
+        "    static formerlyFoo() {}",
+        "}"
+      ].join(eol)
+    );
   });
 
   it("should print string literals with the specified delimiter", function() {
-    const ast = parse([
-      "var obj = {",
-      "    \"foo's\": 'bar',",
-      "    '\"bar\\'s\"': /regex/m",
-      "};"
-    ].join(eol));
+    const ast = parse(
+      [
+        "var obj = {",
+        "    \"foo's\": 'bar',",
+        "    '\"bar\\'s\"': /regex/m",
+        "};"
+      ].join(eol)
+    );
 
     const variableDeclaration = ast.program.body[0];
     n.VariableDeclaration.assert(variableDeclaration);
 
     const printer = new Printer({ quote: "single" });
-    assert.strictEqual(printer.printGenerically(ast).code, [
-      "var obj = {",
-      "    'foo\\'s': 'bar',",
-      "    '\"bar\\'s\"': /regex/m",
-      "};"
-    ].join(eol));
+    assert.strictEqual(
+      printer.printGenerically(ast).code,
+      [
+        "var obj = {",
+        "    'foo\\'s': 'bar',",
+        "    '\"bar\\'s\"': /regex/m",
+        "};"
+      ].join(eol)
+    );
 
     const printer2 = new Printer({ quote: "double" });
-    assert.strictEqual(printer2.printGenerically(ast).code, [
-      "var obj = {",
-      "    \"foo's\": \"bar\",",
-      '    "\\"bar\'s\\"": /regex/m',
-      "};"
-    ].join(eol));
+    assert.strictEqual(
+      printer2.printGenerically(ast).code,
+      [
+        "var obj = {",
+        '    "foo\'s": "bar",',
+        '    "\\"bar\'s\\"": /regex/m',
+        "};"
+      ].join(eol)
+    );
 
     const printer3 = new Printer({ quote: "auto" });
-    assert.strictEqual(printer3.printGenerically(ast).code, [
-      "var obj = {",
-      '    "foo\'s": "bar",',
-      '    \'"bar\\\'s"\': /regex/m',
-      "};"
-    ].join(eol));
+    assert.strictEqual(
+      printer3.printGenerically(ast).code,
+      [
+        "var obj = {",
+        '    "foo\'s": "bar",',
+        "    '\"bar\\'s\"': /regex/m",
+        "};"
+      ].join(eol)
+    );
   });
 
   it("should print block comments at head of class once", function() {
     // Given.
-    const ast = parse([
-      "/**",
-      " * This class was in an IIFE and returned an instance of itself.",
-      " */",
-      "function SimpleClass() {",
-      "};"
-    ].join(eol));
+    const ast = parse(
+      [
+        "/**",
+        " * This class was in an IIFE and returned an instance of itself.",
+        " */",
+        "function SimpleClass() {",
+        "};"
+      ].join(eol)
+    );
 
-    const classIdentifier = b.identifier('SimpleClass');
-    const exportsExpression = b.memberExpression(b.identifier('module'), b.identifier('exports'), false);
-    const assignmentExpression = b.assignmentExpression('=', exportsExpression, classIdentifier);
+    const classIdentifier = b.identifier("SimpleClass");
+    const exportsExpression = b.memberExpression(
+      b.identifier("module"),
+      b.identifier("exports"),
+      false
+    );
+    const assignmentExpression = b.assignmentExpression(
+      "=",
+      exportsExpression,
+      classIdentifier
+    );
     const exportStatement = b.expressionStatement(assignmentExpression);
 
     ast.program.body.push(exportStatement);
@@ -723,44 +685,47 @@ describe("printer", function() {
     const printedClass = new Printer().print(ast).code;
 
     // Then.
-    assert.strictEqual(printedClass, [
-      "/**",
-      " * This class was in an IIFE and returned an instance of itself.",
-      " */",
-      "function SimpleClass() {",
-      "}",
-      "module.exports = SimpleClass;"
-    ].join(eol));
+    assert.strictEqual(
+      printedClass,
+      [
+        "/**",
+        " * This class was in an IIFE and returned an instance of itself.",
+        " */",
+        "function SimpleClass() {",
+        "}",
+        "module.exports = SimpleClass;"
+      ].join(eol)
+    );
   });
 
   it("should support computed properties", function() {
     var code = [
-      'class A {',
+      "class A {",
       '  ["a"]() {}',
       '  [ID("b")]() {}',
-      '  [0]() {}',
-      '  [ID(1)]() {}',
+      "  [0]() {}",
+      "  [ID(1)]() {}",
       '  get ["a"]() {}',
       '  get [ID("b")]() {}',
-      '  get [0]() {}',
-      '  get [ID(1)]() {}',
+      "  get [0]() {}",
+      "  get [ID(1)]() {}",
       '  set ["a"](x) {}',
       '  set [ID("b")](x) {}',
-      '  set [0](x) {}',
-      '  set [ID(1)](x) {}',
+      "  set [0](x) {}",
+      "  set [ID(1)](x) {}",
       '  static ["a"]() {}',
       '  static [ID("b")]() {}',
-      '  static [0]() {}',
-      '  static [ID(1)]() {}',
+      "  static [0]() {}",
+      "  static [ID(1)]() {}",
       '  static get ["a"]() {}',
       '  static get [ID("b")]() {}',
-      '  static get [0]() {}',
-      '  static get [ID(1)]() {}',
+      "  static get [0]() {}",
+      "  static get [ID(1)]() {}",
       '  static set ["a"](x) {}',
       '  static set [ID("b")](x) {}',
-      '  static set [0](x) {}',
-      '  static set [ID(1)](x) {}',
-      '}'
+      "  static set [0](x) {}",
+      "  static set [ID(1)](x) {}",
+      "}"
     ].join(eol);
 
     let ast = parse(code);
@@ -769,45 +734,41 @@ describe("printer", function() {
       tabWidth: 2
     });
 
-    assert.strictEqual(
-      printer.printGenerically(ast).code,
-      code
-    );
+    assert.strictEqual(printer.printGenerically(ast).code, code);
 
     var code = [
-      'var obj = {',
+      "var obj = {",
       '  ["a"]: 1,',
       '  [ID("b")]: 2,',
-      '  [0]: 3,',
-      '  [ID(1)]: 4,',
+      "  [0]: 3,",
+      "  [ID(1)]: 4,",
       '  ["a"]() {},',
       '  [ID("b")]() {},',
-      '  [0]() {},',
-      '  [ID(1)]() {},',
+      "  [0]() {},",
+      "  [ID(1)]() {},",
       '  get ["a"]() {},',
       '  get [ID("b")]() {},',
-      '  get [0]() {},',
-      '  get [ID(1)]() {},',
+      "  get [0]() {},",
+      "  get [ID(1)]() {},",
       '  set ["a"](x) {},',
       '  set [ID("b")](x) {},',
-      '  set [0](x) {},',
-      '  set [ID(1)](x) {}',
-      '};'
+      "  set [0](x) {},",
+      "  set [ID(1)](x) {}",
+      "};"
     ].join(eol);
 
     ast = parse(code);
 
-    assert.strictEqual(
-      printer.printGenerically(ast).code,
-      code
-    );
+    assert.strictEqual(printer.printGenerically(ast).code, code);
 
-    ast = parse([
-      "var o = {",
-      "  // This foo will become a computed method name.",
-      "  foo() { return bar }",
-      "};"
-    ].join(eol));
+    ast = parse(
+      [
+        "var o = {",
+        "  // This foo will become a computed method name.",
+        "  foo() { return bar }",
+        "};"
+      ].join(eol)
+    );
 
     const objExpr = ast.program.body[0].declarations[0].init;
     n.ObjectExpression.assert(objExpr);
@@ -816,21 +777,19 @@ describe("printer", function() {
     objExpr.properties[0].computed = true;
     objExpr.properties[0].kind = "get";
 
-    assert.strictEqual(recast.print(ast).code, [
-      "var o = {",
-      "  // This foo will become a computed method name.",
-      "  get [foo]() { return bar }",
-      "};"
-    ].join(eol));
+    assert.strictEqual(
+      recast.print(ast).code,
+      [
+        "var o = {",
+        "  // This foo will become a computed method name.",
+        "  get [foo]() { return bar }",
+        "};"
+      ].join(eol)
+    );
   });
 
   it("prints trailing commas in object literals", function() {
-    const code = [
-      "({",
-      "  foo: bar,",
-      "  bar: foo,",
-      "});"
-    ].join(eol);
+    const code = ["({", "  foo: bar,", "  bar: foo,", "});"].join(eol);
 
     const ast = parse(code, {
       // Supports trailing commas whereas plain esprima does not.
@@ -839,7 +798,7 @@ describe("printer", function() {
 
     let printer = new Printer({
       tabWidth: 2,
-      trailingComma: true,
+      trailingComma: true
     });
 
     let pretty = printer.printGenerically(ast).code;
@@ -848,7 +807,7 @@ describe("printer", function() {
     // It should also work when using the `trailingComma` option as an object.
     printer = new Printer({
       tabWidth: 2,
-      trailingComma: { objects: true },
+      trailingComma: { objects: true }
     });
 
     pretty = printer.printGenerically(ast).code;
@@ -856,12 +815,7 @@ describe("printer", function() {
   });
 
   it("prints trailing commas in function calls", function() {
-    const code = [
-      "call(",
-      "  1,",
-      "  2,",
-      ");"
-    ].join(eol);
+    const code = ["call(", "  1,", "  2,", ");"].join(eol);
 
     const ast = parse(code, {
       // Supports trailing commas whereas plain esprima does not.
@@ -871,7 +825,7 @@ describe("printer", function() {
     let printer = new Printer({
       tabWidth: 2,
       wrapColumn: 1,
-      trailingComma: true,
+      trailingComma: true
     });
 
     let pretty = printer.printGenerically(ast).code;
@@ -881,7 +835,7 @@ describe("printer", function() {
     printer = new Printer({
       tabWidth: 2,
       wrapColumn: 1,
-      trailingComma: { parameters: true },
+      trailingComma: { parameters: true }
     });
 
     pretty = printer.printGenerically(ast).code;
@@ -889,12 +843,7 @@ describe("printer", function() {
   });
 
   it("prints trailing commas in array expressions", function() {
-    const code = [
-      "[",
-      "  1,",
-      "  2,",
-      "];"
-    ].join(eol);
+    const code = ["[", "  1,", "  2,", "];"].join(eol);
 
     const ast = parse(code, {
       // Supports trailing commas whereas plain esprima does not.
@@ -904,7 +853,7 @@ describe("printer", function() {
     let printer = new Printer({
       tabWidth: 2,
       wrapColumn: 1,
-      trailingComma: true,
+      trailingComma: true
     });
 
     let pretty = printer.printGenerically(ast).code;
@@ -914,7 +863,7 @@ describe("printer", function() {
     printer = new Printer({
       tabWidth: 2,
       wrapColumn: 1,
-      trailingComma: { arrays: true },
+      trailingComma: { arrays: true }
     });
 
     pretty = printer.printGenerically(ast).code;
@@ -922,12 +871,7 @@ describe("printer", function() {
   });
 
   it("prints trailing commas in function definitions", function() {
-    const code = [
-      "function foo(",
-      "  a,",
-      "  b,",
-      ") {}"
-    ].join(eol);
+    const code = ["function foo(", "  a,", "  b,", ") {}"].join(eol);
 
     const ast = parse(code, {
       // Supports trailing commas whereas plain esprima does not.
@@ -937,7 +881,7 @@ describe("printer", function() {
     let printer = new Printer({
       tabWidth: 2,
       wrapColumn: 1,
-      trailingComma: true,
+      trailingComma: true
     });
 
     let pretty = printer.printGenerically(ast).code;
@@ -947,37 +891,35 @@ describe("printer", function() {
     printer = new Printer({
       tabWidth: 2,
       wrapColumn: 1,
-      trailingComma: { parameters: true },
+      trailingComma: { parameters: true }
     });
 
     pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
 
-  (nodeMajorVersion >= 6 ? it : xit)
-  ("shouldn't print a trailing comma for a RestElement", function() {
-    const code = [
-      "function foo(",
-      "  a,",
-      "  b,",
-      "  ...rest",
-      ") {}"
-    ].join(eol);
+  (nodeMajorVersion >= 6 ? it : xit)(
+    "shouldn't print a trailing comma for a RestElement",
+    function() {
+      const code = ["function foo(", "  a,", "  b,", "  ...rest", ") {}"].join(
+        eol
+      );
 
-    const ast = parse(code, {
-      // The flow parser and Babylon recognize `...rest` as a `RestElement`
-      parser: require("@babel/parser")
-    });
+      const ast = parse(code, {
+        // The flow parser and Babylon recognize `...rest` as a `RestElement`
+        parser: require("@babel/parser")
+      });
 
-    const printer = new Printer({
-      tabWidth: 2,
-      wrapColumn: 1,
-      trailingComma: true,
-    });
+      const printer = new Printer({
+        tabWidth: 2,
+        wrapColumn: 1,
+        trailingComma: true
+      });
 
-    const pretty = printer.printGenerically(ast).code;
-    assert.strictEqual(pretty, code);
-  });
+      const pretty = printer.printGenerically(ast).code;
+      assert.strictEqual(pretty, code);
+    }
+  );
 
   it("should support AssignmentPattern and RestElement", function() {
     const code = [
@@ -1004,11 +946,13 @@ describe("printer", function() {
     const code = "(...rest) => rest;";
 
     let ast = b.program([
-      b.expressionStatement(b.arrowFunctionExpression(
-        [b.spreadElementPattern(b.identifier('rest'))],
-        b.identifier('rest'),
-        false
-      ))
+      b.expressionStatement(
+        b.arrowFunctionExpression(
+          [b.spreadElementPattern(b.identifier("rest"))],
+          b.identifier("rest"),
+          false
+        )
+      )
     ]);
 
     const printer = new Printer({
@@ -1020,11 +964,13 @@ describe("printer", function() {
 
     // Print RestElement the same way
     ast = b.program([
-      b.expressionStatement(b.arrowFunctionExpression(
-        [b.restElement(b.identifier('rest'))],
-        b.identifier('rest'),
-        false
-      ))
+      b.expressionStatement(
+        b.arrowFunctionExpression(
+          [b.restElement(b.identifier("rest"))],
+          b.identifier("rest"),
+          false
+        )
+      )
     ]);
 
     pretty = printer.printGenerically(ast).code;
@@ -1033,13 +979,11 @@ describe("printer", function() {
     // Do the same for the `rest` field.
     const arrowFunction = b.arrowFunctionExpression(
       [],
-      b.identifier('rest'),
+      b.identifier("rest"),
       false
     );
-    arrowFunction.rest = b.identifier('rest');
-    ast = b.program([
-      b.expressionStatement(arrowFunction)
-    ]);
+    arrowFunction.rest = b.identifier("rest");
+    ast = b.program([b.expressionStatement(arrowFunction)]);
 
     pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
@@ -1049,14 +993,12 @@ describe("printer", function() {
     const code = "(a) => {};";
 
     const fn = b.arrowFunctionExpression(
-      [b.identifier('a')],
+      [b.identifier("a")],
       b.blockStatement([]),
       false
     );
 
-    const ast = b.program([
-      b.expressionStatement(fn)
-    ]);
+    const ast = b.program([b.expressionStatement(fn)]);
 
     const printer = new Printer({
       arrowParensAlways: true
@@ -1076,10 +1018,9 @@ describe("printer", function() {
     const declaration = b.variableDeclaration("var", [
       b.variableDeclarator(
         b.identifier("a"),
-        b.callExpression(
-          b.memberExpression(fn, b.identifier("bind"), false),
-          [b.identifier("z")]
-        )
+        b.callExpression(b.memberExpression(fn, b.identifier("bind"), false), [
+          b.identifier("z")
+        ])
       )
     ]);
 
@@ -1093,16 +1034,10 @@ describe("printer", function() {
   it("adds parenthesis around async arrow functions with args", function() {
     let code = "async () => {};";
 
-    const fn = b.arrowFunctionExpression(
-      [],
-      b.blockStatement([]),
-      false
-    );
+    const fn = b.arrowFunctionExpression([], b.blockStatement([]), false);
     fn.async = true;
 
-    const ast = b.program([
-      b.expressionStatement(fn)
-    ]);
+    const ast = b.program([b.expressionStatement(fn)]);
 
     const printer = new Printer({
       tabWidth: 2
@@ -1113,14 +1048,14 @@ describe("printer", function() {
 
     // No parenthesis for single params if they are identifiers
     code = "async foo => {};";
-    fn.params = [b.identifier('foo')];
+    fn.params = [b.identifier("foo")];
 
     pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
 
     // Add parenthesis for destructuring
     code = "async ([a, b]) => {};";
-    fn.params = [b.arrayPattern([b.identifier('a'), b.identifier('b')])];
+    fn.params = [b.arrayPattern([b.identifier("a"), b.identifier("b")])];
 
     pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
@@ -1129,20 +1064,14 @@ describe("printer", function() {
   it("adds parenthesis around arrow functions with single arg and a type", function() {
     const code = "(a: b) => {};";
 
-    const arg = b.identifier('a');
+    const arg = b.identifier("a");
     arg.typeAnnotation = b.typeAnnotation(
-      b.genericTypeAnnotation(b.identifier('b'), null)
+      b.genericTypeAnnotation(b.identifier("b"), null)
     );
 
-    const fn = b.arrowFunctionExpression(
-      [arg],
-      b.blockStatement([]),
-      false
-    );
+    const fn = b.arrowFunctionExpression([arg], b.blockStatement([]), false);
 
-    const ast = b.program([
-      b.expressionStatement(fn)
-    ]);
+    const ast = b.program([b.expressionStatement(fn)]);
 
     const printer = new Printer();
     const pretty = printer.printGenerically(ast).code;
@@ -1152,21 +1081,13 @@ describe("printer", function() {
   it("adds parenthesis around arrow functions with single arg and a return type", function() {
     const code = "(a): void => {};";
 
-    const arg = b.identifier('a');
+    const arg = b.identifier("a");
 
-    const fn = b.arrowFunctionExpression(
-      [arg],
-      b.blockStatement([]),
-      false
-    );
+    const fn = b.arrowFunctionExpression([arg], b.blockStatement([]), false);
 
-    fn.returnType = b.typeAnnotation(
-      b.voidTypeAnnotation()
-    );
+    fn.returnType = b.typeAnnotation(b.voidTypeAnnotation());
 
-    const ast = b.program([
-      b.expressionStatement(fn)
-    ]);
+    const ast = b.program([b.expressionStatement(fn)]);
 
     const printer = new Printer();
     const pretty = printer.printGenerically(ast).code;
@@ -1178,16 +1099,11 @@ describe("printer", function() {
 
     const fn = b.arrowFunctionExpression(
       [],
-      b.tsAsExpression(
-      b.objectExpression([]),
-        b.tsObjectKeyword()
-      ),
+      b.tsAsExpression(b.objectExpression([]), b.tsObjectKeyword()),
       false
     );
 
-    const ast = b.program([
-      b.expressionStatement(fn)
-    ]);
+    const ast = b.program([b.expressionStatement(fn)]);
 
     const printer = new Printer();
     const pretty = printer.printGenerically(ast).code;
@@ -1195,37 +1111,20 @@ describe("printer", function() {
   });
 
   it("prints class property initializers with type annotations correctly", function() {
-    const code = [
-      "class A {",
-      "  foo = (a: b): void => {};",
-      "}",
-    ].join(eol);
+    const code = ["class A {", "  foo = (a: b): void => {};", "}"].join(eol);
 
-    const arg = b.identifier('a');
+    const arg = b.identifier("a");
     arg.typeAnnotation = b.typeAnnotation(
-      b.genericTypeAnnotation(b.identifier('b'), null)
+      b.genericTypeAnnotation(b.identifier("b"), null)
     );
 
-    const fn = b.arrowFunctionExpression(
-      [arg],
-      b.blockStatement([]),
-      false
-    );
-    fn.returnType = b.typeAnnotation(
-      b.voidTypeAnnotation()
-    );
+    const fn = b.arrowFunctionExpression([arg], b.blockStatement([]), false);
+    fn.returnType = b.typeAnnotation(b.voidTypeAnnotation());
 
     const ast = b.program([
       b.classDeclaration(
-        b.identifier('A'),
-        b.classBody([
-          b.classProperty(
-            b.identifier('foo'),
-            fn,
-            null,
-            false
-          )
-        ])
+        b.identifier("A"),
+        b.classBody([b.classProperty(b.identifier("foo"), fn, null, false)])
       )
     ]);
 
@@ -1238,21 +1137,17 @@ describe("printer", function() {
   });
 
   it("prints ClassProperty correctly", function() {
-    const code = [
-      "class A {",
-      "  foo: Type = Bar;",
-      "}",
-    ].join(eol);
+    const code = ["class A {", "  foo: Type = Bar;", "}"].join(eol);
 
     const ast = b.program([
       b.classDeclaration(
-        b.identifier('A'),
+        b.identifier("A"),
         b.classBody([
           b.classProperty(
-            b.identifier('foo'),
-            b.identifier('Bar'),
+            b.identifier("foo"),
+            b.identifier("Bar"),
             b.typeAnnotation(
-              b.genericTypeAnnotation(b.identifier('Type'), null)
+              b.genericTypeAnnotation(b.identifier("Type"), null)
             )
           )
         ])
@@ -1268,22 +1163,13 @@ describe("printer", function() {
   });
 
   it("prints static ClassProperty correctly", function() {
-    const code = [
-      "class A {",
-      "  static foo = Bar;",
-      "}",
-    ].join(eol);
+    const code = ["class A {", "  static foo = Bar;", "}"].join(eol);
 
     const ast = b.program([
       b.classDeclaration(
-        b.identifier('A'),
+        b.identifier("A"),
         b.classBody([
-          b.classProperty(
-            b.identifier('foo'),
-            b.identifier('Bar'),
-            null,
-            true
-          )
+          b.classProperty(b.identifier("foo"), b.identifier("Bar"), null, true)
         ])
       )
     ]);
@@ -1297,15 +1183,13 @@ describe("printer", function() {
   });
 
   it("prints template expressions correctly", function() {
-    let code = [
-      "graphql`query`;",
-    ].join(eol);
+    let code = ["graphql`query`;"].join(eol);
 
     let ast = b.program([
       b.taggedTemplateStatement(
-        b.identifier('graphql'),
+        b.identifier("graphql"),
         b.templateLiteral(
-          [b.templateElement({cooked: 'query', raw: 'query'}, false)],
+          [b.templateElement({ cooked: "query", raw: "query" }, false)],
           []
         )
       )
@@ -1318,38 +1202,27 @@ describe("printer", function() {
     let pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
 
-    code = [
-      "graphql`query${foo.getQuery()}field${bar}`;",
-    ].join(eol);
+    code = ["graphql`query${foo.getQuery()}field${bar}`;"].join(eol);
 
     ast = b.program([
       b.taggedTemplateStatement(
-        b.identifier('graphql'),
+        b.identifier("graphql"),
         b.templateLiteral(
           [
-            b.templateElement(
-              {cooked: 'query', raw: 'query'},
-              false
-            ),
-            b.templateElement(
-              {cooked: 'field', raw: 'field'},
-              false
-            ),
-            b.templateElement(
-              {cooked: '', raw: ''},
-              true
-            ),
+            b.templateElement({ cooked: "query", raw: "query" }, false),
+            b.templateElement({ cooked: "field", raw: "field" }, false),
+            b.templateElement({ cooked: "", raw: "" }, true)
           ],
           [
             b.callExpression(
               b.memberExpression(
-                b.identifier('foo'),
-                b.identifier('getQuery'),
+                b.identifier("foo"),
+                b.identifier("getQuery"),
                 false
               ),
               []
             ),
-            b.identifier('bar')
+            b.identifier("bar")
           ]
         )
       )
@@ -1365,7 +1238,7 @@ describe("printer", function() {
       "    field,",
       "    ${bar},",
       "  }",
-      "`;",
+      "`;"
     ].join(eol);
 
     ast = parse(code);
@@ -1374,11 +1247,7 @@ describe("printer", function() {
   });
 
   it("preserves newlines at the beginning/end of files", function() {
-    const code = [
-      "",
-      "f();",
-      ""
-    ].join(eol);
+    const code = ["", "f();", ""].join(eol);
 
     const lines = fromString(code);
     const ast = parse(code, {
@@ -1402,19 +1271,14 @@ describe("printer", function() {
       tabWidth: 2
     });
 
-    assert.strictEqual(printer.print(ast).code, [
-      "",
-      "debugger;",
-      "f();",
-      ""
-    ].join(eol));
+    assert.strictEqual(
+      printer.print(ast).code,
+      ["", "debugger;", "f();", ""].join(eol)
+    );
   });
 
   it("respects options.lineTerminator", function() {
-    const lines = [
-      "var first = 1;",
-      "var second = 2;"
-    ];
+    const lines = ["var first = 1;", "var second = 2;"];
     const code = lines.join("\n");
     const ast = parse(code);
 
@@ -1439,7 +1303,7 @@ describe("printer", function() {
       "      field,",
       "    }",
       "  `",
-      "};",
+      "};"
     ].join(eol);
 
     const ast = parse(code);
@@ -1474,12 +1338,12 @@ describe("printer", function() {
     });
 
     recast.visit(ast, {
-      visitTaggedTemplateExpression: function (path) {
+      visitTaggedTemplateExpression: function(path) {
         function replaceIdWithNodeId(path: any) {
           path.replace(path.value.replace(/\bid\b/g, "nodeID"));
         }
 
-        path.get("quasi", "quasis").each(function (quasiPath: any) {
+        path.get("quasi", "quasis").each(function(quasiPath: any) {
           replaceIdWithNodeId(quasiPath.get("value", "cooked"));
           replaceIdWithNodeId(quasiPath.get("value", "raw"));
         });
@@ -1543,16 +1407,19 @@ describe("printer", function() {
     const ast2 = b.typeAlias(
       b.identifier("MyType"),
       null,
-      b.objectTypeAnnotation([], [
-        b.objectTypeIndexer(
-          b.identifier('key'),
-          b.stringTypeAnnotation(),
-          b.stringTypeAnnotation(),
-        )
-      ])
+      b.objectTypeAnnotation(
+        [],
+        [
+          b.objectTypeIndexer(
+            b.identifier("key"),
+            b.stringTypeAnnotation(),
+            b.stringTypeAnnotation()
+          )
+        ]
+      )
     );
 
-    const printer = new Printer({trailingComma: true});
+    const printer = new Printer({ trailingComma: true });
     const pretty1 = printer.printGenerically(ast1).code;
     const pretty2 = printer.printGenerically(ast2).code;
     assert.strictEqual(pretty1, code1);
@@ -1596,9 +1463,10 @@ describe("printer", function() {
       b.identifier("MyType"),
       null,
       b.nullableTypeAnnotation(
-        b.unionTypeAnnotation(
-          [b.stringTypeAnnotation(), b.numberTypeAnnotation()]
-        )
+        b.unionTypeAnnotation([
+          b.stringTypeAnnotation(),
+          b.numberTypeAnnotation()
+        ])
       )
     );
 
@@ -1607,82 +1475,101 @@ describe("printer", function() {
     assert.strictEqual(pretty, code);
   });
 
-  (nodeMajorVersion >= 6 ? it : xit)
-  ("uses the `arrayBracketSpacing` and the `objectCurlySpacing` option", function() {
-    const babelParser = require("@babel/parser");
-    const parseOptions = {
-      parser: {
-        parse: function (source: string) {
-          return babelParser.parse(source, {
-            sourceType: 'module',
-            plugins: ['flow'],
-          });
+  (nodeMajorVersion >= 6 ? it : xit)(
+    "uses the `arrayBracketSpacing` and the `objectCurlySpacing` option",
+    function() {
+      const babelParser = require("@babel/parser");
+      const parseOptions = {
+        parser: {
+          parse: function(source: string) {
+            return babelParser.parse(source, {
+              sourceType: "module",
+              plugins: ["flow"]
+            });
+          }
         }
-      }
-    };
+      };
 
-    const testCaseList = [{
-      printerConfig: {arrayBracketSpacing: false, objectCurlySpacing: false},
-      code: [
-        'import {java, script} from "javascript";',
-        '',
-        'function foo(a) {',
-        '    type MyType = {message: string};',
-        '    return [1, 2, 3];',
-        '}',
-        '',
-        'export {foo};'
-      ].join(eol)
-    }, {
-      printerConfig: {arrayBracketSpacing: true, objectCurlySpacing: false},
-      code: [
-        'import {java, script} from "javascript";',
-        '',
-        'function foo(a) {',
-        '    type MyType = {message: string};',
-        '    return [ 1, 2, 3 ];',
-        '}',
-        '',
-        'export {foo};'
-      ].join(eol)
-    }, {
-      printerConfig: {arrayBracketSpacing: false, objectCurlySpacing: true},
-      code: [
-        'import { java, script } from "javascript";',
-        '',
-        'function foo(a) {',
-        '    type MyType = { message: string };',
-        '    return [1, 2, 3];',
-        '}',
-        '',
-        'export { foo };'
-      ].join(eol)
-    }, {
-      printerConfig: {arrayBracketSpacing: true, objectCurlySpacing: true},
-      code: [
-        'import { java, script } from "javascript";',
-        '',
-        'function foo(a) {',
-        '    type MyType = { message: string };',
-        '    return [ 1, 2, 3 ];',
-        '}',
-        '',
-        'export { foo };'
-      ].join(eol)
-    }];
+      const testCaseList = [
+        {
+          printerConfig: {
+            arrayBracketSpacing: false,
+            objectCurlySpacing: false
+          },
+          code: [
+            'import {java, script} from "javascript";',
+            "",
+            "function foo(a) {",
+            "    type MyType = {message: string};",
+            "    return [1, 2, 3];",
+            "}",
+            "",
+            "export {foo};"
+          ].join(eol)
+        },
+        {
+          printerConfig: {
+            arrayBracketSpacing: true,
+            objectCurlySpacing: false
+          },
+          code: [
+            'import {java, script} from "javascript";',
+            "",
+            "function foo(a) {",
+            "    type MyType = {message: string};",
+            "    return [ 1, 2, 3 ];",
+            "}",
+            "",
+            "export {foo};"
+          ].join(eol)
+        },
+        {
+          printerConfig: {
+            arrayBracketSpacing: false,
+            objectCurlySpacing: true
+          },
+          code: [
+            'import { java, script } from "javascript";',
+            "",
+            "function foo(a) {",
+            "    type MyType = { message: string };",
+            "    return [1, 2, 3];",
+            "}",
+            "",
+            "export { foo };"
+          ].join(eol)
+        },
+        {
+          printerConfig: {
+            arrayBracketSpacing: true,
+            objectCurlySpacing: true
+          },
+          code: [
+            'import { java, script } from "javascript";',
+            "",
+            "function foo(a) {",
+            "    type MyType = { message: string };",
+            "    return [ 1, 2, 3 ];",
+            "}",
+            "",
+            "export { foo };"
+          ].join(eol)
+        }
+      ];
 
-    testCaseList.forEach(function(testCase) {
-      const code = testCase.code;
-      const printer = new Printer(testCase.printerConfig);
+      testCaseList.forEach(function(testCase) {
+        const code = testCase.code;
+        const printer = new Printer(testCase.printerConfig);
 
-      const ast = parse(code, parseOptions);
-      const pretty = printer.printGenerically(ast).code;
+        const ast = parse(code, parseOptions);
+        const pretty = printer.printGenerically(ast).code;
 
-      assert.strictEqual(pretty, code);
-    });
-  });
+        assert.strictEqual(pretty, code);
+      });
+    }
+  );
 
-  it("prints no extra semicolons in for-loop heads (#377)", function () {
+  it("prints no extra semicolons in for-loop heads (#377)", function() {
     function check(head: any, parser: any) {
       const source = "for (" + head + ") console.log(i);";
       const ast = recast.parse(source, { parser: parser });
@@ -1698,10 +1585,7 @@ describe("printer", function() {
       const closeParenIndex = reprinted.indexOf(")", openParenIndex);
       assert.notStrictEqual(closeParenIndex, -1);
 
-      const newHead = reprinted.slice(
-        openParenIndex + 1,
-        closeParenIndex
-      );
+      const newHead = reprinted.slice(openParenIndex + 1, closeParenIndex);
 
       assert.strictEqual(newHead.split(";").length, 3);
     }
@@ -1727,58 +1611,43 @@ describe("printer", function() {
     }
   });
 
-  it("parenthesizes NumericLiteral MemberExpression objects", function () {
-    const nonBabelNode = b.memberExpression(
-      b.literal(1),
-      b.identifier('foo')
-    );
+  it("parenthesizes NumericLiteral MemberExpression objects", function() {
+    const nonBabelNode = b.memberExpression(b.literal(1), b.identifier("foo"));
 
     const babelNode = b.memberExpression(
       b.numericLiteral(1),
-      b.identifier('foo')
+      b.identifier("foo")
     );
 
-    assert.strictEqual(
-      recast.print(nonBabelNode).code,
-      "(1).foo"
-    );
+    assert.strictEqual(recast.print(nonBabelNode).code, "(1).foo");
 
-    assert.strictEqual(
-      recast.print(babelNode).code,
-      "(1).foo"
-    );
+    assert.strictEqual(recast.print(babelNode).code, "(1).foo");
   });
 
-  it("obeys 'optional' property of OptionalMemberExpression", function () {
+  it("obeys 'optional' property of OptionalMemberExpression", function() {
     const node = b.optionalMemberExpression(
-      b.identifier('foo'),
-      b.identifier('bar')
+      b.identifier("foo"),
+      b.identifier("bar")
     );
 
-    assert.strictEqual(
-      recast.print(node).code,
-      "foo?.bar"
-    );
+    assert.strictEqual(recast.print(node).code, "foo?.bar");
 
     const nonOptionalNode = b.optionalMemberExpression(
-      b.identifier('foo'),
-      b.identifier('bar'),
+      b.identifier("foo"),
+      b.identifier("bar"),
       false,
       false
     );
 
-    assert.strictEqual(
-      recast.print(nonOptionalNode).code,
-      "foo.bar"
-    );
+    assert.strictEqual(recast.print(nonOptionalNode).code, "foo.bar");
   });
 
   it("prints numbers in bases other than 10 without converting them", function() {
     const code = [
-      'let decimal = 6;',
-      'let hex = 0xf00d;',
-      'let binary = 0b1010;',
-      'let octal = 0o744;'
+      "let decimal = 6;",
+      "let hex = 0xf00d;",
+      "let binary = 0b1010;",
+      "let octal = 0o744;"
     ].join(eol);
     const ast = parse(code);
     const printer = new Printer({});
@@ -1787,8 +1656,8 @@ describe("printer", function() {
     assert.strictEqual(pretty, code);
   });
 
-  it("reprints modified numeric literals", function () {
-    const code = '3 + 4;';
+  it("reprints modified numeric literals", function() {
+    const code = "3 + 4;";
     const ast = parse(code);
     const expr = ast.program.body[0].expression;
     const left = expr.left;
@@ -1797,34 +1666,34 @@ describe("printer", function() {
     left.value++;
     right.value++;
 
-    assert.strictEqual(recast.print(ast).code, '4 + 5;');
+    assert.strictEqual(recast.print(ast).code, "4 + 5;");
   });
 
-  it("prints flow tuple type annotations correctly, respecting array options", function () {
+  it("prints flow tuple type annotations correctly, respecting array options", function() {
     const code = [
-      'type MyTupleType = [',
+      "type MyTupleType = [",
       '  "tuple element 1",',
       '  "tuple element 2",',
       '  "tuple element 3",',
-      '];',
+      "];"
     ].join(eol);
 
     const ast = b.program([
       b.typeAlias(
-        b.identifier('MyTupleType'),
+        b.identifier("MyTupleType"),
         null,
         b.tupleTypeAnnotation([
-          b.stringLiteralTypeAnnotation('tuple element 1', 'tuple element 1'),
-          b.stringLiteralTypeAnnotation('tuple element 2', 'tuple element 2'),
-          b.stringLiteralTypeAnnotation('tuple element 3', 'tuple element 3'),
+          b.stringLiteralTypeAnnotation("tuple element 1", "tuple element 1"),
+          b.stringLiteralTypeAnnotation("tuple element 2", "tuple element 2"),
+          b.stringLiteralTypeAnnotation("tuple element 3", "tuple element 3")
         ])
-      ),
+      )
     ]);
 
     const printer = new Printer({
       tabWidth: 2,
       wrapColumn: 40,
-      trailingComma: true,
+      trailingComma: true
     });
 
     const pretty = printer.printGenerically(ast).code;
@@ -1835,14 +1704,12 @@ describe("printer", function() {
     const code = "({}).x = 1;";
 
     const assignment = b.assignmentExpression(
-      '=',
-      b.memberExpression(b.objectExpression([]), b.identifier('x'), false),
+      "=",
+      b.memberExpression(b.objectExpression([]), b.identifier("x"), false),
       b.literal(1)
     );
 
-    const ast = b.program([
-      b.expressionStatement(assignment)
-    ]);
+    const ast = b.program([b.expressionStatement(assignment)]);
 
     const printer = new Printer({
       arrowParensAlways: true
@@ -1852,14 +1719,12 @@ describe("printer", function() {
   });
 
   it("adds parenthesis around conditional", function() {
-    const code = 'new (typeof a ? b : c)();';
+    const code = "new (typeof a ? b : c)();";
     const callee = recast.parse("typeof a ? b : c").program.body[0].expression;
 
     const newExpression = b.newExpression(callee, []);
 
-    const ast = b.program([
-      b.expressionStatement(newExpression)
-    ]);
+    const ast = b.program([b.expressionStatement(newExpression)]);
 
     const printer = new Printer({
       arrowParensAlways: true
@@ -1870,25 +1735,29 @@ describe("printer", function() {
 
   it("prints flow object type internal slots correctly", function() {
     const code = [
-      'type MyObjectType = {',
-      '  [myIndexer: string]: any,',
-      '  (myParameter: any): any,',
-      '  (myOptionalParameter?: any): any,',
-      '  (myParameterWithRest: any, ...rest: any[]): any,',
-      '  [[myInternalSlot]]: any,',
-      '  static [[myStaticOptionalInternalSlot]]?: (arg: any) => any,',
-      '  static [[myStaticMethodOptionalInternalSlot]]?(arg: any): any,',
-      '  myProperty: any,',
-      '};',
+      "type MyObjectType = {",
+      "  [myIndexer: string]: any,",
+      "  (myParameter: any): any,",
+      "  (myOptionalParameter?: any): any,",
+      "  (myParameterWithRest: any, ...rest: any[]): any,",
+      "  [[myInternalSlot]]: any,",
+      "  static [[myStaticOptionalInternalSlot]]?: (arg: any) => any,",
+      "  static [[myStaticMethodOptionalInternalSlot]]?(arg: any): any,",
+      "  myProperty: any,",
+      "};"
     ].join(eol);
 
     const ast = b.program([
       b.typeAlias(
-        b.identifier('MyObjectType'),
+        b.identifier("MyObjectType"),
         null,
         b.objectTypeAnnotation.from({
           properties: [
-            b.objectTypeProperty(b.identifier("myProperty"), b.anyTypeAnnotation(), false)
+            b.objectTypeProperty(
+              b.identifier("myProperty"),
+              b.anyTypeAnnotation(),
+              false
+            )
           ],
           indexers: [
             b.objectTypeIndexer(
@@ -1904,7 +1773,7 @@ describe("printer", function() {
                   b.functionTypeParam(
                     b.identifier("myParameter"),
                     b.anyTypeAnnotation(),
-                    false,
+                    false
                   )
                 ],
                 b.anyTypeAnnotation(),
@@ -1918,7 +1787,7 @@ describe("printer", function() {
                   b.functionTypeParam(
                     b.identifier("myOptionalParameter"),
                     b.anyTypeAnnotation(),
-                    true,
+                    true
                   )
                 ],
                 b.anyTypeAnnotation(),
@@ -1932,7 +1801,7 @@ describe("printer", function() {
                   b.functionTypeParam(
                     b.identifier("myParameterWithRest"),
                     b.anyTypeAnnotation(),
-                    false,
+                    false
                   )
                 ],
                 b.anyTypeAnnotation(),
@@ -1951,35 +1820,53 @@ describe("printer", function() {
               value: b.anyTypeAnnotation(),
               static: false,
               method: false,
-              optional: false,
+              optional: false
             }),
             b.objectTypeInternalSlot.from({
               id: b.identifier("myStaticOptionalInternalSlot"),
-              value: b.functionTypeAnnotation([
-                b.functionTypeParam(b.identifier("arg"), b.anyTypeAnnotation(), false)
-              ], b.anyTypeAnnotation(), null, null),
+              value: b.functionTypeAnnotation(
+                [
+                  b.functionTypeParam(
+                    b.identifier("arg"),
+                    b.anyTypeAnnotation(),
+                    false
+                  )
+                ],
+                b.anyTypeAnnotation(),
+                null,
+                null
+              ),
               static: true,
               method: false,
-              optional: true,
+              optional: true
             }),
             b.objectTypeInternalSlot.from({
               id: b.identifier("myStaticMethodOptionalInternalSlot"),
-              value: b.functionTypeAnnotation([
-                b.functionTypeParam(b.identifier("arg"), b.anyTypeAnnotation(), false)
-              ], b.anyTypeAnnotation(), null, null),
+              value: b.functionTypeAnnotation(
+                [
+                  b.functionTypeParam(
+                    b.identifier("arg"),
+                    b.anyTypeAnnotation(),
+                    false
+                  )
+                ],
+                b.anyTypeAnnotation(),
+                null,
+                null
+              ),
               static: true,
               method: true,
-              optional: true,
-            }),
-          ],
+              optional: true
+            })
+          ]
         })
-      ),
+      )
     ]);
 
     const printer = new Printer({
       tabWidth: 2,
       wrapColumn: 40,
-      trailingComma: true,
+      trailingComma: true
     });
 
     const pretty = printer.printGenerically(ast).code;
@@ -1988,11 +1875,11 @@ describe("printer", function() {
 
   it("prints class private methods and properties correctly", function() {
     const code = [
-      'class MyClassWithPrivate {',
-      '  #myPrivateProperty: any;',
-      '  #myPrivatePropertyWithValue: any = value;',
-      '  #myPrivateMethod() {}',
-      '}',
+      "class MyClassWithPrivate {",
+      "  #myPrivateProperty: any;",
+      "  #myPrivatePropertyWithValue: any = value;",
+      "  #myPrivateMethod() {}",
+      "}"
     ].join(eol);
 
     const ast = b.program([
@@ -2002,26 +1889,26 @@ describe("printer", function() {
           b.classPrivateProperty.from({
             key: b.privateName(b.identifier("myPrivateProperty")),
             typeAnnotation: b.typeAnnotation(b.anyTypeAnnotation()),
-            value: null,
+            value: null
           }),
           b.classPrivateProperty.from({
             key: b.privateName(b.identifier("myPrivatePropertyWithValue")),
             typeAnnotation: b.typeAnnotation(b.anyTypeAnnotation()),
-            value: b.identifier("value"),
+            value: b.identifier("value")
           }),
           b.classPrivateMethod(
             b.privateName(b.identifier("myPrivateMethod")),
             [],
-            b.blockStatement([]),
-          ),
+            b.blockStatement([])
+          )
         ])
-      ),
+      )
     ]);
 
     const printer = new Printer({
       tabWidth: 2,
       wrapColumn: 40,
-      trailingComma: true,
+      trailingComma: true
     });
 
     const pretty = printer.printGenerically(ast).code;
@@ -2029,10 +1916,9 @@ describe("printer", function() {
   });
 
   it("prints an interpreter directive correctly", function() {
-    const code = [
-      '#!/usr/bin/env node',
-      'console.log("Hello, world!");'
-    ].join(eol);
+    const code = ["#!/usr/bin/env node", 'console.log("Hello, world!");'].join(
+      eol
+    );
 
     const ast = b.program.from({
       interpreter: b.interpreterDirective("/usr/bin/env node"),
@@ -2043,7 +1929,7 @@ describe("printer", function() {
             [b.stringLiteral("Hello, world!")]
           )
         )
-      ],
+      ]
     });
 
     const pretty = new Printer().printGenerically(ast).code;
@@ -2052,7 +1938,7 @@ describe("printer", function() {
 
   it("prints an interface type annotation correctly", function() {
     const code = [
-      'let myVar: interface extends MyOtherInterface { myProperty: any };',
+      "let myVar: interface extends MyOtherInterface { myProperty: any };"
     ].join(eol);
 
     const ast = b.program([
@@ -2066,13 +1952,13 @@ describe("printer", function() {
                   b.objectTypeProperty(
                     b.identifier("myProperty"),
                     b.anyTypeAnnotation(),
-                    false,
+                    false
                   )
                 ]),
-                [b.interfaceExtends(b.identifier("MyOtherInterface"))],
+                [b.interfaceExtends(b.identifier("MyOtherInterface"))]
               )
             )
-          }),
+          })
         )
       ])
     ]);
@@ -2083,48 +1969,54 @@ describe("printer", function() {
 
   it("object destructuring for function parameters", function() {
     const code = [
-      'function myFunction(',
-      '    {',
+      "function myFunction(",
+      "    {",
       '        yes = "y",',
       '        no: no = "n",',
-      '        short,',
-      '        long: longHand',
-      '    }',
-      ') {}',
+      "        short,",
+      "        long: longHand",
+      "    }",
+      ") {}"
     ].join(eol);
 
     const simplifiedDefaultArgProperty = b.property(
-      'init',
-      b.identifier('yes'),
-      b.assignmentPattern(b.identifier('yes'), b.literal('y')),
+      "init",
+      b.identifier("yes"),
+      b.assignmentPattern(b.identifier("yes"), b.literal("y"))
     );
     simplifiedDefaultArgProperty.shorthand = true;
 
     const notSimplifiedDefaultArgProperty = b.property(
-      'init',
-      b.identifier('no'),
-      b.assignmentPattern(b.identifier('no'), b.literal('n')),
+      "init",
+      b.identifier("no"),
+      b.assignmentPattern(b.identifier("no"), b.literal("n"))
     );
 
     const simplifiedProperty = b.property(
-      'init',
-      b.identifier('short'),
-      b.identifier('short'),
+      "init",
+      b.identifier("short"),
+      b.identifier("short")
     );
     simplifiedProperty.shorthand = true;
 
-    const notSimplifiedProperty = b.property('init', b.identifier('long'), b.identifier('longHand'));
+    const notSimplifiedProperty = b.property(
+      "init",
+      b.identifier("long"),
+      b.identifier("longHand")
+    );
 
     const ast = b.program([
       b.functionDeclaration(
-        b.identifier('myFunction'),
-        [b.objectPattern([
-          simplifiedDefaultArgProperty,
-          notSimplifiedDefaultArgProperty,
-          simplifiedProperty,
-          notSimplifiedProperty
-        ])],
-        b.blockStatement([]),
+        b.identifier("myFunction"),
+        [
+          b.objectPattern([
+            simplifiedDefaultArgProperty,
+            notSimplifiedDefaultArgProperty,
+            simplifiedProperty,
+            notSimplifiedProperty
+          ])
+        ],
+        b.blockStatement([])
       )
     ]);
 

--- a/test/syntax.ts
+++ b/test/syntax.ts
@@ -7,8 +7,7 @@ const hasOwn = Object.prototype.hasOwnProperty;
 
 // Babel 7 no longer supports Node 4 or 5.
 const nodeMajorVersion = parseInt(process.versions.node, 10);
-(nodeMajorVersion >= 6 ? describe : xdescribe)
-("syntax", function() {
+(nodeMajorVersion >= 6 ? describe : xdescribe)("syntax", function() {
   // Make sure we handle all possible node types in Syntax, and no additional
   // types that are not present in Syntax.
   it("Completeness", function(done) {
@@ -24,14 +23,18 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
       types.visit(ast, {
         visitFunctionDeclaration(path) {
           const decl = path.node;
-          if (types.namedTypes.Identifier.check(decl.id) &&
-              decl.id.name === "genericPrintNoParens") {
+          if (
+            types.namedTypes.Identifier.check(decl.id) &&
+            decl.id.name === "genericPrintNoParens"
+          ) {
             this.traverse(path, {
               visitSwitchCase(path) {
                 const test = path.node.test;
-                if (test &&
-                    test.type === "StringLiteral" &&
-                    typeof test.value === "string") {
+                if (
+                  test &&
+                  test.type === "StringLiteral" &&
+                  typeof test.value === "string"
+                ) {
                   const name = test.value;
                   typeNames[name] = name;
                 }

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -3,14 +3,13 @@ import path from "path";
 import fs from "fs";
 import * as recast from "../main";
 import * as types from "ast-types";
-import {EOL as eol} from "os";
+import { EOL as eol } from "os";
 import * as parser from "../parsers/typescript";
 
 // Babel 7 no longer supports Node 4 or 5.
 const nodeMajorVersion = parseInt(process.versions.node, 10);
-(nodeMajorVersion >= 6 ? describe : xdescribe)
-("TypeScript", function() {
-  it('basic printing', function() {
+(nodeMajorVersion >= 6 ? describe : xdescribe)("TypeScript", function() {
+  it("basic printing", function() {
     function check(lines: any) {
       const code = lines.join(eol);
       const ast = recast.parse(code, { parser });
@@ -20,304 +19,256 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
 
     check([
       'let color: string = "blue";',
-      'let isDone: boolean = false;',
-      'let decimal: number = 6;',
-      'let hex: number = 0xf00d;',
-      'let binary: number = 0b1010;',
-      'let octal: number = 0o744;',
-      'let list: number[] = [1, 2, 3];',
-      'let matrix: number[][];',
-      'let x: [string, number];',
-      'let f: <E>(e: E) => void;',
+      "let isDone: boolean = false;",
+      "let decimal: number = 6;",
+      "let hex: number = 0xf00d;",
+      "let binary: number = 0b1010;",
+      "let octal: number = 0o744;",
+      "let list: number[] = [1, 2, 3];",
+      "let matrix: number[][];",
+      "let x: [string, number];",
+      "let f: <E>(e: E) => void;",
       'let sn: string | null = "isNull";'
     ]);
 
     check([
-      'type A = number;',
-      'type B = string;',
-      'type C = never;',
-      'type D = any;',
-      'type E = [string, number];',
-      'type F = void;',
-      'type G = undefined;',
-      'type H = bigint;',
-      '',
-      'type I = {',
-      '  a: string,',
-      '  b?: number',
-      '};'
+      "type A = number;",
+      "type B = string;",
+      "type C = never;",
+      "type D = any;",
+      "type E = [string, number];",
+      "type F = void;",
+      "type G = undefined;",
+      "type H = bigint;",
+      "",
+      "type I = {",
+      "  a: string,",
+      "  b?: number",
+      "};"
     ]);
 
-    check([
-      'type c = T & U & V;'
-    ]);
+    check(["type c = T & U & V;"]);
+
+    check(["let list: Array<number> = [1, 2, 3];"]);
+
+    check(["let n = a!.c();"]);
+
+    check(['type A = "cat" | "dog" | "bird";']);
 
     check([
-      'let list: Array<number> = [1, 2, 3];'
-    ]);
-
-    check([
-      'let n = a!.c();'
-    ]);
-
-    check([
-      'type A = "cat" | "dog" | "bird";'
-    ]);
-
-    check([
-      'type A<T, U> = {',
+      "type A<T, U> = {",
       '  u: "cat",',
-      '  x: number,',
-      '  y: T,',
-      '  z: U',
-      '};'
+      "  x: number,",
+      "  y: T,",
+      "  z: U",
+      "};"
     ]);
 
     check([
-      'type F = <T, U>(',
-      '  a: string,',
-      '  b: {',
-      '    y: T,',
-      '    z: U',
-      '  }',
-      ') => void;'
+      "type F = <T, U>(",
+      "  a: string,",
+      "  b: {",
+      "    y: T,",
+      "    z: U",
+      "  }",
+      ") => void;"
     ]);
 
     check([
-      'type Readonly<T> = {',
-      '  readonly [P in keyof T]: T[P];',
-      '};',
-      '',
-      'type Pick<T, K extends keyof T> = {',
-      '  [P in K]: T[P];',
-      '};'
+      "type Readonly<T> = {",
+      "  readonly [P in keyof T]: T[P];",
+      "};",
+      "",
+      "type Pick<T, K extends keyof T> = {",
+      "  [P in K]: T[P];",
+      "};"
     ]);
 
     check([
-      'let strLength1: string = (<string> someValue).length;',
-      'let strLength2: string = <string> someValue;',
-      'let square = <Square> {};',
-      'let strLength3: number = (someValue as string).length;',
-      'let strLength4: number = someValue as string;'
+      "let strLength1: string = (<string> someValue).length;",
+      "let strLength2: string = <string> someValue;",
+      "let square = <Square> {};",
+      "let strLength3: number = (someValue as string).length;",
+      "let strLength4: number = someValue as string;"
+    ]);
+
+    check(["let counter = <Counter> function(start: number) {};"]);
+
+    check(["if ((<F> p).s) {", "  (<F> p).s();", "}"]);
+
+    check([
+      "function i(p): p is F {}",
+      "function i(p): p is string | number {}"
+    ]);
+
+    check(["function f<T, U>(a: T, b: U): void {", "  let c: number;", "}"]);
+
+    check([
+      "function pluck<T, K extends keyof T>(o: T, names: K[]): T[K][] {",
+      "  console.log(o);",
+      "}"
     ]);
 
     check([
-      'let counter = <Counter> function(start: number) {};'
+      "let myAdd: <T, U>(x: T, y?: number) => U = function(x: number, y?: number): number {};",
+      "function bb(f: string, ...r: string[]): void {}",
+      "function f(this: void) {}",
+      "function l<T extends L>(arg: T): T {}",
+      "function l<T extends A.B.C>(arg: T): T {}",
+      "function l<T extends keyof U>(obj: T) {}",
+      "",
+      "function create<T>(",
+      "  c: {",
+      "    new<U>(a: U): T",
+      "  }",
+      "): void {}"
     ]);
 
-    check([
-      'if ((<F> p).s) {',
-      '  (<F> p).s();',
-      '}'
-    ]);
+    check(["const a = b as U as V;"]);
 
     check([
-      'function i(p): p is F {}',
-      'function i(p): p is string | number {}'
-    ]);
-
-    check([
-      'function f<T, U>(a: T, b: U): void {',
-      '  let c: number;',
-      '}'
-    ]);
-
-    check([
-      'function pluck<T, K extends keyof T>(o: T, names: K[]): T[K][] {',
-      '  console.log(o);',
-      '}'
-    ]);
-
-    check([
-      'let myAdd: <T, U>(x: T, y?: number) => U = function(x: number, y?: number): number {};',
-      'function bb(f: string, ...r: string[]): void {}',
-      'function f(this: void) {}',
-      'function l<T extends L>(arg: T): T {}',
-      'function l<T extends A.B.C>(arg: T): T {}',
-      'function l<T extends keyof U>(obj: T) {}',
-      '',
-      'function create<T>(',
-      '  c: {',
-      '    new<U>(a: U): T',
-      '  }',
-      '): void {}'
-    ]);
-
-    check([
-      'const a = b as U as V;'
-    ]);
-
-    check([
-      'enum Color {',
-      '  Red,',
-      '  Green,',
-      '  Blue',
-      '}',
-      '',
-      'enum Color {',
-      '  Red = 1,',
-      '  Green = 2,',
-      '  Blue = 3',
-      '}',
-      '',
-      'enum Color {',
-      '  Red = 1,',
-      '  Green',
-      '}',
-      '',
-      'enum Color {',
+      "enum Color {",
+      "  Red,",
+      "  Green,",
+      "  Blue",
+      "}",
+      "",
+      "enum Color {",
+      "  Red = 1,",
+      "  Green = 2,",
+      "  Blue = 3",
+      "}",
+      "",
+      "enum Color {",
+      "  Red = 1,",
+      "  Green",
+      "}",
+      "",
+      "enum Color {",
       '  Red = "RED",',
       '  Green = "GREEN",',
       '  Blue = "BLUE"',
-      '}',
-      '',
-      'enum Color {',
-      '  Red = init(),',
+      "}",
+      "",
+      "enum Color {",
+      "  Red = init(),",
       '  Green = "GREEN"',
-      '}',
-      '',
-      'enum E {',
-      '  A = 1,',
-      '  B,',
-      '  C',
-      '}',
-      '',
-      'enum F {',
-      '  A = 1 << 1,',
-      '  B = C | D.G,',
+      "}",
+      "",
+      "enum E {",
+      "  A = 1,",
+      "  B,",
+      "  C",
+      "}",
+      "",
+      "enum F {",
+      "  A = 1 << 1,",
+      "  B = C | D.G,",
       '  E = "1".length',
-      '}',
-      '',
-      'const enum G {',
-      '  A = 1',
-      '}',
-      '',
-      'declare enum H {',
-      '  A = 1',
-      '}'
+      "}",
+      "",
+      "const enum G {",
+      "  A = 1",
+      "}",
+      "",
+      "declare enum H {",
+      "  A = 1",
+      "}"
     ]);
 
     check([
-      'class C<T> extends B {',
-      '  f(a: T) {',
-      '    c(a as D);',
-      '  }',
-      '}'
+      "class C<T> extends B {",
+      "  f(a: T) {",
+      "    c(a as D);",
+      "  }",
+      "}"
     ]);
 
     check([
-      'interface LabelledContainer<T> {',
-      '  label: string;',
-      '  content: T;',
-      '  option?: boolean;',
-      '  readonly x: number;',
-      '  [index: number]: string;',
-      '  [propName: string]: any;',
-      '  readonly [index: number]: string;',
-      '  (source: string, subString: string): boolean;',
-      '  (start: number): string;',
-      '  reset(): void;',
-      '  a(c: (this: void, e: E) => void): void;',
-      '}'
+      "interface LabelledContainer<T> {",
+      "  label: string;",
+      "  content: T;",
+      "  option?: boolean;",
+      "  readonly x: number;",
+      "  [index: number]: string;",
+      "  [propName: string]: any;",
+      "  readonly [index: number]: string;",
+      "  (source: string, subString: string): boolean;",
+      "  (start: number): string;",
+      "  reset(): void;",
+      "  a(c: (this: void, e: E) => void): void;",
+      "}"
     ]);
 
     check([
-      'interface Square<T, U> extends Shape<T, U>, Visible<T, U> {',
-      '  sideLength: number;',
-      '}'
+      "interface Square<T, U> extends Shape<T, U>, Visible<T, U> {",
+      "  sideLength: number;",
+      "}"
     ]);
 
     check([
-      'class Button extends Control<T, U> implements SelectableControl<T, U>, ClickableControl<U> {',
-      '  select() {}',
-      '}'
+      "class Button extends Control<T, U> implements SelectableControl<T, U>, ClickableControl<U> {",
+      "  select() {}",
+      "}"
     ]);
 
     check([
-      'class Animal {',
+      "class Animal {",
       '  static className: string = "Animal";',
-      '',
-      '  constructor(theName: string) {',
-      '    this.name = theName;',
-      '  }',
-      '',
-      '  private name: string;',
-      '  public fur: boolean;',
-      '  protected sound: string;',
-      '  private getName() {}',
-      '  public talk() {}',
-      '  protected getSound() {}',
-      '  static createAnimal() {}',
-      '}'
+      "",
+      "  constructor(theName: string) {",
+      "    this.name = theName;",
+      "  }",
+      "",
+      "  private name: string;",
+      "  public fur: boolean;",
+      "  protected sound: string;",
+      "  private getName() {}",
+      "  public talk() {}",
+      "  protected getSound() {}",
+      "  static createAnimal() {}",
+      "}"
     ]);
 
-    check([
-      'export interface S {',
-      '  i(s: string): boolean;',
-      '}',
-    ]);
+    check(["export interface S {", "  i(s: string): boolean;", "}"]);
 
     check([
-      'namespace Validation {',
-      '  export interface S {',
-      '    i(j: string): boolean;',
-      '  }',
-      '}'
+      "namespace Validation {",
+      "  export interface S {",
+      "    i(j: string): boolean;",
+      "  }",
+      "}"
     ]);
 
-    check([
-      'export interface S {',
-      '  i(j: string): boolean;',
-      '}'
-    ]);
+    check(["export interface S {", "  i(j: string): boolean;", "}"]);
+
+    check(["declare namespace D3 {", "  export const f: number = 2;", "}"]);
+
+    check(["declare function foo<K, V>(arg: T = getDefault()): R"]);
 
     check([
-      'declare namespace D3 {',
-      '  export const f: number = 2;',
-      '}'
+      "class Animal {",
+      "  public static async *[name]<T>(arg: U): V;",
+      "}"
     ]);
 
-    check([
-      'declare function foo<K, V>(arg: T = getDefault()): R'
-    ]);
-
-    check([
-      'class Animal {',
-      '  public static async *[name]<T>(arg: U): V;',
-      '}'
-    ]);
-
-    check([
-      'function myFunction(',
-      '  {',
-      '    param1',
-      '  }: Params',
-      ') {}'
-    ]);
+    check(["function myFunction(", "  {", "    param1", "  }: Params", ") {}"]);
 
     check([
       'const unqualified: import("package") = 1;',
       'const qualified: import("package").ns = 2;',
       'const veryQualified: import("package").ns.foo.bar = 3;',
       'const qualifiedWithParams: import("package").ns.foo<T, U> = 4;',
-      'const justParameterized: import("package")<T> = 5;',
+      'const justParameterized: import("package")<T> = 5;'
     ]);
 
-    check([
-      'const a = function<T>(a: T): void {};'
-    ]);
+    check(["const a = function<T>(a: T): void {};"]);
 
-    check([
-      'new A<number>();',
-    ]);
+    check(["new A<number>();"]);
 
-    check([
-      'createPlugin<number>();',
-    ]);
+    check(["createPlugin<number>();"]);
 
-    check([
-      'type Class<T> = new (...args: any) => T;',
-    ]);
+    check(["type Class<T> = new (...args: any) => T;"]);
   });
 });
 
@@ -337,34 +288,42 @@ function testReprinting(pattern: any, description: any) {
     return;
   }
 
-  describe(description, function () {
-    require("glob").sync(pattern, {
-      cwd: __dirname
-    }).filter((file: string) => !(
-      // Skip the following files, because they have problems that are not due
-      // to any problems in Recast. TODO Revisit this list periodically.
-      (file.indexOf("/tsx/") >= 0 ||
-      file.endsWith("stitching/errors.ts") ||
-      file.endsWith("decorators/type-arguments-invalid/input.js") ||
-      // Throws an error with a slightly different message than expected:
-      file.endsWith("types/tuple-rest-invalid/input.js") || // @babel/parser can't handle naked arrow function expression statements:
-      file.endsWith("/optional-parameter/input.js"))
-    )).forEach((file: string) => it(file, function () {
-      const absPath = path.join(__dirname, file);
-      const source = fs.readFileSync(absPath, "utf8");
-      const ast = tryToParseFile(source, absPath);
+  describe(description, function() {
+    require("glob")
+      .sync(pattern, {
+        cwd: __dirname
+      })
+      .filter(
+        (file: string) =>
+          !// Skip the following files, because they have problems that are not due
+          // to any problems in Recast. TODO Revisit this list periodically.
+          (
+            file.indexOf("/tsx/") >= 0 ||
+            file.endsWith("stitching/errors.ts") ||
+            file.endsWith("decorators/type-arguments-invalid/input.js") ||
+            // Throws an error with a slightly different message than expected:
+            file.endsWith("types/tuple-rest-invalid/input.js") || // @babel/parser can't handle naked arrow function expression statements:
+            file.endsWith("/optional-parameter/input.js")
+          )
+      )
+      .forEach((file: string) =>
+        it(file, function() {
+          const absPath = path.join(__dirname, file);
+          const source = fs.readFileSync(absPath, "utf8");
+          const ast = tryToParseFile(source, absPath);
 
-      if (ast === null) {
-        return;
-      }
+          if (ast === null) {
+            return;
+          }
 
-      this.timeout(20000);
+          this.timeout(20000);
 
-      assert.strictEqual(recast.print(ast).code, source);
-      const reprintedCode = recast.prettyPrint(ast).code;
-      const reparsedAST = recast.parse(reprintedCode, { parser });
-      types.astNodesAreEquivalent(ast, reparsedAST);
-    }));
+          assert.strictEqual(recast.print(ast).code, source);
+          const reprintedCode = recast.prettyPrint(ast).code;
+          const reparsedAST = recast.parse(reprintedCode, { parser });
+          types.astNodesAreEquivalent(ast, reparsedAST);
+        })
+      );
   });
 }
 
@@ -373,8 +332,11 @@ function tryToParseFile(source: any, absPath: any) {
     return recast.parse(source, { parser });
   } catch (e1) {
     try {
-      var options = JSON.parse(fs.readFileSync(
-        path.join(path.dirname(absPath), "options.json")).toString());
+      var options = JSON.parse(
+        fs
+          .readFileSync(path.join(path.dirname(absPath), "options.json"))
+          .toString()
+      );
     } catch (e2) {
       if (e2.code !== "ENOENT") {
         console.error(e2);

--- a/test/visit.ts
+++ b/test/visit.ts
@@ -7,134 +7,135 @@ import { Printer } from "../lib/printer";
 import { EOL as eol } from "os";
 
 const lines = [
-    "// file comment",
-    "exports.foo({",
-    "    // some comment",
-    "    bar: 42,",
-    "    baz: this",
-    "});"
+  "// file comment",
+  "exports.foo({",
+  "    // some comment",
+  "    bar: 42,",
+  "    baz: this",
+  "});"
 ];
 
 describe("types.visit", function() {
-    it("replacement", function() {
-        const source = lines.join(eol);
-        const printer = new Printer;
-        const ast = parse(source);
-        const withThis = printer.print(ast).code;
-        const thisExp = /\bthis\b/g;
+  it("replacement", function() {
+    const source = lines.join(eol);
+    const printer = new Printer();
+    const ast = parse(source);
+    const withThis = printer.print(ast).code;
+    const thisExp = /\bthis\b/g;
 
-        assert.ok(thisExp.test(withThis));
+    assert.ok(thisExp.test(withThis));
 
-        types.visit(ast, {
-            visitThisExpression: function() {
-                return builders.identifier("self");
-            }
-        });
-
-        assert.strictEqual(
-            printer.print(ast).code,
-            withThis.replace(thisExp, "self")
-        );
-
-        const propNames: any[] = [];
-        const methods: types.Visitor = {
-            visitProperty: function(path) {
-                const key: any = path.node.key;
-                propNames.push(key.value || key.name);
-                this.traverse(path);
-            }
-        };
-
-        types.visit(ast, methods);
-        assert.deepEqual(propNames, ["bar", "baz"]);
-
-        types.visit(ast, {
-            visitProperty: function(path) {
-                if (namedTypes.Identifier.check(path.node.value) &&
-                    path.node.value.name === "self") {
-                    path.replace();
-                    return false;
-                }
-
-                this.traverse(path);
-                return;
-            }
-        });
-
-        propNames.length = 0;
-
-        types.visit(ast, methods);
-        assert.deepEqual(propNames, ["bar"]);
+    types.visit(ast, {
+      visitThisExpression: function() {
+        return builders.identifier("self");
+      }
     });
 
-    it("reindent", function() {
-        const lines = [
-            "a(b(c({",
-            "    m: d(function() {",
-            "        if (e('y' + 'z'))",
-            "            f(42).h()",
-            "                 .i()",
-            "                 .send();",
-            "        g(8);",
-            "    })",
-            "})));"
-        ];
+    assert.strictEqual(
+      printer.print(ast).code,
+      withThis.replace(thisExp, "self")
+    );
 
-        const altered = [
-            "a(xxx(function() {",
-            "    if (e('y' > 'z'))",
-            "        f(42).h()",
-            "             .i()",
-            "             .send();",
-            "    g(8);",
-            "}, c(function() {",
-            "    if (e('y' > 'z'))",
-            "        f(42).h()",
-            "             .i()",
-            "             .send();",
-            "    g(8);",
-            "})));"
-        ];
+    const propNames: any[] = [];
+    const methods: types.Visitor = {
+      visitProperty: function(path) {
+        const key: any = path.node.key;
+        propNames.push(key.value || key.name);
+        this.traverse(path);
+      }
+    };
 
-        const source = lines.join(eol);
-        const ast = parse(source);
-        const printer = new Printer;
+    types.visit(ast, methods);
+    assert.deepEqual(propNames, ["bar", "baz"]);
 
-        let funExpr: any;
-        types.visit(ast, {
-            visitFunctionExpression: function(path) {
-                assert.strictEqual(typeof funExpr, "undefined");
-                funExpr = path.node;
-                this.traverse(path);
-            },
+    types.visit(ast, {
+      visitProperty: function(path) {
+        if (
+          namedTypes.Identifier.check(path.node.value) &&
+          path.node.value.name === "self"
+        ) {
+          path.replace();
+          return false;
+        }
 
-            visitBinaryExpression: function(path) {
-                path.node.operator = ">";
-                this.traverse(path);
-            }
-        });
-
-        namedTypes.FunctionExpression.assert(funExpr);
-
-        types.visit(ast, {
-            visitCallExpression: function(path) {
-                this.traverse(path);
-                const expr = path.node;
-                if (namedTypes.Identifier.check(expr.callee) &&
-                    expr.callee.name === "b") {
-                    expr.callee.name = "xxx";
-                    expr["arguments"].unshift(funExpr);
-                }
-            },
-
-            visitObjectExpression: function() {
-                return funExpr;
-            }
-        });
-
-        assert.strictEqual(
-            altered.join(eol),
-            printer.print(ast).code
-        );
+        this.traverse(path);
+        return;
+      }
     });
+
+    propNames.length = 0;
+
+    types.visit(ast, methods);
+    assert.deepEqual(propNames, ["bar"]);
+  });
+
+  it("reindent", function() {
+    const lines = [
+      "a(b(c({",
+      "    m: d(function() {",
+      "        if (e('y' + 'z'))",
+      "            f(42).h()",
+      "                 .i()",
+      "                 .send();",
+      "        g(8);",
+      "    })",
+      "})));"
+    ];
+
+    const altered = [
+      "a(xxx(function() {",
+      "    if (e('y' > 'z'))",
+      "        f(42).h()",
+      "             .i()",
+      "             .send();",
+      "    g(8);",
+      "}, c(function() {",
+      "    if (e('y' > 'z'))",
+      "        f(42).h()",
+      "             .i()",
+      "             .send();",
+      "    g(8);",
+      "})));"
+    ];
+
+    const source = lines.join(eol);
+    const ast = parse(source);
+    const printer = new Printer();
+
+    let funExpr: any;
+    types.visit(ast, {
+      visitFunctionExpression: function(path) {
+        assert.strictEqual(typeof funExpr, "undefined");
+        funExpr = path.node;
+        this.traverse(path);
+      },
+
+      visitBinaryExpression: function(path) {
+        path.node.operator = ">";
+        this.traverse(path);
+      }
+    });
+
+    namedTypes.FunctionExpression.assert(funExpr);
+
+    types.visit(ast, {
+      visitCallExpression: function(path) {
+        this.traverse(path);
+        const expr = path.node;
+        if (
+          namedTypes.Identifier.check(expr.callee) &&
+          expr.callee.name === "b"
+        ) {
+          expr.callee.name = "xxx";
+          expr["arguments"].unshift(funExpr);
+        }
+      },
+
+      visitObjectExpression: function() {
+        return funExpr;
+      }
+    });
+
+    assert.strictEqual(altered.join(eol), printer.print(ast).code);
+  });
 });


### PR DESCRIPTION

I omitted `test/` because there's quite a few vertical alignments of sample code that prettier does not preserve.