### PR TITLE
refactor: use arrow functions where appropriate

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -546,9 +546,7 @@ function containsCallExpression(node: any): any {
   }
 
   if (n.Node.check(node)) {
-    return types.someField(node, function(_name: any, child: any) {
-      return containsCallExpression(child);
-    });
+    return types.someField(node, (_name: any, child: any) => containsCallExpression(child));
   }
 
   return false;

--- a/lib/lines.ts
+++ b/lib/lines.ts
@@ -263,12 +263,10 @@ export class Lines {
       return this;
     }
 
-    return new Lines(this.infos.map(function (info: any, i: any) {
-      return {
-        ...info,
-        locked: i > 0,
-      };
-    }));
+    return new Lines(this.infos.map((info: any, i: any) => ({
+      ...info,
+      locked: i > 0
+    })));
   }
 
   getIndentAt(line: number) {

--- a/lib/patcher.ts
+++ b/lib/patcher.ts
@@ -55,9 +55,7 @@ const Patcher = function Patcher(this: PatcherType, lines: any) {
       toConcat.push(lines.slice(from, to));
     }
 
-    replacements.sort(function(a, b) {
-      return comparePos(a.start, b.start);
-    }).forEach(function(rep) {
+    replacements.sort((a, b) => comparePos(a.start, b.start)).forEach(function(rep) {
       if (comparePos(sliceFrom, rep.start) > 0) {
         // Ignore nested replacement ranges.
       } else {

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -75,9 +75,7 @@ const Printer = function Printer(this: PrinterType, config?: any) {
     // new print function that uses the modified options.
     function makePrintFunctionWith(options: any, overrides: any) {
         options = Object.assign({}, options, overrides);
-        return function (path: any) {
-            return print(path, options);
-        };
+        return (path: any) => print(path, options);
     }
 
     function print(path: any, options: any) {
@@ -154,12 +152,10 @@ const Printer = function Printer(this: PrinterType, config?: any) {
 
         // Print the entire AST generically.
         function printGenerically(path: any) {
-            return printComments(path, function (path: any) {
-                return genericPrint(path, config, {
-                    includeComments: true,
-                    avoidRootParens: false
-                }, printGenerically);
-            });
+            return printComments(path, (path: any) => genericPrint(path, config, {
+                includeComments: true,
+                avoidRootParens: false
+            }, printGenerically));
         }
 
         const path = FastPath.from(ast);
@@ -251,9 +247,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
             parts.push(path.call(print, "interpreter"));
         }
 
-        parts.push(path.call(function(bodyPath: any) {
-            return printStatementSequence(bodyPath, options, print);
-        }, "body"));
+        parts.push(path.call((bodyPath: any) => printStatementSequence(bodyPath, options, print), "body"));
 
         return concat(parts);
 
@@ -596,9 +590,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     }
 
     case "BlockStatement":
-        var naked = path.call(function(bodyPath: any) {
-            return printStatementSequence(bodyPath, options, print);
-        }, "body");
+        var naked = path.call((bodyPath: any) => printStatementSequence(bodyPath, options, print), "body");
 
 
         if (naked.isEmpty()) {
@@ -1099,9 +1091,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         return concat(parts);
 
     case "DoExpression":
-        var statements = path.call(function(bodyPath: any) {
-            return printStatementSequence(bodyPath, options, print);
-        }, "body");
+        var statements = path.call((bodyPath: any) => printStatementSequence(bodyPath, options, print), "body");
 
         return concat([
             "do {\n",
@@ -1191,9 +1181,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
             parts.push("default:");
 
         if (n.consequent.length > 0) {
-            parts.push("\n", path.call(function(consequentPath: any) {
-                return printStatementSequence(consequentPath, options, print);
-            }, "consequent").indent(options.tabWidth));
+            parts.push("\n", path.call((consequentPath: any) => printStatementSequence(consequentPath, options, print), "consequent").indent(options.tabWidth));
         }
 
         return concat(parts);
@@ -1335,9 +1323,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
         return concat([
             "{\n",
-            path.call(function(bodyPath: any) {
-                return printStatementSequence(bodyPath, options, print);
-            }, "body").indent(options.tabWidth),
+            path.call((bodyPath: any) => printStatementSequence(bodyPath, options, print), "body").indent(options.tabWidth),
             "\n}"
         ]);
 
@@ -2463,9 +2449,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     }
 
     case "TSModuleBlock":
-        return path.call(function (bodyPath: any) {
-            return printStatementSequence(bodyPath, options, print);
-        }, "body");
+        return path.call((bodyPath: any) => printStatementSequence(bodyPath, options, print), "body");
 
     // Unhandled types below. If encountered, nodes of these types should
     // be either left alone or desugared into AST types that are fully
@@ -2735,9 +2719,7 @@ function printMethod(path: any, options: any, print: any) {
         parts.push(
             path.call(print, "value", "typeParameters"),
             "(",
-            path.call(function(valuePath: any) {
-                return printFunctionParams(valuePath, options, print);
-            }, "value"),
+            path.call((valuePath: any) => printFunctionParams(valuePath, options, print), "value"),
             ")",
             path.call(print, "value", "returnType")
         );
@@ -2970,9 +2952,7 @@ function endsWithBrace(lines: any) {
 }
 
 function swapQuotes(str: string) {
-    return str.replace(/['"]/g, function(m) {
-        return m === '"' ? '\'' : '"';
-    });
+    return str.replace(/['"]/g, m => m === '"' ? '\'' : '"');
 }
 
 function nodeStr(str: string, options: any) {

--- a/test/babel.ts
+++ b/test/babel.ts
@@ -214,9 +214,7 @@ describe("Babel", function () {
 
     assert.strictEqual(
       reprinted,
-      code.split(eol).filter(function (line) {
-        return ! line.match(/^import React from/);
-      }).join(eol)
+      code.split(eol).filter(line => ! line.match(/^import React from/)).join(eol)
     );
   });
 
@@ -401,14 +399,12 @@ describe("Babel", function () {
     const code = "function foo(bar = true) {}";
     recast.parse(code, {
       parser: {
-        parse: function (source: any) {
-          return babelTransform(source, {
-            code: false,
-            ast: true,
-            sourceMap: false,
-            presets: [babelPresetEnv]
-          }).ast;
-        }
+        parse: (source: any) => babelTransform(source, {
+          code: false,
+          ast: true,
+          sourceMap: false,
+          presets: [babelPresetEnv]
+        }).ast
       }
     });
   });

--- a/test/patcher.ts
+++ b/test/patcher.ts
@@ -75,9 +75,7 @@ describe("patcher", function() {
     function check(indent: number) {
       const lines = fromString(trickyCode).indent(indent);
       const file = parse(lines.toString());
-      const reprinter = FastPath.from(file).call(function(bodyPath: any) {
-        return getReprinter(bodyPath);
-      }, "program", "body", 0, "body");
+      const reprinter = FastPath.from(file).call((bodyPath: any) => getReprinter(bodyPath), "program", "body", 0, "body");
 
       const reprintedLines = reprinter(function() {
         assert.ok(false, "should not have called print function");

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1612,12 +1612,10 @@ describe("printer", function() {
     const babelParser = require("@babel/parser");
     const parseOptions = {
       parser: {
-        parse: function (source: string) {
-          return babelParser.parse(source, {
-            sourceType: 'module',
-            plugins: ['flow'],
-          });
-        }
+        parse: (source: string) => babelParser.parse(source, {
+          sourceType: 'module',
+          plugins: ['flow'],
+        })
       }
     };
 

--- a/test/visit.ts
+++ b/test/visit.ts
@@ -26,9 +26,7 @@ describe("types.visit", function() {
         assert.ok(thisExp.test(withThis));
 
         types.visit(ast, {
-            visitThisExpression: function() {
-                return builders.identifier("self");
-            }
+            visitThisExpression: () => builders.identifier("self")
         });
 
         assert.strictEqual(
@@ -127,9 +125,7 @@ describe("types.visit", function() {
                 }
             },
 
-            visitObjectExpression: function() {
-                return funExpr;
-            }
+            visitObjectExpression: () => funExpr
         });
 
         assert.strictEqual(

--- a/test/visit.ts
+++ b/test/visit.ts
@@ -26,7 +26,9 @@ describe("types.visit", function() {
         assert.ok(thisExp.test(withThis));
 
         types.visit(ast, {
-            visitThisExpression: () => builders.identifier("self")
+            visitThisExpression: function() {
+                return builders.identifier("self");
+            }
         });
 
         assert.strictEqual(
@@ -125,7 +127,9 @@ describe("types.visit", function() {
                 }
             },
 
-            visitObjectExpression: () => funExpr
+            visitObjectExpression: function() {
+                return funExpr;
+            }
         });
 
         assert.strictEqual(


### PR DESCRIPTION

This was done via codemod:

```
npm i @codemod/cli @resugar/codemod-functions-arrow
./node_modules/.bin/codemod -p @resugar/codemod-functions-arrow {lib,test}/*.ts
```

This only rewrites functions that have a single statement that returns a value.