### PR TITLE
fix(patcher.ts): allow lines to be a string again

### DIFF
--- a/lib/patcher.ts
+++ b/lib/patcher.ts
@@ -25,7 +25,7 @@ interface PatcherConstructor {
 
 const Patcher = function Patcher(this: PatcherType, lines: any) {
   assert.ok(this instanceof Patcher);
-  assert.ok(lines instanceof linesModule.Lines);
+  assert.ok(lines instanceof linesModule.Lines || isString.check(lines));
 
   const self = this, replacements: any[] = [];
 


### PR DESCRIPTION
I'm getting errors here when I use print in certain places:
```
      AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  assert_1.default.ok(lines instanceof linesModule.Lines)

      + expected - actual

      -false
      +true
      
      at new Patcher (node_modules/recast/lib/patcher.js:28:22)
      at /Users/andy/codemods/node_modules/recast/lib/patcher.js:149:23
      at print (node_modules/recast/lib/printer.js:86:15)
      at /Users/andy/codemods/node_modules/recast/lib/printer.js:58:20
      at Object.printComments (node_modules/recast/lib/comments.js:283:22)
      at print (node_modules/recast/lib/printer.js:65:31)
      at Printer.print (node_modules/recast/lib/printer.js:98:21)
      at Object.print (node_modules/recast/main.js:39:43)
      at print (test/graphqlToFlowTest.js:130:25)
      at c (node_modules/lodash/lodash.min.js:6:348)
      at Function.ru (node_modules/lodash/lodash.min.js:67:252)
      at t (node_modules/lodash/lodash.min.js:131:335)
      at Qe (node_modules/lodash/lodash.min.js:67:92)
      at /Users/andy/codemods/node_modules/lodash/lodash.min.js:41:394
      at l (node_modules/lodash/lodash.min.js:6:528)
      at wr (node_modules/lodash/lodash.min.js:41:362)
      at Un.value (node_modules/lodash/lodash.min.js:134:528)
      at wr (node_modules/lodash/lodash.min.js:41:353)
      at On.An.toJSON.An.valueOf.An.value (node_modules/lodash/lodash.min.js:136:453)
      at /Users/andy/codemods/node_modules/lodash/lodash.min.js:49:85
      at pipeline (src/pipeline.js:3:38)
      at Context.<anonymous> (test/graphqlToFlowTest.js:124:20)
```

Looking at the code, I'm pretty sure the whoever wrote the assertions wasn't thinking about the `isString` check below.