### PR TITLE
Fix Flow function type param

### DIFF
--- a/lib/patcher.ts
+++ b/lib/patcher.ts
@@ -371,6 +371,17 @@ function findObjectReprints(newPath: any, oldPath: any, reprints: any) {
       return false;
     }
 
+    const newParentNode = newPath.getParentNode();
+    const oldParentNode = oldPath.getParentNode();
+    if (oldParentNode !== null && oldParentNode.type === 'FunctionTypeAnnotation'
+      && newParentNode !== null && newParentNode.type === 'FunctionTypeAnnotation') {
+        const oldNeedsParens = oldParentNode.params.length !== 1 || !!oldParentNode.params[0].name;
+        const newNeedParens = newParentNode.params.length !== 1 || !!newParentNode.params[0].name;
+      if (!oldNeedsParens && newNeedParens) {
+        return false;
+      }
+    }
+
     // Here we need to decide whether the reprinted code for newNode is
     // appropriate for patching into the location of oldNode.
 

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1659,7 +1659,8 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
         var needsColon =
             isArrowFunctionTypeAnnotation &&
-            !namedTypes.FunctionTypeParam.check(parent);
+            !namedTypes.FunctionTypeParam.check(parent) &&
+            !namedTypes.TypeAlias.check(parent);
 
         if (needsColon) {
             parts.push(": ");

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1665,10 +1665,12 @@ function genericPrintNoParens(path: any, options: any, print: any) {
             parts.push(": ");
         }
 
+        const needsParens = n.params.length !== 1 || n.params[0].name
+
         parts.push(
-            "(",
+            needsParens ? "(" : '',
             printFunctionParams(path, options, print),
-            ")",
+            needsParens ? ")" : '',
         );
 
         // The returnType is not wrapped in a TypeAnnotation, so the colon
@@ -1683,12 +1685,17 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         return concat(parts);
 
     case "FunctionTypeParam":
-        return concat([
-            path.call(print, "name"),
-            n.optional ? '?' : '',
-            ": ",
-            path.call(print, "typeAnnotation"),
-        ]);
+        const name = path.call(print, "name");
+        parts.push(name);
+        if (n.optional) {
+            parts.push('?');
+        }
+        if (name.infos[0].line) {
+            parts.push(': ');
+        }
+        parts.push(path.call(print, "typeAnnotation"));
+
+        return concat(parts);
 
     case "GenericTypeAnnotation":
         return concat([

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1984,6 +1984,40 @@ describe("printer", function() {
     assert.strictEqual(pretty, code);
   });
 
+  it("prints flow type alias to function correctly", function () {
+    const code = [
+      'type MyTypeAlias = (x?: ?number) => string;',
+    ].join(eol);
+
+    const ast = b.program([
+      b.typeAlias(
+        b.identifier('MyTypeAlias'),
+        null,
+        b.functionTypeAnnotation(
+          [
+            b.functionTypeParam(
+              b.identifier("x"),
+              b.nullableTypeAnnotation(b.numberTypeAnnotation()),
+              true,
+            )
+          ],
+          b.stringTypeAnnotation(),
+          null,
+          null,
+        ),
+      ),
+    ]);
+
+    const printer = new Printer({
+      tabWidth: 2,
+      wrapColumn: 40,
+      trailingComma: true,
+    });
+
+    const pretty = printer.printGenerically(ast).code;
+    assert.strictEqual(pretty, code);
+  })
+
   it("prints class private methods and properties correctly", function() {
     const code = [
       'class MyClassWithPrivate {',


### PR DESCRIPTION
Fix issues around:
- FunctionTypeParam when used without parenthesis like `number => string`.
- TypeAlias of FunctionTypeAnnotation