### PR TITLE
Add support for "declare" in TS class fields with Babel

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1334,6 +1334,10 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         return concat(parts);
 
     case "ClassProperty":
+        if (n.declare) {
+            parts.push("declare ");
+        }
+
         var access = n.accessibility || n.access;
         if (typeof access === "string") {
             parts.push(access, " ");

--- a/test/babel.ts
+++ b/test/babel.ts
@@ -471,4 +471,27 @@ describe("Babel", function () {
         ].join(eol)
     );
   });
+
+  it("should print typescript class elements modifiers", function () {
+    const code = [
+      'class A {',
+      '  x;',
+      '}'
+    ].join(eol);
+
+    const ast = recast.parse(code, parseOptions);
+
+    ast.program.body[0].body.body[0].readonly = true;
+    ast.program.body[0].body.body[0].declare = true;
+    ast.program.body[0].body.body[0].accessibility = "public";
+
+    assert.strictEqual(
+      recast.print(ast).code,
+      [
+        'class A {',
+        '  declare public readonly x;',
+        '}'
+      ].join(eol)
+    );
+  })
 });


### PR DESCRIPTION
It has been introduced in TypeScript 3.7 and [Babel 7.7](https://babeljs.io/blog/2019/11/05/7.7.0#typescript-37-10543-https-githubcom-babel-babel-pull-10543-10545-https-githubcom-babel-babel-pull-10545)