### PR TITLE
add parentheses for function expressions for TSAsExpression

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -2142,8 +2142,10 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     case "TSAsExpression": {
         var withParens = n.extra && n.extra.parenthesized === true;
         if (withParens) parts.push("(");
+        const expression = path.call(print, "expression");
+        const needParens = path.getValue().expression.type === "ArrowFunctionExpression";
         parts.push(
-            path.call(print, "expression"),
+            needParens ? '(' + expression + ')' : expression,
             fromString(" as "),
             path.call(print, "typeAnnotation")
         );

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -2143,7 +2143,8 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         var withParens = n.extra && n.extra.parenthesized === true;
         if (withParens) parts.push("(");
         const expression = path.call(print, "expression");
-        const needParens = path.getValue().expression.type === "ArrowFunctionExpression";
+        const expressionType = path.getValue().expression.type;
+        const needParens = expressionType === "ArrowFunctionExpression" || expressionType === "FunctionExpression";
         parts.push(
             needParens ? '(' + expression + ')' : expression,
             fromString(" as "),

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -152,6 +152,12 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
     ]);
 
     check([
+      'const highlight = (function(n) {',
+      '  return false;',
+      '}) as (a: number) => boolean;',
+    ]);
+
+    check([
       'enum Color {',
       '  Red,',
       '  Green,',

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -148,6 +148,10 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
     ]);
 
     check([
+      'const highlight = (n => false) as (a: number) => boolean;'
+    ]);
+
+    check([
       'enum Color {',
       '  Red,',
       '  Green,',


### PR DESCRIPTION
Ensure parentheses are printed for the case:

```ts
const highlight = (n => false) as (a: number) => boolean;
```