### PR TITLE
fix precedence for ** operator, to correctly parenthesize expressions

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -529,7 +529,8 @@ var PRECEDENCE: any = {};
  ["<", ">", "<=", ">=", "in", "instanceof"],
  [">>", "<<", ">>>"],
  ["+", "-"],
- ["*", "/", "%", "**"]
+ ["*", "/", "%"],
+ ["**"]
 ].forEach(function(tier, i) {
   tier.forEach(function(op) {
     PRECEDENCE[op] = i;

--- a/test/babel.ts
+++ b/test/babel.ts
@@ -345,7 +345,7 @@ describe("Babel", function () {
 
     assert.strictEqual(
       recast.print(ast).code,
-      'x * y ** (x / y);'
+      '(x * y) ** (x / y);'
     );
   });
 


### PR DESCRIPTION
Input code:

```
2 * (n / 2) ** 0.5;
```

Was printed as:

```
2 * (n / 2 ** 0.5);
```

After the fix would be printed as in input.

was discovered here: https://github.com/zxbodya/flowts/issues/4