### PR TITLE
Fix trailing comma in destructuring rest spread

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -698,7 +698,11 @@ function genericPrintNoParens(path: any, options: any, print: any) {
             allowBreak = !multiLine;
           } else if (len !== 1 && isTypeAnnotation) {
             parts.push(separator);
-          } else if (!oneLine && util.isTrailingCommaEnabled(options, "objects")) {
+          } else if (
+            !oneLine &&
+            util.isTrailingCommaEnabled(options, "objects") &&
+            childPath.getValue().type !== "RestElement"
+          ) {
             parts.push(separator);
           }
           i++;

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -836,6 +836,28 @@ describe("printer", function () {
     },
   );
 
+  it("shouldn't print a trailing comma for a RestElement in destructuring", function () {
+    const code = [
+      "const {",
+      "  foo,",
+      "  bar,",
+      "  ...rest",
+      "} = input;",
+    ].join(eol);
+
+    const ast = parse(code, {
+      parser: require("@babel/parser"),
+    });
+
+    const printer = new Printer({
+      tabWidth: 2,
+      trailingComma: true,
+    });
+
+    const pretty = printer.printGenerically(ast).code;
+    assert.strictEqual(pretty, code);
+  });
+
   it("should support AssignmentPattern and RestElement", function () {
     const code = [
       "function foo(a, [b, c] = d(a), ...[e, f, ...rest]) {",


### PR DESCRIPTION
When the `trailingComma` option is enabled, we shouldn't append a trailing comma to a rest spread.

Closes #559