### PR TITLE
Use tslib to avoid repeatedly inlining helper definitions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3232,6 +3232,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -3457,10 +3465,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
     },
     "tsutils": {
       "version": "3.17.1",
@@ -3469,6 +3476,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
+        }
       }
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "ast-types": "0.13.3",
     "esprima": "~4.0.0",
     "private": "^0.1.8",
-    "source-map": "~0.6.1"
+    "source-map": "~0.6.1",
+    "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@babel/core": "7.9.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noImplicitReturns": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
+    "importHelpers": true,
     "stripInternal": true
   },
   "exclude": [


### PR DESCRIPTION
Much like [`@babel/runtime`](https://www.npmjs.com/package/@babel/runtime) for Babel, the [`tslib`](https://www.npmjs.com/package/tslib) package is a runtime library that TypeScript can leverage to emit fewer helper function declarations.