### PR TITLE
Prepare for ast-types@0.13.4.

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -341,8 +341,7 @@ FPp.needsParens = function (assumeExpressionContext) {
     return false;
   }
 
-  if (parent.type === "ParenthesizedExpression" ||
-      (node.extra && node.extra.parenthesized)) {
+  if (parent.type === "ParenthesizedExpression" || (node.extra && node.extra.parenthesized)) {
     return false;
   }
 
@@ -454,31 +453,27 @@ FPp.needsParens = function (assumeExpressionContext) {
       }
 
     case "ArrowFunctionExpression":
-      if (n.CallExpression.check(parent) &&
-          name === "callee" &&
-          parent.callee === node) {
+      if (n.CallExpression.check(parent) && name === "callee" && parent.callee === node) {
         return true;
       }
 
-      if (n.MemberExpression.check(parent) &&
-          name === "object" &&
-          parent.object === node) {
+      if (n.MemberExpression.check(parent) && name === "object" && parent.object === node) {
         return true;
       }
 
-      if (n.TSAsExpression &&
-          n.TSAsExpression.check(parent) &&
-          name === "expression" &&
-          parent.expression === node) {
+      if (
+        n.TSAsExpression &&
+        n.TSAsExpression.check(parent) &&
+        name === "expression" &&
+        parent.expression === node
+      ) {
         return true;
       }
 
       return isBinary(parent);
 
     case "ObjectExpression":
-      if (parent.type === "ArrowFunctionExpression" &&
-          name === "body" &&
-          parent.body === node) {
+      if (parent.type === "ArrowFunctionExpression" && name === "body" && parent.body === node) {
         return true;
       }
 
@@ -505,9 +500,7 @@ FPp.needsParens = function (assumeExpressionContext) {
       }
   }
 
-  if (parent.type === "NewExpression" &&
-      name === "callee" &&
-      parent.callee === node) {
+  if (parent.type === "NewExpression" && name === "callee" && parent.callee === node) {
     return containsCallExpression(node);
   }
 

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1905,6 +1905,20 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     case "TSTupleType":
       return concat(["[", fromString(", ").join(path.map(print, "elementTypes")), "]"]);
 
+    case "TSNamedTupleMember":
+      parts.push(path.call(print, "label"));
+
+      if (n.optional) {
+        parts.push("?");
+      }
+
+      parts.push(
+        ": ",
+        path.call(print, "elementType"),
+      );
+
+      return concat(parts);
+
     case "TSRestType":
       return concat(["...", path.call(print, "typeAnnotation")]);
 

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1872,8 +1872,8 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         path.call(print, "typeParameters"),
         "(",
         printFunctionParams(path, options, print),
-        ")",
-        path.call(print, "typeAnnotation"),
+        ") => ",
+        path.call(print, "typeAnnotation", "typeAnnotation"),
       ]);
 
     case "TSConstructorType":
@@ -1882,8 +1882,8 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         path.call(print, "typeParameters"),
         "(",
         printFunctionParams(path, options, print),
-        ")",
-        path.call(print, "typeAnnotation"),
+        ") => ",
+        path.call(print, "typeAnnotation", "typeAnnotation"),
       ]);
 
     case "TSMappedType": {
@@ -1975,22 +1975,8 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     case "TSNonNullExpression":
       return concat([path.call(print, "expression"), "!"]);
 
-    case "TSTypeAnnotation": {
-      // similar to flow's FunctionTypeAnnotation, this can be
-      // ambiguous: it can be prefixed by => or :
-      // in a type predicate, it takes the for u is U
-      const parent = path.getParentNode(0);
-      let prefix = ": ";
-      if (namedTypes.TSFunctionType.check(parent) || namedTypes.TSConstructorType.check(parent)) {
-        prefix = " => ";
-      }
-
-      if (namedTypes.TSTypePredicate.check(parent)) {
-        prefix = " is ";
-      }
-
-      return concat([prefix, path.call(print, "typeAnnotation")]);
-    }
+    case "TSTypeAnnotation":
+      return concat([": ", path.call(print, "typeAnnotation")]);
 
     case "TSIndexSignature":
       return concat([
@@ -2036,7 +2022,20 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return concat(parts);
 
     case "TSTypePredicate":
-      return concat([path.call(print, "parameterName"), path.call(print, "typeAnnotation")]);
+      if (n.asserts) {
+        parts.push("asserts ");
+      }
+
+      parts.push(path.call(print, "parameterName"));
+
+      if (n.typeAnnotation) {
+        parts.push(
+          " is ",
+          path.call(print, "typeAnnotation", "typeAnnotation"),
+        );
+      }
+
+      return concat(parts);
 
     case "TSCallSignatureDeclaration":
       return concat([

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1912,10 +1912,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         parts.push("?");
       }
 
-      parts.push(
-        ": ",
-        path.call(print, "elementType"),
-      );
+      parts.push(": ", path.call(print, "elementType"));
 
       return concat(parts);
 
@@ -2043,10 +2040,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       parts.push(path.call(print, "parameterName"));
 
       if (n.typeAnnotation) {
-        parts.push(
-          " is ",
-          path.call(print, "typeAnnotation", "typeAnnotation"),
-        );
+        parts.push(" is ", path.call(print, "typeAnnotation", "typeAnnotation"));
       }
 
       return concat(parts);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1307,9 +1307,19 @@
       }
     },
     "ast-types": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
-      "integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA=="
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "requires": {
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+        }
+      }
     },
     "astral-regex": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "fs": false
   },
   "dependencies": {
-    "ast-types": "0.13.3",
+    "ast-types": "^0.13.4",
     "esprima": "~4.0.0",
     "private": "^0.1.8",
     "source-map": "~0.6.1"

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -170,14 +170,14 @@ describe("parens", function () {
     check("function* test () { yield yield foo }");
   });
 
-  it('ArrowFunctionExpression', () => {
-    check('(() => {})()');
-    check('test(() => {})');
+  it("ArrowFunctionExpression", () => {
+    check("(() => {})()");
+    check("test(() => {})");
 
-    check('(() => {}).test');
-    check('test[() => {}]');
+    check("(() => {}).test");
+    check("test[() => {}]");
 
-    check('(() => {}) + (() => {})');
+    check("(() => {}) + (() => {})");
   });
 
   it("ReprintedParens", function () {

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -5,7 +5,7 @@ import * as recast from "../main";
 import * as types from "ast-types";
 import { EOL as eol } from "os";
 import * as parser from "../parsers/typescript";
-import { Printer } from '../lib/printer';
+import { Printer } from "../lib/printer";
 
 const { namedTypes: n } = types;
 const printer = new Printer();
@@ -272,10 +272,7 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
 
     check(["type Class<T> = new (...args: any) => T;"]);
 
-    check([
-      "type T1 = [...Array<any>];",
-      "type T2 = [...any[]];",
-    ]);
+    check(["type T1 = [...Array<any>];", "type T2 = [...any[]];"]);
 
     check([
       "type Color = [r: number, g: number, b: number, a?: number];",

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -272,7 +272,18 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
 
     check(["type Class<T> = new (...args: any) => T;"]);
 
-    check(["type T1 = [...Array<any>];", "type T2 = [...any[]];"]);
+    check([
+      "type T1 = [...Array<any>];",
+      "type T2 = [...any[]];",
+    ]);
+
+    check([
+      "type Color = [r: number, g: number, b: number, a?: number];",
+      "type Red = Color.r;",
+      "type Green = Color.g;",
+      "type Blue = Color.b;",
+      "type Alpha = Color.a;",
+    ]);
   });
 
   it("parens", function () {


### PR DESCRIPTION
Whenever we update the `ast-types` dependency, we have to make sure Recast has printer cases for any/all updated type definitions. This is why #727 was initially failing (as expected).

Will close #727.