### PR TITLE
fix: parenthesizes around arrow function body returning object

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -391,7 +391,11 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         );
       }
 
-      parts.push(" => ", path.call(print, "body"));
+      if (n.body.type === 'ObjectExpression') {
+          parts.push(" => ", '(', path.call(print, "body"), ')');
+      } else {
+          parts.push(" => ", path.call(print, "body"));
+      }
 
       return concat(parts);
 

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1031,6 +1031,25 @@ describe("printer", function () {
     const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
+  
+  it("adds parenthesis around arrow functions body when returning object expression using babel parser", function () {
+    const expected = "() => ({a: 'b'});";
+    const source = "(a) => ({a: 'b'});";
+    const ast = recast.parse(source, {
+        parser: require('@babel/parser'),
+    });
+    const traverse = require('@babel/traverse').default;
+    
+    traverse(ast, {
+        Function(path: any) {
+            path.get('params.0').remove();
+        }
+    });
+
+    const printer = new Printer();
+    const result = printer.print(ast).code;
+    assert.strictEqual(result, expected);
+  });
 
   it("prints class property initializers with type annotations correctly", function () {
     const code = ["class A {", "  foo = (a: b): void => {};", "}"].join(eol);


### PR DESCRIPTION
Fixes #743. Using `recast` with `babel-parser` and `traverser` break code with arrow function expression returning an object.

Code:

```js
(a) => ({a: 'b'});
```

Becomes:

```js
() => {a: 'b'}
```
After removing function argument from `@babel/traverse`.
