### PR TITLE
Introduce 'preserveMultilineDeclarations' option that prevents declarations of several variables over multiple lines in a single statement from being reformatted into a single line.

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -155,7 +155,7 @@ export interface Options extends DeprecatedOptions {
   /**
    * If true, printing multiple declarators will put them on separate lines.
    */
-  preserveMultilineDeclarations: boolean;
+  preserveMultilineDeclarations?: boolean;
 
   /**
    * Whether to return an array of .tokens on the root AST node.

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -153,6 +153,11 @@ export interface Options extends DeprecatedOptions {
   flowObjectCommas?: boolean;
 
   /**
+   * If true, printing multiple declarators will put them on separate lines.
+   */
+  preserveMultilineDeclarations: boolean;
+
+  /**
    * Whether to return an array of .tokens on the root AST node.
    * @default true
    */
@@ -183,6 +188,7 @@ const defaults: Options = {
   objectCurlySpacing: true,
   arrowParensAlways: false,
   flowObjectCommas: true,
+  preserveMultilineDeclarations: false,
   tokens: true,
 };
 const hasOwn = defaults.hasOwnProperty;
@@ -218,6 +224,7 @@ export function normalize(opts?: Options): NormalizedOptions {
     objectCurlySpacing: get("objectCurlySpacing"),
     arrowParensAlways: get("arrowParensAlways"),
     flowObjectCommas: get("flowObjectCommas"),
+    preserveMultilineDeclarations: get("preserveMultilineDeclarations"),
     tokens: !!get("tokens"),
   };
 }

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -986,10 +986,12 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       let lastLine : number | undefined = undefined;
       let isMultiline = false;
       const printed = path.map(function (childPath: any) {
-        const currentEndLine = childPath.stack[childPath.stack.length - 1].loc.end.line;
+        const lastPathElement = childPath.stack[childPath.stack.length - 1];
+        const currentEndLine = lastPathElement.loc != null ? lastPathElement.loc.end.line : undefined;
         if (lastLine != null && currentEndLine !== lastLine) {
           isMultiline = true;
         }
+        lastLine = currentEndLine;
         const lines = print(childPath);
         maxLen = Math.max(lines.length, maxLen);
         return lines;

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -983,13 +983,19 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       parts.push(n.kind, " ");
 
       let maxLen = 0;
+      let lastLine : number | undefined = undefined;
+      let isMultiline = false;
       const printed = path.map(function (childPath: any) {
+        const currentEndLine = childPath.stack[childPath.stack.length - 1].loc.end.line;
+        if (lastLine != null && currentEndLine !== lastLine) {
+          isMultiline = true;
+        }
         const lines = print(childPath);
         maxLen = Math.max(lines.length, maxLen);
         return lines;
       }, "declarations");
 
-      if (maxLen === 1) {
+      if (maxLen === 1 && !(options.preserveMultilineDeclarations && isMultiline)) {
         parts.push(fromString(", ").join(printed));
       } else if (printed.length > 1) {
         parts.push(

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1033,6 +1033,34 @@ describe("printer", function () {
     assert.strictEqual(pretty, code);
   });
 
+  it("preserves multiline variable declarations " +
+    "when options.preserveMultilineDeclarations is true " +
+    "and the original declaration spans several lines",  () => {
+
+    const code = "var a = 1,\n    b = 2;";
+    const ast = parse(code);
+
+    const printer = new Printer({
+      preserveMultilineDeclarations: true,
+    });
+    const pretty = printer.printGenerically(ast).code;
+    assert.strictEqual(pretty, code);
+  });
+
+  it("preserves single line variable declarations " +
+    "when options.preserveMultilineDeclarations is true " +
+    "and the original declaration in on a single line",  () => {
+
+    const code = "var a = 1, b = 2;";
+    const ast = parse(code);
+
+    const printer = new Printer({
+      preserveMultilineDeclarations: true,
+    });
+    const pretty = printer.printGenerically(ast).code;
+    assert.strictEqual(pretty, code);
+  });
+
   it("adds parenthesis around arrow function when binding", function () {
     const code = "var a = (x => y).bind(z);";
 


### PR DESCRIPTION
When the 'preserveMultilineDeclarations' option is set to true, printing tries to preserve the previous formatting of variable declarations. When multiple variables have been declared in a single line, the output is on a single line. When multiple variables have been declared on multiple lines, the output is also on multiple lines.

A new option is used to preserve the original behavior.