### PR TITLE
Add more tests of chain expressions.

### DIFF
--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1692,6 +1692,36 @@ describe("printer", function () {
     assert.strictEqual(recast.print(node).code, "foo?.bar");
   });
 
+  it("reprints various optional member/call expressions", function () {
+    const parser = require("../parsers/babel");
+
+    function check(code: string) {
+      const ast = recast.parse(code, { parser });
+      const exprStmt = ast.program.body[0];
+      n.ExpressionStatement.assert(exprStmt);
+      const expr = exprStmt.expression;
+      const output = recast.prettyPrint(expr, { tabWidth: 2 }).code;
+      assert.strictEqual(code, output);
+    }
+
+    check("a.b");
+    check("a?.b");
+    check("a?.b.c");
+    check("a.b?.c");
+    check("a?.b?.c");
+    check("a?.(b)");
+    check("a?.b(c)");
+    check("a?.b?.(c)");
+    check("a.b?.(c)");
+    check("a.b?.(c)?.d");
+    check("a.b?.(c)?.d(e)");
+    check("a.b?.(c)?.d?.(e)");
+    check("a?.b?.(c).d?.(e)");
+    check("a?.b?.(c)?.d?.(e)");
+    check("(a?.b)?.(c)?.d?.(e)");
+    check("(a?.b?.(c)?.d)?.(e)");
+  });
+
   it("prints numbers in bases other than 10 without converting them", function () {
     const code = [
       "let decimal = 6;",


### PR DESCRIPTION
Follow-up to #766, addressing a few issues:

1. The `ChainElement` type is an abstract supertype of `CallExpression` and `MemberExpression` (see https://github.com/benjamn/ast-types/pull/399), so [`switch (n.type)`](https://github.com/benjamn/recast/blob/ae0a51e9e75b892e8d6aa26eef6e6976742aab9a/lib/printer.ts#L244) will always see either `"CallExpression"` or `"MemberExpression"` and never `"ChainElement"`.

2. We need to keep the printing of `{Member,Call}Expression` aligned with the printing of `Optional{Member,Call}Expression`, at least until the latter types are fully deprecated by all parsers.

3. The optionality logic for call expressions was slightly off. Whether a `?.` is printed should not depend on the optionality of `n.callee`. This has been an issue since #511, per git blame.