### PR TITLE
refactor: printer: apply putout rules on printer.ts

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -4,7 +4,7 @@ import { Lines, fromString, concat } from "./lines";
 import { normalize as normalizeOptions } from "./options";
 import { getReprinter } from "./patcher";
 import * as types from "ast-types";
-const namedTypes = types.namedTypes;
+const {namedTypes} = types;
 const isString = types.builtInTypes.string;
 const isObject = types.builtInTypes.object;
 import FastPath from "./fast-path";
@@ -78,7 +78,10 @@ const Printer = (function Printer(this: PrinterType, config?: any) {
   // Non-destructively modifies options with overrides, and returns a
   // new print function that uses the modified options.
   function makePrintFunctionWith(options: any, overrides: any) {
-    options = Object.assign({}, options, overrides);
+    options = {
+      ...options,
+      ...overrides
+    };
     return (path: any) => print(path, options);
   }
 
@@ -98,7 +101,7 @@ const Printer = (function Printer(this: PrinterType, config?: any) {
     const oldTabWidth = config.tabWidth;
 
     if (!explicitTabWidth) {
-      const loc = path.getNode().loc;
+      const {loc} = path.getNode();
       if (loc && loc.lines && loc.lines.guessTabWidth) {
         config.tabWidth = loc.lines.guessTabWidth();
       }
@@ -547,7 +550,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     case "ImportExpression":
       return concat(["import(", path.call(print, "source"), ")"]);
 
-    case "ImportDeclaration": {
+    case "ImportDeclaration":
       parts.push("import ");
 
       if (n.importKind && n.importKind !== "value") {
@@ -605,7 +608,6 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       parts.push(path.call(print, "source"), ";");
 
       return concat(parts);
-    }
 
     case "BlockStatement": {
       const naked = path.call(
@@ -635,7 +637,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return concat(parts);
     }
 
-    case "ReturnStatement": {
+    case "ReturnStatement":
       parts.push("return");
 
       if (n.argument) {
@@ -655,7 +657,6 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       parts.push(";");
 
       return concat(parts);
-    }
 
     case "CallExpression":
     case "OptionalCallExpression":
@@ -702,9 +703,9 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       fields.push("properties");
 
       let len = 0;
-      fields.forEach(function (field) {
+      for (const field of fields) {
         len += n[field].length;
-      });
+      }
 
       const oneLine = (isTypeAnnotation && len === 1) || len === 0;
       const leftBrace = n.exact ? "{|" : "{";
@@ -713,7 +714,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       const leftBraceIndex = parts.length - 1;
 
       let i = 0;
-      fields.forEach(function (field) {
+      for (const field of fields) {
         path.each(function (childPath: any) {
           let lines = print(childPath);
 
@@ -745,7 +746,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
           }
           i++;
         }, field);
-      });
+      }
 
       if (n.inexact) {
         const line = fromString("...", options);
@@ -1687,7 +1688,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     case "EnumBooleanBody":
     case "EnumNumberBody":
     case "EnumStringBody":
-    case "EnumSymbolBody": {
+    case "EnumSymbolBody":
       if (n.type === "EnumSymbolBody" || n.explicitType) {
         parts.push(
           " of ",
@@ -1705,7 +1706,6 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       );
 
       return concat(parts);
-    }
 
     case "EnumDefaultedMember":
       return concat([path.call(print, "id"), ","]);
@@ -2095,7 +2095,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         path.call(print, "typeAnnotation", "typeAnnotation"),
       ]);
 
-    case "TSMappedType": {
+    case "TSMappedType":
       parts.push(
         n.readonly ? "readonly " : "",
         "[",
@@ -2109,7 +2109,6 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       }
 
       return concat(["{\n", concat(parts).indent(options.tabWidth), "\n}"]);
-    }
 
     case "TSTupleType":
       return concat([
@@ -2334,7 +2333,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return concat(parts);
     }
 
-    case "TSTypeAssertion": {
+    case "TSTypeAssertion":
       parts.push(
         "<",
         path.call(print, "typeAnnotation"),
@@ -2342,7 +2341,6 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         path.call(print, "expression"),
       );
       return concat(parts);
-    }
 
     case "TSTypeParameterDeclaration":
     case "TSTypeParameterInstantiation":
@@ -2604,7 +2602,7 @@ function printStatementSequence(path: any, options: any, print: any) {
   const parts: any[] = [];
 
   filtered.forEach(function (info, i) {
-    const printed = info.printed;
+    const {printed} = info;
     const stmt = info.node;
     const multiLine = printed.length > 1;
     const notFirst = i > 0;
@@ -2678,7 +2676,7 @@ function maxSpace(s1: any, s2: any) {
 
 function printMethod(path: any, options: any, print: any) {
   const node = path.getNode();
-  const kind = node.kind;
+  const {kind} = node;
   const parts = [];
 
   let nodeValue = node.value;
@@ -2783,7 +2781,7 @@ function printFunctionParams(path: any, options: any, print: any) {
   const fun = path.getValue();
 
   let params;
-  let printed: Array<Lines> = [];
+  let printed: Lines[] = [];
   if (fun.params) {
     params = fun.params;
     printed = path.map(print, "params");


### PR DESCRIPTION
I'm working on code transformer [putout](https://github.com/coderaiser/putout). It has a lot built-in rules, so I want to suggest results of it's work on `printer.ts` using next rules:

```json
{
    "rules": {
        "remove-debugger": "off",
        "remove-console": "off",
        "merge-if-statements": "off",
        "apply-destructuring/object": "on",
        "remove-nested-blocks": "on",
        "convert-object-assign-to-merge-spread": "on",
        "convert-for-each-to-for-of": "on",
        "convert-generic-to-shorthand": "on"
    }
}
```

I can disable some rules, If you think there is no need on `recast` codebase for them, anyways, I think this can make `recast` codebase a little bit better :). I'm using `recast` as a dependency and glad to make contribution back.

If it will be merged and when we decide on rule set, I can run `putout` on all codebase.