### PR TITLE
fix: TSTypeAnnotation printer

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -2220,9 +2220,9 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         path.getParentNode(0),
       );
 
-      let prfx = isFunctionType ? "=> " : ": ";
+      const prefix = isFunctionType ? "=> " : ": ";
 
-      return concat([prfx, path.call(print, "typeAnnotation")]);
+      return concat([prefix, path.call(print, "typeAnnotation")]);
     }
 
     case "TSIndexSignature":

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -2215,8 +2215,15 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     case "TSNonNullExpression":
       return concat([path.call(print, "expression"), "!"]);
 
-    case "TSTypeAnnotation":
-      return concat([": ", path.call(print, "typeAnnotation")]);
+    case "TSTypeAnnotation": {
+      const isFunctionType = namedTypes.TSFunctionType.check(
+        path.getParentNode(0),
+      );
+
+      let prfx = isFunctionType ? "=> " : ": ";
+
+      return concat([prfx, path.call(print, "typeAnnotation")]);
+    }
 
     case "TSIndexSignature":
       return concat([

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -2079,6 +2079,45 @@ describe("printer", function () {
     assert.strictEqual(pretty, code);
   });
 
+  it("prints an typscript type annotation correctly", function () {
+    const code = [
+      "type MessageGetter = (params: Params) => string;",
+      "",
+      "type MessageStruct = {",
+      "    text: string",
+      "};",
+    ].join(eol);
+
+    const ast = b.program([
+      b.tsTypeAliasDeclaration(
+        b.identifier("MessageGetter"),
+        b.tsFunctionType.from({
+          parameters: [
+            b.identifier.from({
+              name: "params",
+              typeAnnotation: b.tsTypeAnnotation(
+                b.tsTypeReference(b.identifier("Params")),
+              ),
+            }),
+          ],
+          typeAnnotation: b.tsTypeAnnotation(b.tsStringKeyword()),
+        }),
+      ),
+      b.tsTypeAliasDeclaration(
+        b.identifier("MessageStruct"),
+        b.tsTypeLiteral([
+          b.tsPropertySignature.from({
+            key: b.identifier("text"),
+            typeAnnotation: b.tsTypeAnnotation(b.tsStringKeyword()),
+          }),
+        ]),
+      ),
+    ]);
+
+    const pretty = new Printer().printGenerically(ast).code;
+    assert.strictEqual(pretty, code);
+  });
+
   it("object destructuring for function parameters", function () {
     const code = [
       "function myFunction(",


### PR DESCRIPTION
Fixes: https://github.com/benjamn/recast/issues/814

Now instead of `type Message = (params: Params) : typeof add;` we are get `type Message = (params: Params) => typeof add;`