### PR TITLE
Allow inputSourceMap on .parse() 

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -143,7 +143,7 @@ const Printer = (function Printer(this: PrinterType, config?: any) {
     return new PrintResult(
       lines.toString(config),
       util.composeSourceMaps(
-        config.inputSourceMap,
+        config.inputSourceMap || ast.inputSourceMap,
         lines.getSourceMap(config.sourceMapName, config.sourceRoot),
       ),
     );

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -348,3 +348,13 @@ export function isTrailingCommaEnabled(options: any, context: any) {
   }
   return !!trailingComma;
 }
+
+export function extractInlineSourceMaps(source: string) {
+  const re = /\s*\/\/(?:@|#) sourceMappingURL=data:application\/json;base64,(\S*)$/m;
+  const map = source.match(re);
+
+  return {
+    source: map ? source.replace(re, '') : source,
+    inputSourceMap: map ? (Buffer.from(map[1], 'base64')).toString() : undefined
+  };
+}


### PR DESCRIPTION
Closes #128
Closes #146

This is a followup of 146 with (mostly) the same changes, rebased on top of master and written as typescript. It also allows passing in a separate sourcemap to `.parse()` using the `inputSourceMap` instead of _only_ extracting inline sourcemaps.

All credit to @caridy.