### PR TITLE
fix: parenthesizes around arrow function body returning object 

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -347,10 +347,7 @@ FPp.needsParens = function (assumeExpressionContext) {
     return false;
   }
 
-  if (
-    parent.type === "ParenthesizedExpression" ||
-    (node.extra && node.extra.parenthesized)
-  ) {
+  if (parent.type === "ParenthesizedExpression") {
     return false;
   }
 

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1135,6 +1135,25 @@ describe("printer", function () {
     const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
+  
+  it("adds parenthesis around arrow functions body when returning object expression using babel parser", function () {
+    const expected = "() => ({a: 'b'});";
+    const source = "(a) => ({a: 'b'});";
+    const ast = recast.parse(source, {
+        parser: require('@babel/parser'),
+    });
+    const traverse = require('@babel/traverse').default;
+    
+    traverse(ast, {
+        Function(path: any) {
+            path.get('params.0').remove();
+        }
+    });
+
+    const printer = new Printer();
+    const result = printer.print(ast).code;
+    assert.strictEqual(result, expected);
+  });
 
   it("prints class property initializers with type annotations correctly", function () {
     const code = ["class A {", "  foo = (a: b): void => {};", "}"].join(eol);

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1135,15 +1135,23 @@ describe("printer", function () {
     const pretty = printer.printGenerically(ast).code;
     assert.strictEqual(pretty, code);
   });
-  
+
   it("adds parenthesis around arrow functions body when returning object expression using babel parser", function () {
-    const expected = "() => ({a: 'b'});";
-    const source = "(a) => ({a: 'b'});";
+    const expected = [
+      "() => ({",
+      "  a: 'b'",
+      "});",
+    ].join(eol);
+    const source = [
+      "(a) => ({",
+      "  a: 'b'",
+      "});"
+    ].join(eol);
     const ast = recast.parse(source, {
         parser: require('@babel/parser'),
     });
     const traverse = require('@babel/traverse').default;
-    
+
     traverse(ast, {
         Function(path: any) {
             path.get('params.0').remove();


### PR DESCRIPTION
fixes #743, fixes #744

I caught the same issue when having codemod changing function type annotations

it looks to be caused by 
https://github.com/benjamn/recast/commit/69e1227cca2d44a152fc890442d80f7910499323#diff-f2dc028279be53ae3c8d23750deff945df0bf5cafd17fe66d0a10d0b7421e93fR344-R345

which for me looks a bit suspicious, and when reverting - does not look to break any existing tests
 
adopted the test from #744
