### PR TITLE
fix: additional semicolon in TSInterfaceBody

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -2424,12 +2424,11 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       ]);
 
     case "TSInterfaceBody": {
-      const lines = fromString(";\n").join(path.map(print, "body"));
+      const lines = fromString("\n").join(path.map(print, "body"));
       if (lines.isEmpty()) {
         return fromString("{}", options);
       }
-
-      return concat(["{\n", lines.indent(options.tabWidth), ";", "\n}"]);
+      return concat(["{\n", lines.indent(options.tabWidth), "\n}"]);
     }
 
     case "TSImportType":

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -213,23 +213,23 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
 
     check([
       "interface LabelledContainer<T> {",
-      "  label: string;",
-      "  content: T;",
-      "  option?: boolean;",
-      "  readonly x: number;",
-      "  [index: number]: string;",
-      "  [propName: string]: any;",
-      "  readonly [index: number]: string;",
-      "  (source: string, subString: string): boolean;",
-      "  (start: number): string;",
-      "  reset(): void;",
-      "  a(c: (this: void, e: E) => void): void;",
+      "  label: string",
+      "  content: T",
+      "  option?: boolean",
+      "  readonly x: number",
+      "  [index: number]: string",
+      "  [propName: string]: any",
+      "  readonly [index: number]: string",
+      "  (source: string, subString: string): boolean",
+      "  (start: number): string",
+      "  reset(): void",
+      "  a(c: (this: void, e: E) => void): void",
       "}",
     ]);
 
     check([
       "interface Square<T, U> extends Shape<T, U>, Visible<T, U> {",
-      "  sideLength: number;",
+      "  sideLength: number",
       "}",
     ]);
 
@@ -257,17 +257,17 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
       "}",
     ]);
 
-    check(["export interface S {", "  i(s: string): boolean;", "}"]);
+    check(["export interface S {", "  i(s: string): boolean", "}"]);
 
     check([
       "namespace Validation {",
       "  export interface S {",
-      "    i(j: string): boolean;",
+      "    i(j: string): boolean",
       "  }",
       "}",
     ]);
 
-    check(["export interface S {", "  i(j: string): boolean;", "}"]);
+    check(["export interface S {", "  i(j: string): boolean", "}"]);
 
     check(["declare namespace D3 {", "  export const f: number = 2;", "}"]);
 
@@ -306,6 +306,68 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
       "type Blue = Color.b;",
       "type Alpha = Color.a;",
     ]);
+  });
+
+  it("InterfaceBody: duplicate semicolon", function () {
+    const code = [
+        "interface Hello {",
+        "  'hello': any;",
+        "  'hello': string;",
+        "}",
+    ].join(eol);
+    
+    const ast = recast.parse(code, { parser });
+    
+    ast.program.body[0].body.body.pop();
+
+    assert.strictEqual(
+      recast.print(ast).code,
+      [
+      "interface Hello {",
+      "  'hello': any;",
+      "}",
+      ].join(eol),
+    );
+  });
+  
+  it("InterfaceBody: duplicate semicolon: a lot of properties", function () {
+    const code = [
+      "interface LabelledContainer<T> {",
+      "  label: string;",
+      "  content: T;",
+      "  option?: boolean;",
+      "  readonly x: number;",
+      "  [index: number]: string;",
+      "  [propName: string]: any;",
+      "  readonly [index: number]: string;",
+      "  (source: string, subString: string): boolean;",
+      "  (start: number): string;",
+      "  reset(): void;",
+      "  a(c: (this: void, e: E) => void): void;",
+      "}",
+    ].join(eol);
+    
+    const ast = recast.parse(code, { parser });
+    
+    ast.program.body[0].body.body.shift();
+
+    assert.strictEqual(
+      recast.print(ast).code,
+      [
+        "interface LabelledContainer<T> {",
+        "  content: T;",
+        "  option?: boolean;",
+        "  readonly x: number;",
+        "  [index: number]: string;",
+        "  [propName: string]: any;",
+        "  readonly [index: number]: string;",
+        "  (source: string, subString: string): boolean;",
+        "  (start: number): string;",
+        "  reset(): void;",
+        "  a(c: (this: void, e: E) => void): void;",
+        "}",
+      ].join(eol),
+    );
   });
 });
 


### PR DESCRIPTION
Closes #867.

`TSInterfaceBody` handling in `printer.ts` adds additional semicolons when `recast.print` is used. This produces not working and not parsable code. Anyways, `prettyPrint` works good, it do not look at source, and try to guess that semicolons is needed, but it's internal method that no one use.

This PR removes additional semicolons, and keeps code parsable for both cases: `prettyPrint` and `print`.
So internal from source code:

```ts
interface Hello {
    hello: any;
}
```

`prettyPrint` will produce:

```ts
 interface Hello {
    hello: any
}
```

And `print` will produce:

```ts
 interface Hello {
    hello: any;
}
```