### PR TITLE
add sourceType option for esprima

### DIFF
--- a/parsers/esprima.ts
+++ b/parsers/esprima.ts
@@ -20,6 +20,7 @@ export function parse(source: string, options?: any) {
     tolerant: getOption(options, "tolerant", true),
     tokens: true,
     jsx: getOption(options, "jsx", false),
+    sourceType: getOption(options, "sourceType", "module"),
   });
 
   if (!Array.isArray(ast.comments)) {


### PR DESCRIPTION
according to [distinguishing-a-script-and-a-module](https://esprima.readthedocs.io/en/4.0/syntactic-analysis.html#distinguishing-a-script-and-a-module,),
we should pass `sourceType` option to the `esprima.parse` function.

we have `esprima.parseScript`, `esprima.parseModule` and a deprecated `esprima.parse`.
[[API] Explicitly distinguish parsing a module vs a script #1576](https://github.com/jquery/esprima/issues/1576)