### PR TITLE
Refine Prettier configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
@@ -12,18 +12,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ['10.x', '12.x', '14.x', '15.x']
+        node_version: ["10.x", "12.x", "14.x", "15.x"]
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node_version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node_version }}
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node_version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node_version }}
 
-    - name: npm install, build and test
-      run: |
-        npm install
-        npm run build --if-present
-        npm test
+      - name: npm install, build and test
+        run: |
+          npm install
+          npm run build --if-present
+          npm test

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
-**/*.d.ts
+*.d.ts
+test/data/
+/example

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -8,6 +8,8 @@ module.exports = {
       files: "*.md",
       options: {
         printWidth: 60,
+        // Don't reformat code examples in README
+        embeddedLanguageFormatting: "off",
       },
     },
   ],

--- a/README.md
+++ b/README.md
@@ -5,13 +5,12 @@
 1. to remodel or reconstruct (a literary work, document, sentence, etc.).
 1. to supply (a theater or opera work) with a new cast.
 
-Installation
----
+## Installation
 
 From NPM:
 
     npm install recast
-    
+
 From GitHub:
 
     cd path/to/node_modules
@@ -19,10 +18,10 @@ From GitHub:
     cd recast
     npm install .
 
-Import style
----
+## Import style
 
 Recast is designed to be imported using **named** imports:
+
 ```js
 import { parse, print } from "recast";
 console.log(print(parse(source)).code);
@@ -32,6 +31,7 @@ console.log(recast.print(recast.parse(source)).code);
 ```
 
 If you're using CommonJS:
+
 ```js
 const { parse, print } = require("recast");
 console.log(print(parse(source)).code);
@@ -40,12 +40,12 @@ const recast = require("recast");
 console.log(recast.print(recast.parse(source)).code);
 ```
 
-Usage
----
+## Usage
 
 Recast exposes two essential interfaces, one for parsing JavaScript code (`require("recast").parse`) and the other for reprinting modified syntax trees (`require("recast").print`).
 
 Here's a simple but non-trivial example of how you might use `.parse` and `.print`:
+
 ```js
 import * as recast from "recast";
 
@@ -61,9 +61,11 @@ const code = [
 // Parse the code using an interface similar to require("esprima").parse.
 const ast = recast.parse(code);
 ```
-Now do *whatever* you want to `ast`. Really, anything at all!
+
+Now do _whatever_ you want to `ast`. Really, anything at all!
 
 See [ast-types](https://github.com/benjamn/ast-types) (especially the [def/core.ts](https://github.com/benjamn/ast-types/blob/master/def/core.ts)) module for a thorough overview of the `ast` API.
+
 ```js
 // Grab a reference to the function declaration we just parsed.
 const add = ast.program.body[0];
@@ -89,11 +91,15 @@ ast.program.body[0] = b.variableDeclaration("var", [
 // Just for fun, because addition is commutative:
 add.params.push(add.params.shift());
 ```
+
 When you finish manipulating the AST, let `recast.print` work its magic:
+
 ```js
 const output = recast.print(ast).code;
 ```
+
 The `output` string now looks exactly like this, weird formatting and all:
+
 ```js
 var add = function(b, a) {
   return a +
@@ -101,26 +107,32 @@ var add = function(b, a) {
     b;
 }
 ```
+
 The magic of Recast is that it reprints only those parts of the syntax tree that you modify. In other words, the following identity is guaranteed:
+
 ```js
 recast.print(recast.parse(source)).code === source
 ```
+
 Whenever Recast cannot reprint a modified node using the original source code, it falls back to using a generic pretty printer. So the worst that can happen is that your changes trigger some harmless reformatting of your code.
 
 If you really don't care about preserving the original formatting, you can access the pretty printer directly:
+
 ```js
 var output = recast.prettyPrint(ast, { tabWidth: 2 }).code;
 ```
+
 And here's the exact `output`:
+
 ```js
 var add = function(b, a) {
   return a + b;
 }
 ```
+
 Note that the weird formatting was discarded, yet the behavior and abstract structure of the code remain the same.
 
-Using a different parser
----
+## Using a different parser
 
 By default, Recast uses the [Esprima JavaScript parser](https://www.npmjs.com/package/esprima) when you call `recast.parse(code)`. While Esprima supports almost all modern ECMAScript syntax, you may want to use a different parser to enable TypeScript or Flow syntax, or just because you want to match other compilation tools you might be using.
 
@@ -158,21 +170,21 @@ const tsAst = recast.parse(source, {
 
 **Note:** Some of these parsers import npm packages that Recast does not directly depend upon, so please be aware you may have to run `npm install babylon@next` to use the `typescript`, `flow`, or `babylon` parsers, or `npm install acorn` to use the `acorn` parser. Only Esprima is installed by default when Recast is installed.
 
-Source maps
----
+## Source maps
 
 One of the coolest consequences of tracking and reusing original source code during reprinting is that it's pretty easy to generate a high-resolution mapping between the original code and the generated code—completely automatically!
 
 With every `slice`, `join`, and re-`indent`-ation, the reprinting process maintains exact knowledge of which character sequences are original, and where in the original source they came from.
 
 All you have to think about is how to manipulate the syntax tree, and Recast will give you a [source map](https://github.com/mozilla/source-map) in exchange for specifying the names of your source file(s) and the desired name of the map:
+
 ```js
 var result = recast.print(transform(recast.parse(source, {
   sourceFileName: "source.js"
 })), {
   sourceMapName: "map.json"
 });
-    
+
 console.log(result.code); // Resulting string of code.
 console.log(result.map); // JSON source map.
 
@@ -191,13 +203,12 @@ Note that you are free to mix and match syntax trees parsed from different sourc
 
 Note also that the source maps generated by Recast are character-by-character maps, so meaningful identifier names are not recorded at this time. This approach leads to higher-resolution debugging in modern browsers, at the expense of somewhat larger map sizes. Striking the perfect balance here is an area for future exploration, but such improvements will not require any breaking changes to the interface demonstrated above.
 
-Options
----
+## Options
+
 All Recast API functions take second parameter with configuration options, documented in
 [options.ts](https://github.com/benjamn/recast/blob/master/lib/options.ts)
 
-Motivation
----
+## Motivation
 
 The more code you have, the harder it becomes to make big, sweeping changes quickly and confidently. Even if you trust yourself not to make too many mistakes, and no matter how proficient you are with your text editor, changing tens of thousands of lines of code takes precious, non-refundable time.
 

--- a/main.ts
+++ b/main.ts
@@ -10,7 +10,6 @@ export {
    * arbitrary modification and reprinting.
    */
   parse,
-
   /**
    * Convenient shorthand for the ast-types package.
    */
@@ -68,7 +67,7 @@ export interface RunOptions extends Options {
 }
 
 function runFile(path: any, transformer: Transformer, options?: RunOptions) {
-  fs.readFile(path, "utf-8", function(err, code) {
+  fs.readFile(path, "utf-8", function (err, code) {
     if (err) {
       console.error(err);
       return;
@@ -82,9 +81,13 @@ function defaultWriteback(output: string) {
   process.stdout.write(output);
 }
 
-function runString(code: string, transformer: Transformer, options?: RunOptions) {
-  const writeback = options && options.writeback || defaultWriteback;
-  transformer(parse(code, options), function(node: any) {
+function runString(
+  code: string,
+  transformer: Transformer,
+  options?: RunOptions,
+) {
+  const writeback = (options && options.writeback) || defaultWriteback;
+  transformer(parse(code, options), function (node: any) {
     writeback(print(node, options).code);
   });
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "npm run lint && npm run build && npm run mocha",
     "build": "npm run clean && tsc",
     "lint": "eslint --ext .ts .",
-    "format": "prettier --write '{lib,test}/**.ts' '*rc.js'",
+    "format": "prettier --write .",
     "clean": "ts-emit-clean",
     "prepack": "npm run build",
     "postpack": "npm run clean"
@@ -62,7 +62,7 @@
     "glob": "7.1.6",
     "lint-staged": "^10.2.6",
     "mocha": "8.2.1",
-    "prettier": "^2.0.5",
+    "prettier": "2.2.1",
     "reify": "0.20.12",
     "ts-emit-clean": "1.0.0",
     "typescript": "^3.9.7"

--- a/parsers/_babel_options.ts
+++ b/parsers/_babel_options.ts
@@ -6,7 +6,9 @@ export type Overrides = Partial<{
   strictMode: ParserOptions["strictMode"];
 }>;
 
-export default function getBabelOptions(options?: Overrides): ParserOptions & { plugins: ParserPlugin[] } {
+export default function getBabelOptions(
+  options?: Overrides,
+): ParserOptions & { plugins: ParserPlugin[] } {
   // The goal here is to tolerate as much syntax as possible, since Recast
   // is not in the business of forbidding anything. If you want your
   // parser to be more restrictive for some reason, you can always pass
@@ -28,7 +30,7 @@ export default function getBabelOptions(options?: Overrides): ParserOptions & { 
       "doExpressions",
       "dynamicImport",
       "exportDefaultFrom",
-      "exportExtensions" as any as ParserPlugin,
+      ("exportExtensions" as any) as ParserPlugin,
       "exportNamespaceFrom",
       "functionBind",
       "functionSent",
@@ -38,8 +40,8 @@ export default function getBabelOptions(options?: Overrides): ParserOptions & { 
       "objectRestSpread",
       "optionalCatchBinding",
       "optionalChaining",
-      ["pipelineOperator", { proposal: "minimal" }] as any as ParserPlugin,
+      (["pipelineOperator", { proposal: "minimal" }] as any) as ParserPlugin,
       "throwExpressions",
-    ]
+    ],
   };
-};
+}

--- a/parsers/acorn.ts
+++ b/parsers/acorn.ts
@@ -21,13 +21,13 @@ export function parse(source: string, options?: any) {
     onToken: tokens,
   });
 
-  if (! ast.comments) {
+  if (!ast.comments) {
     ast.comments = comments;
   }
 
-  if (! ast.tokens) {
+  if (!ast.tokens) {
     ast.tokens = tokens;
   }
 
   return ast;
-};
+}

--- a/parsers/babel.ts
+++ b/parsers/babel.ts
@@ -5,13 +5,13 @@ type BabelParser = { parse: typeof babelParse };
 
 // Prefer the new @babel/parser package, but fall back to babylon if
 // that's what's available.
-export const parser = function (): BabelParser {
+export const parser = (function (): BabelParser {
   try {
     return require("@babel/parser");
   } catch (e) {
     return require("babylon");
   }
-}();
+})();
 
 // This module is suitable for passing as options.parser when calling
 // recast.parse to process JavaScript code with Babel:
@@ -24,4 +24,4 @@ export function parse(source: string, options?: Overrides) {
   const babelOptions = getBabelOptions(options);
   babelOptions.plugins.push("jsx", "flow");
   return parser.parse(source, babelOptions);
-};
+}

--- a/parsers/esprima.ts
+++ b/parsers/esprima.ts
@@ -19,7 +19,7 @@ export function parse(source: string, options?: any) {
     range: getOption(options, "range", false),
     tolerant: getOption(options, "tolerant", true),
     tokens: true,
-    jsx: getOption(options, "jsx", false)
+    jsx: getOption(options, "jsx", false),
   });
 
   if (!Array.isArray(ast.comments)) {
@@ -27,4 +27,4 @@ export function parse(source: string, options?: any) {
   }
 
   return ast;
-};
+}

--- a/parsers/flow.ts
+++ b/parsers/flow.ts
@@ -12,4 +12,4 @@ export function parse(source: string, options?: Overrides) {
   const babelOptions = getBabelOptions(options);
   babelOptions.plugins.push("jsx", "flow");
   return parser.parse(source, babelOptions);
-};
+}

--- a/parsers/typescript.ts
+++ b/parsers/typescript.ts
@@ -12,4 +12,4 @@ export function parse(source: string, options?: Overrides) {
   const babelOptions = getBabelOptions(options);
   babelOptions.plugins.push("typescript");
   return parser.parse(source, babelOptions);
-};
+}

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1669,12 +1669,8 @@ describe("printer", function () {
 
   it("prints chained expression elements", function () {
     const node = b.chainExpression(
-      b.memberExpression(
-        b.identifier("foo"),
-        b.identifier("bar"),
-        false
-      ),
-    )
+      b.memberExpression(b.identifier("foo"), b.identifier("bar"), false),
+    );
 
     assert.strictEqual(recast.print(node).code, "foo.bar");
   });
@@ -1685,9 +1681,9 @@ describe("printer", function () {
         b.identifier("foo"),
         b.identifier("bar"),
         false,
-        true
+        true,
       ),
-    )
+    );
 
     assert.strictEqual(recast.print(node).code, "foo?.bar");
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,5 @@
     "importHelpers": true,
     "stripInternal": true
   },
-  "exclude": [
-    "node_modules",
-    "test/data"
-  ]
+  "exclude": ["node_modules", "test/data"]
 }


### PR DESCRIPTION
- pin Prettier's version in `package.json` (see https://prettier.io/docs/en/install.html)
- make `npm run format` format more files, not only `lib` and `test`
- run reformat

Also I noticed lint-staged is installed and configured, but husky isn't installed. lint-staged doesn't work without husky. Should I remove lint-staged?