### PR TITLE
Fix parenthesis missing

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -8,6 +8,7 @@ const isNumber = types.builtInTypes.number;
 
 const PRECEDENCE: any = {};
 [
+  ["??"],
   ["||"],
   ["&&"],
   ["|"],

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1136,6 +1136,31 @@ describe("printer", function () {
     assert.strictEqual(pretty, code);
   });
 
+  it("adds parenthesis around nullish expression, when nullish expression is BinaryExpression's child", function () {
+    const code = "let a = (c?.b ?? 1) + 1;";
+
+    const b = recast.types.builders;
+
+    const ast = b.variableDeclaration("let", [
+      b.variableDeclarator(
+        b.identifier("a"),
+        b.binaryExpression(
+          "+",
+          b.logicalExpression(
+            "??",
+            b.optionalMemberExpression(b.identifier("c"), b.identifier("b")),
+            b.numericLiteral(1),
+          ),
+          b.numericLiteral(1),
+        ),
+      ),
+    ]);
+
+    const printer = new Printer();
+    const pretty = printer.printGenerically(ast).code;
+    assert.strictEqual(pretty, code);
+  });
+
   it("prints class property initializers with type annotations correctly", function () {
     const code = ["class A {", "  foo = (a: b): void => {};", "}"].join(eol);
 
@@ -1669,12 +1694,8 @@ describe("printer", function () {
 
   it("prints chained expression elements", function () {
     const node = b.chainExpression(
-      b.memberExpression(
-        b.identifier("foo"),
-        b.identifier("bar"),
-        false
-      ),
-    )
+      b.memberExpression(b.identifier("foo"), b.identifier("bar"), false),
+    );
 
     assert.strictEqual(recast.print(node).code, "foo.bar");
   });
@@ -1685,9 +1706,9 @@ describe("printer", function () {
         b.identifier("foo"),
         b.identifier("bar"),
         false,
-        true
+        true,
       ),
-    )
+    );
 
     assert.strictEqual(recast.print(node).code, "foo?.bar");
   });


### PR DESCRIPTION
Parentheses are missing,
when BinaryExpression child is nullish expression

Resolve #890