### PR TITLE
Typescript parser to support JSX

### DIFF
--- a/parsers/typescript.ts
+++ b/parsers/typescript.ts
@@ -10,6 +10,6 @@ import getBabelOptions, { Overrides } from "./_babel_options";
 //
 export function parse(source: string, options?: Overrides) {
   const babelOptions = getBabelOptions(options);
-  babelOptions.plugins.push("typescript");
+  babelOptions.plugins.push("typescript", "jsx");
   return parser.parse(source, babelOptions);
 };


### PR DESCRIPTION
The Typescript parser is currently unable to parse JSX elements. 

Repro: [Codesandbox](https://codesandbox.io/s/old-firefly-yqdfh?file=/src/index.js) 

This is because the `jsx` babel plugin has not been added to the babel plugin array. 

**note:** I'm not sure if we should be using the [isTSX](https://babeljs.io/docs/en/babel-plugin-transform-typescript#istsx) option instead/as well as the `jsx` plugin


Related: https://github.com/fkling/astexplorer/issues/460

