### PR TITLE
Print FunctionTypeAnnotation.typeParameters

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1746,9 +1746,12 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         parts.push(": ");
       }
 
-      const needsParens = n.params.length !== 1 || n.params[0].name;
+      const hasTypeParameters = !!n.typeParameters;
+      const needsParens =
+        hasTypeParameters || n.params.length !== 1 || n.params[0].name;
 
       parts.push(
+        hasTypeParameters ? path.call(print, "typeParameters") : "",
         needsParens ? "(" : "",
         printFunctionParams(path, options, print),
         needsParens ? ")" : "",

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -118,6 +118,7 @@ describe("type syntax", function () {
     // Generic
     check("var a: Array<Foo>;");
     check("var a: number[];");
+    check("var a: <T>() => T;");
 
     // Return types
     check("function a(): number {}");


### PR DESCRIPTION
Fixes #960
Print `<T>` of a function type annotation like `<T>(t:T) => T`.