### PR TITLE
Update source map example to use less misleading file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ All you have to think about is how to manipulate the syntax tree, and Recast wil
 var result = recast.print(transform(recast.parse(source, {
   sourceFileName: "source.js"
 })), {
-  sourceMapName: "map.json"
+  sourceMapName: "source.min.js"
 });
     
 console.log(result.code); // Resulting string of code.


### PR DESCRIPTION
Fixes #76. See discussion in that issue.

I chose `source.min.js` as a hopefully obvious target name, since that's the context where source maps are used most often. I guess `target.js` could also have been a good name too.