### PR TITLE
WIP: Fix https://github.com/benjamn/recast/issues/831

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.d.ts
 # Except...
 !/types/**/*.d.ts
+.idea

--- a/lib/lines.ts
+++ b/lib/lines.ts
@@ -82,13 +82,8 @@ export class Lines {
     const sourcesToContents: any = {};
 
     targetLines.mappings.forEach(function (mapping: any) {
-      const sourceCursor =
-        mapping.sourceLines.skipSpaces(mapping.sourceLoc.start) ||
-        mapping.sourceLines.lastPos();
-
-      const targetCursor =
-        targetLines.skipSpaces(mapping.targetLoc.start) ||
-        targetLines.lastPos();
+      const sourceCursor = mapping.sourceLines.lastPos();
+      const targetCursor = targetLines.lastPos();
 
       while (
         comparePos(sourceCursor, mapping.sourceLoc.end) < 0 &&


### PR DESCRIPTION
Removing the `skipSpaces` optimization from the `Lines.getSourceMap` method does fix https://github.com/benjamn/recast/issues/831. [This test](https://github.com/GianlucaGuarini/recast/blob/3d9f488229e38e85994ccd7d4aa413d04fbe9dd7/test/mapping.ts#L81-L85) should be manually updated and it would be great if you could let me know if my patch goes into the right direction.