### PR TITLE
Babel-like `retainLines` printer option

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -351,7 +351,7 @@ FPp.needsParens = function (assumeExpressionContext) {
     parent.type === "ParenthesizedExpression" ||
     (node.extra && node.extra.parenthesized)
   ) {
-    return false;
+    return true;
   }
 
   switch (node.type) {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -29,6 +29,13 @@ export interface Options extends DeprecatedOptions {
   useTabs?: boolean;
 
   /**
+   * If you want the pretty-printer to match line numbers with the original
+   * source, make this option true.
+   * @default false
+   */
+  retainLines?: boolean;
+
+  /**
    * The reprinting code leaves leading whitespace untouched unless it has
    * to reindent a line, or you pass false for this option.
    * @default true
@@ -168,6 +175,7 @@ const defaults: Options = {
   parser: require("../parsers/esprima"),
   tabWidth: 4,
   useTabs: false,
+  retainLines: false,
   reuseWhitespace: true,
   lineTerminator: require("os").EOL || "\n",
   wrapColumn: 74, // Aspirational for now.
@@ -202,6 +210,7 @@ export function normalize(opts?: Options): NormalizedOptions {
   return {
     tabWidth: +get("tabWidth"),
     useTabs: !!get("useTabs"),
+    retainLines: !!get("retainLines"),
     reuseWhitespace: !!get("reuseWhitespace"),
     lineTerminator: get("lineTerminator"),
     wrapColumn: Math.max(get("wrapColumn"), 0),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@agoric/recast",
-  "version": "0.20.10",
+  "name": "recast",
+  "version": "0.20.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@agoric/recast",
-      "version": "0.20.10",
+      "name": "recast",
+      "version": "0.20.5",
       "license": "MIT",
       "dependencies": {
         "ast-types": "agoric-labs/ast-types#Agoric-built",
@@ -3630,7 +3630,7 @@
     },
     "node_modules/ast-types": {
       "version": "0.15.2",
-      "resolved": "git+ssh://git@github.com/agoric-labs/ast-types.git#a2604e3d9ea8344952bff1cb9edca521d28f0c60",
+      "resolved": "git+ssh://git@github.com/agoric-labs/ast-types.git#258b7d6a4be531569352aedb00f767e6d1f754d2",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
@@ -10319,7 +10319,7 @@
       "dev": true
     },
     "ast-types": {
-      "version": "git+ssh://git@github.com/agoric-labs/ast-types.git#a2604e3d9ea8344952bff1cb9edca521d28f0c60",
+      "version": "git+ssh://git@github.com/agoric-labs/ast-types.git#258b7d6a4be531569352aedb00f767e6d1f754d2",
       "from": "ast-types@agoric-labs/ast-types#Agoric-built",
       "requires": {
         "tslib": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "recast",
-  "version": "0.20.5",
+  "name": "@agoric/recast",
+  "version": "0.20.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.20.5",
+      "name": "@agoric/recast",
+      "version": "0.20.10",
       "license": "MIT",
       "dependencies": {
-        "ast-types": "0.14.2",
+        "ast-types": "agoric-labs/ast-types#Agoric-built",
         "esprima": "~4.0.0",
         "source-map": "~0.6.1",
         "tslib": "^2.0.1"
@@ -3628,9 +3629,9 @@
       }
     },
     "node_modules/ast-types": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
-      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "version": "0.15.2",
+      "resolved": "git+ssh://git@github.com/agoric-labs/ast-types.git#a2604e3d9ea8344952bff1cb9edca521d28f0c60",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -10318,9 +10319,8 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
-      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+      "version": "git+ssh://git@github.com/agoric-labs/ast-types.git#a2604e3d9ea8344952bff1cb9edca521d28f0c60",
+      "from": "ast-types@agoric-labs/ast-types#Agoric-built",
       "requires": {
         "tslib": "^2.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Ben Newman <bn@cs.stanford.edu>",
-  "name": "@agoric/recast",
-  "version": "0.20.10",
+  "name": "recast",
+  "version": "0.20.5",
   "description": "JavaScript syntax tree transformer, nondestructive pretty-printer, and automatic source map generator",
   "keywords": [
     "ast",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "author": "Ben Newman <bn@cs.stanford.edu>",
-  "name": "recast",
+  "name": "@agoric/recast",
   "version": "0.20.5",
   "description": "JavaScript syntax tree transformer, nondestructive pretty-printer, and automatic source map generator",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Ben Newman <bn@cs.stanford.edu>",
   "name": "@agoric/recast",
-  "version": "0.20.8",
+  "version": "0.20.10",
   "description": "JavaScript syntax tree transformer, nondestructive pretty-printer, and automatic source map generator",
   "keywords": [
     "ast",
@@ -42,7 +42,7 @@
     "fs": false
   },
   "dependencies": {
-    "ast-types": "file:./agoric-ast-types-v0.14.2.tgz",
+    "ast-types": "agoric-labs/ast-types#Agoric-built",
     "esprima": "~4.0.0",
     "source-map": "~0.6.1",
     "tslib": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Ben Newman <bn@cs.stanford.edu>",
   "name": "@agoric/recast",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "description": "JavaScript syntax tree transformer, nondestructive pretty-printer, and automatic source map generator",
   "keywords": [
     "ast",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Ben Newman <bn@cs.stanford.edu>",
   "name": "@agoric/recast",
-  "version": "0.20.6",
+  "version": "0.20.8",
   "description": "JavaScript syntax tree transformer, nondestructive pretty-printer, and automatic source map generator",
   "keywords": [
     "ast",
@@ -42,7 +42,7 @@
     "fs": false
   },
   "dependencies": {
-    "ast-types": "0.14.2",
+    "ast-types": "file:./agoric-ast-types-v0.14.2.tgz",
     "esprima": "~4.0.0",
     "source-map": "~0.6.1",
     "tslib": "^2.0.1"


### PR DESCRIPTION
This is a minimum-hack-only implementation of `options.retainLines`, in the hopes it will be useful someday to actually finish the feature.

It currently only works for top-level statements, not anything nested.
