### PR TITLE
Print class property definite assignment assertions

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1449,6 +1449,10 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         parts.push("?");
       }
 
+      if (n.definite) {
+        parts.push("!");
+      }
+
       if (n.typeAnnotation) {
         parts.push(path.call(print, "typeAnnotation"));
       }

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1206,6 +1206,33 @@ describe("printer", function () {
     assert.strictEqual(pretty, code);
   });
 
+  it("prints 'definite' ClassProperty correctly", function () {
+    const code = ["class A {", "  foo!: string;", "}"].join(eol);
+
+    const ast = b.program([
+      b.classDeclaration(
+        b.identifier("A"),
+        b.classBody([
+          Object.assign(
+            b.classProperty(
+              b.identifier("foo"),
+              null,
+              b.typeAnnotation(b.stringTypeAnnotation()),
+            ),
+            { definite: true },
+          ),
+        ]),
+      ),
+    ]);
+
+    const printer = new Printer({
+      tabWidth: 2,
+    });
+
+    const pretty = printer.printGenerically(ast).code;
+    assert.strictEqual(pretty, code);
+  });
+
   it("prints static ClassProperty correctly", function () {
     const code = ["class A {", "  static foo = Bar;", "}"].join(eol);
 


### PR DESCRIPTION
Resolves #1012

This PR makes the printer aware of `definite` property in `ClassProperty` AST node, printing `!` when `true`