### PR TITLE
Fix pretty-printing strings with \u2028 or \u2029

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -3086,19 +3086,25 @@ function getPossibleRaw(node:
   }
 }
 
+function jsSafeStringify(str: string) {
+  return JSON.stringify(str).replace(/[\u2028\u2029]/g, function (m) {
+    return "\\u" + m.charCodeAt(0).toString(16);
+  });
+}
+
 function nodeStr(str: string, options: any) {
   isString.assert(str);
   switch (options.quote) {
     case "auto": {
-      const double = JSON.stringify(str);
-      const single = swapQuotes(JSON.stringify(swapQuotes(str)));
+      const double = jsSafeStringify(str);
+      const single = swapQuotes(jsSafeStringify(swapQuotes(str)));
       return double.length > single.length ? single : double;
     }
     case "single":
-      return swapQuotes(JSON.stringify(swapQuotes(str)));
+      return swapQuotes(jsSafeStringify(swapQuotes(str)));
     case "double":
     default:
-      return JSON.stringify(str);
+      return jsSafeStringify(str);
   }
 }
 

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -660,6 +660,22 @@ describe("printer", function () {
     );
   });
 
+  it("pretty-prints U+2028 and U+2029 as Unicode escapes", function () {
+    const ast = parse('"\\u2028";');
+    const printer = new Printer();
+    assert.strictEqual(
+      printer.printGenerically(ast).code,
+      '"\\u2028";',
+    );
+
+    const ast2 = parse('"\\u2029";');
+    const printer2 = new Printer();
+    assert.strictEqual(
+      printer2.printGenerically(ast2).code,
+      '"\\u2029";',
+    );
+  });
+
   it("should print block comments at head of class once", function () {
     // Given.
     const ast = parse(


### PR DESCRIPTION
These two characters are considered ordinary characters by JSON but line
terminators by ECMAScript (prior to ES2019).  When pretty-printing a
string containing either character, JSON.stringify leaves it unescaped.
The result in recast.prettyPrint is that fromString, which follows
ECMAScript definitions, converts it mistakenly to a newline character.

Escaping these characters manually when the intent is to generate
ECMAScript (rather than JSON) eliminates the problem.