### PR TITLE
Parenthesize function at start of sequence

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -643,9 +643,11 @@ FPp.firstInStatement = function () {
       return true;
     }
 
+    // s[i + 1] and s[i + 2] represent the array between the parent
+    // SequenceExpression node and its child nodes
     if (
       n.SequenceExpression.check(parent) &&
-      parentName === "expressions" &&
+      s[i + 1] === "expressions" &&
       childName === 0
     ) {
       assert.strictEqual(parent.expressions[0], child);

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -338,6 +338,10 @@ describe("parens", function () {
     check("(function (){})()");
   });
 
+  it("should be added to function expressions at start of sequence", function () {
+    check("(function (){})(), 0");
+  });
+
   it("issues #504 and #512", function () {
     check("() => ({})['foo']");
     check("() => ({ foo: 123 }[foo] + 2) * 3");


### PR DESCRIPTION
The firstInStatement function was missing the first child of a
SequenceExpression because it needs to check both the type of the parent
*node* and the name of the parent *path element*, which are not the same
in this case.

This fix is a "minimal change" style; it should be correct even if it's
not beautiful.  A cleaner fix would probably involve changing the way
the loop finds nodes.