### PR TITLE
Test/ambient context

### DIFF
--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -273,7 +273,7 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
 
     check(["export interface S {", "  i(j: string): boolean;", "}"]);
 
-    check(["declare namespace D3 {", "  export const f: number = 2;", "}"]);
+    check(["declare namespace D3 {", "  export const f: number;", "}"]);
 
     check(["declare function foo<K, V>(arg: T = getDefault()): R"]);
 


### PR DESCRIPTION
When you update **@babel/parser** to latest version you will see broken tests:

<img width="774" alt="image" src="https://user-images.githubusercontent.com/1573141/160904869-03ecee24-a861-418e-bb4d-a6227c2d3acb.png">

This is related to next code:

```ts
declare namespace D3 {
  export const f: number = 2;
}
```

It has an error and should not [contain implementation](https://stackoverflow.com/questions/26946495/what-means-ambient-in-typescript):

```ts
declare namespace D3 {
  export const f: number;
}
```

Here is the same error in [TypeScript Playground](https://www.typescriptlang.org/play?#code/CYUwxgNghgTiAEA7KBbEBnADlMCAiAzPAN4BQ88IAHpgPYwAu8Yti6TAZgFxICuKAIxAx4AXngAmANykAvqVJA).