### PR TITLE
Support Flow "declare class" fully: type parameters, "extends", "implements"

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1663,12 +1663,33 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return concat(parts);
 
     case "DeclareClass":
-      return printFlowDeclaration(path, [
-        "class ",
-        path.call(print, "id"),
-        " ",
-        path.call(print, "body"),
-      ]);
+      parts.push("class");
+
+      if (n.id) {
+        parts.push(" ", path.call(print, "id"));
+      }
+
+      if (n.typeParameters) {
+        parts.push(path.call(print, "typeParameters"));
+      }
+
+      if (n.extends && n.extends.length > 0) {
+        parts.push(
+          " extends ",
+          fromString(", ").join(path.map(print, "extends")),
+        );
+      }
+
+      if (n["implements"] && n["implements"].length > 0) {
+        parts.push(
+          " implements ",
+          fromString(", ").join(path.map(print, "implements")),
+        );
+      }
+
+      parts.push(" ", path.call(print, "body"));
+
+      return printFlowDeclaration(path, parts);
 
     case "DeclareFunction":
       return printFlowDeclaration(path, [

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -155,6 +155,12 @@ describe("type syntax", function () {
     check("declare function foo(c: (e: Event) => void, b: B): void;");
     check("declare function foo(c: C, d?: Array<D>): void;");
     check("declare class C { x: string }");
+    check("declare class A<X> extends B<X[]> { x: X }");
+    check(
+      "declare class A extends B implements I<string>, J {}",
+      flowParserParseOptions,
+    );
+
     check(
       "declare module M {" +
         eol +


### PR DESCRIPTION
And add test cases.

The first commit does this by basically copying from the "ClassDeclaration" case.

But there's so much in common between them -- it'd be nice to share most of this logic. Otherwise, as this breakage demonstrates, it's easy for one of them to lag behind in getting a feature the other has. So in the second commit, we unify the handling of "DeclareClass" (used for Flow "declare class …") with "ClassDeclaration" and "ClassExpression", which are already unified with each other.

The "implements" property on "DeclareClass" isn't yet known to ast-types -- I'll send a PR there for that. But it's already emitted by flow-parser, so the round-trip tests already work.
