### PR TITLE
Fix parenthesis missing

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -8,6 +8,7 @@ const isNumber = types.builtInTypes.number;
 
 const PRECEDENCE: any = {};
 [
+  ["??"],
   ["||"],
   ["&&"],
   ["|"],

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1148,6 +1148,31 @@ describe("printer", function () {
     assert.strictEqual(pretty, code);
   });
 
+  it("adds parenthesis around nullish expression, when nullish expression is BinaryExpression's child", function () {
+    const code = "let a = (c?.b ?? 1) + 1;";
+
+    const b = recast.types.builders;
+
+    const ast = b.variableDeclaration("let", [
+      b.variableDeclarator(
+        b.identifier("a"),
+        b.binaryExpression(
+          "+",
+          b.logicalExpression(
+            "??",
+            b.optionalMemberExpression(b.identifier("c"), b.identifier("b")),
+            b.numericLiteral(1),
+          ),
+          b.numericLiteral(1),
+        ),
+      ),
+    ]);
+
+    const printer = new Printer();
+    const pretty = printer.printGenerically(ast).code;
+    assert.strictEqual(pretty, code);
+  });
+
   it("prints class property initializers with type annotations correctly", function () {
     const code = ["class A {", "  foo = (a: b): void => {};", "}"].join(eol);
 


### PR DESCRIPTION
Parentheses are missing,
when BinaryExpression child is nullish expression

_(Closes #896, which I cannot edit for some reason)_