### PR TITLE
Emit needed parens for all kinds of Flow types

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -329,13 +329,13 @@ FPp.needsParens = function (assumeExpressionContext) {
   const name = this.getName();
 
   // If the value of this path is some child of a Node and not a Node
-  // itself, then it doesn't need parentheses. Only Node objects (in fact,
-  // only Expression nodes) need parentheses.
+  // itself, then it doesn't need parentheses. Only Node objects
+  // need parentheses.
   if (this.getValue() !== node) {
     return false;
   }
 
-  // Only statements don't need parentheses.
+  // Statements don't need parentheses.
   if (n.Statement.check(node)) {
     return false;
   }
@@ -423,13 +423,6 @@ FPp.needsParens = function (assumeExpressionContext) {
           // explicit exceptions above if this proves overzealous.
           return true;
       }
-
-    case "OptionalIndexedAccessType":
-      return node.optional && parent.type === "IndexedAccessType";
-
-    case "IntersectionTypeAnnotation":
-    case "UnionTypeAnnotation":
-      return parent.type === "NullableTypeAnnotation";
 
     case "Literal":
       return (
@@ -531,6 +524,19 @@ FPp.needsParens = function (assumeExpressionContext) {
       ) {
         return true;
       }
+      break;
+
+    // Flow type nodes.
+    //
+    // (TS type nodes don't need any logic here, because they represent
+    // parentheses explicitly in the AST, with TSParenthesizedType.)
+
+    case "OptionalIndexedAccessType":
+      return node.optional && parent.type === "IndexedAccessType";
+
+    case "IntersectionTypeAnnotation":
+    case "UnionTypeAnnotation":
+      return parent.type === "NullableTypeAnnotation";
   }
 
   if (

--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -532,11 +532,81 @@ FPp.needsParens = function (assumeExpressionContext) {
     // parentheses explicitly in the AST, with TSParenthesizedType.)
 
     case "OptionalIndexedAccessType":
-      return parent.type === "IndexedAccessType";
+      switch (parent.type) {
+        case "IndexedAccessType":
+          // `(O?.['x'])['y']` is distinct from `O?.['x']['y']`.
+          return name === "objectType" && parent.objectType === node;
+        default:
+          return false;
+      }
+
+    case "IndexedAccessType":
+    case "ArrayTypeAnnotation":
+      return false;
+
+    case "NullableTypeAnnotation":
+      switch (parent.type) {
+        case "OptionalIndexedAccessType":
+        case "IndexedAccessType":
+          return name === "objectType" && parent.objectType === node;
+        case "ArrayTypeAnnotation":
+          return true;
+        default:
+          return false;
+      }
 
     case "IntersectionTypeAnnotation":
+      switch (parent.type) {
+        case "OptionalIndexedAccessType":
+        case "IndexedAccessType":
+          return name === "objectType" && parent.objectType === node;
+        case "ArrayTypeAnnotation":
+        case "NullableTypeAnnotation":
+          return true;
+        default:
+          return false;
+      }
+
     case "UnionTypeAnnotation":
-      return parent.type === "NullableTypeAnnotation";
+      switch (parent.type) {
+        case "OptionalIndexedAccessType":
+        case "IndexedAccessType":
+          return name === "objectType" && parent.objectType === node;
+        case "ArrayTypeAnnotation":
+        case "NullableTypeAnnotation":
+        case "IntersectionTypeAnnotation":
+          return true;
+        default:
+          return false;
+      }
+
+    case "FunctionTypeAnnotation":
+      switch (parent.type) {
+        case "OptionalIndexedAccessType":
+        case "IndexedAccessType":
+          return name === "objectType" && parent.objectType === node;
+
+        case "ArrayTypeAnnotation":
+        // We need parens.
+
+        // fallthrough
+        case "NullableTypeAnnotation":
+        // We don't *need* any parens here… unless some ancestor
+        // means we do, by putting a `&` or `|` on the right.
+        // Just use parens; probably more readable that way anyway.
+        // (FWIW, this agrees with Prettier's behavior.)
+
+        // fallthrough
+        case "IntersectionTypeAnnotation":
+        case "UnionTypeAnnotation":
+          // We need parens if there's another `&` or `|` after this node.
+          // For consistency, just always use parens.
+          // (FWIW, this agrees with Prettier's behavior.)
+          return true;
+
+        default:
+          return false;
+      }
   }
 
   if (

--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -532,7 +532,7 @@ FPp.needsParens = function (assumeExpressionContext) {
     // parentheses explicitly in the AST, with TSParenthesizedType.)
 
     case "OptionalIndexedAccessType":
-      return node.optional && parent.type === "IndexedAccessType";
+      return parent.type === "IndexedAccessType";
 
     case "IntersectionTypeAnnotation":
     case "UnionTypeAnnotation":

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -204,6 +204,8 @@ describe("type syntax", function () {
     check("type B = Array<string>?.[number];");
     check("type C = Obj?.['bar']['baz'];");
     check("type D = (Obj?.['bar'])['baz'];");
+    check("type C3 = Obj?.['foo']['bar']['baz'];");
+    check("type D3 = (Obj?.['foo']['bar'])['baz'];");
     check("type E = Obj?.['bar'][];");
     check("type F = Obj?.['bar'][boolean][];");
     check("type G = Obj['bar']?.[boolean][];");

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -14,6 +14,12 @@ describe("type syntax", function () {
     parser: require("flow-parser"),
   };
 
+  function checkEquiv(a: string, b: string) {
+    const aAst = parse(a, flowParserParseOptions);
+    const bAst = parse(b, flowParserParseOptions);
+    types.astNodesAreEquivalent.assert(aAst, bAst);
+  }
+
   function check(source: string, parseOptions?: any) {
     parseOptions = parseOptions || flowParserParseOptions;
     const ast1 = parse(source, parseOptions);
@@ -212,12 +218,6 @@ describe("type syntax", function () {
     check("type H = (Obj?.['bar'])[string][];");
     check("type I = Obj?.['bar']?.[string][];");
 
-    function checkEquiv(a: string, b: string) {
-      const aAst = parse(a, flowParserParseOptions);
-      const bAst = parse(b, flowParserParseOptions);
-      types.astNodesAreEquivalent.assert(aAst, bAst);
-    }
-
     // Since FastPath#needsParens does not currently add any parentheses to
     // these expressions, make sure they do not matter for parsing the AST.
 
@@ -230,5 +230,109 @@ describe("type syntax", function () {
       "type F = (Obj['bar'])?.[string][];",
       "type F = Obj['bar']?.[string][];",
     );
+  });
+
+  it("parenthesizes correctly", () => {
+    // The basic binary operators `&` and `|`.
+    // `&` binds tighter than `|`
+    check("type Num = number & (empty | mixed);"); // parens needed
+    check("type Num = number | empty & mixed;"); // equivalent to `…|(…&…)`
+
+    // Unary suffix `[]`, with the above.
+    // `[]` binds tighter than `&` or `|`
+    check("type T = (number | string)[];");
+    check("type T = number | string[];"); // a union
+    check("type T = (number & mixed)[];");
+    check("type T = number & mixed[];"); // an intersection
+
+    // Unary prefix `?`, with the above.
+    // `?` binds tighter than `&` or `|`
+    check("type T = ?(A & B);");
+    check("type T = ?(A | B);");
+    // `?` binds less tightly than `[]`
+    check("type T = (?number)[];"); // array of nullable
+    check("type T = ?number[];"); // nullable of array
+
+    // (Optional) indexed-access types, with the above.
+    // `[…]` and `?.[…]` bind (their left) tighter than either `&` or `|`
+    check("type T = (O & P)['x'];");
+    check("type T = (O | P)['x'];");
+    check("type T = (O & P)?.['x'];");
+    check("type T = (O | P)?.['x'];");
+    // `[…]` and `?.[…]` bind (their left) tighter than `?`
+    check("type T = (?O)['x'];"); // indexed-access of nullable
+    check("type T = ?O['x'];"); // nullable of indexed-access
+    check("type T = (?O)?.['x'];"); // optional-indexed-access of nullable
+    check("type T = ?O?.['x'];"); // nullable of optional-indexed-access
+    // `[…]` and `?.[…]` provide brackets on their right, so skip parens:
+    check("type T = A[B & C];");
+    check("type T = A[B | C];");
+    check("type T = A[?B];");
+    check("type T = A[B[]];");
+    check("type T = A[B[C]];");
+    check("type T = A[B?.[C]];");
+    check("type T = A?.[B & C];");
+    check("type T = A?.[B | C];");
+    check("type T = A?.[?B];");
+    check("type T = A?.[B[]];");
+    check("type T = A?.[B[C]];");
+    check("type T = A?.[B?.[C]];");
+    // `[…]` and `?.[…]` interact in a nonobvious way:
+    // OptionalIndexedAccessType inside IndexedAccessType.
+    check("type T = (O?.['x']['y'])['z'];"); // indexed of optional-indexed
+    check("type T = O?.['x']['y']['z'];"); // optional-indexed throughout
+
+    return;
+    // Skip test cases involving function types, because those are currently
+    // broken in other ways.  Those will be fixed by:
+    //   https://github.com/benjamn/recast/pull/1089
+
+    // Function types.
+    // Function binds less tightly than binary operators at right:
+    check("type T = (() => number) & O;"); // an intersection
+    check("type T = (() => number) | void;"); // a union
+    check("type T = () => number | void;"); // a function
+    check("type T = (() => void)['x'];");
+    check("type T = () => void['x'];"); // a function
+    check("type T = (() => void)?.['x'];");
+    check("type T = () => void?.['x'];"); // a function
+    // … and less tightly than suffix operator:
+    check("type T = (() => void)[];"); // an array
+    check("type T = () => void[];"); // a function
+
+    // Function does bind tighter than prefix operator (how could it not?)
+    checkEquiv("type T = ?() => void;", "type T = ?(() => void);");
+    // … and tighter than `&` or `|` at left (ditto):
+    checkEquiv("type T = A | () => void;", "type T = A | (() => void);");
+    checkEquiv("type T = A & () => void;", "type T = A & (() => void);");
+    // … but we choose to insert parens anyway:
+    check("type T = ?(() => void);");
+    check("type T = A | (() => void);");
+    check("type T = A & (() => void);");
+    // We don't insert parens for the *right* operand of indexed access,
+    // though, that'd be silly (sillier than writing such a type at all?):
+    check("type T = A[() => void];");
+    check("type T = A?.[() => void];");
+
+    // Here's one reason we insert those parens we don't strictly have to:
+    // Even when the parent is something at left so that function binds
+    // tighter than it, *its* parent (or further ancestor) might be
+    // something at right that binds tighter than function.
+    // E.g., union of nullable of function:
+    check("type T = ?(() => void) | A;");
+    checkEquiv("type T = ?() => void | A;", "type T = ?() => (void | A);");
+    // … or intersection of nullable of function:
+    check("type T = ?(() => void) & A;");
+    checkEquiv("type T = ?() => void & A;", "type T = ?() => (void & A);");
+    // … or array or (optional-)indexed-access of nullable of function:
+    check("type T = ?(() => void)[];");
+    check("type T = ?(() => void)['x'];");
+    check("type T = ?(() => void)?.['x'];");
+    // … or union of intersection:
+    check("type T = A & (() => void) | B;");
+    // Or for an example beyond the grandparent: union of cubic nullable:
+    check("type T = ???(() => void) | B;");
+    // … or union of intersection of nullable:
+    check("type T = A & ?(() => void) | B;");
   });
 });

--- a/test/flow.ts
+++ b/test/flow.ts
@@ -10,15 +10,12 @@ describe("type syntax", function () {
     quote: "single",
     flowObjectCommas: false,
   });
-  const esprimaParserParseOptions = {
-    parser: require("esprima-fb"),
-  };
   const flowParserParseOptions = {
     parser: require("flow-parser"),
   };
 
   function check(source: string, parseOptions?: any) {
-    parseOptions = parseOptions || esprimaParserParseOptions;
+    parseOptions = parseOptions || flowParserParseOptions;
     const ast1 = parse(source, parseOptions);
     const code = printer.printGenerically(ast1).code;
     const ast2 = parse(code, parseOptions);
@@ -30,7 +27,7 @@ describe("type syntax", function () {
     // Import type annotations
     check("import type foo from 'foo';");
     check("import typeof foo from 'foo';");
-    check("import { type foo } from 'foo';", flowParserParseOptions);
+    check("import { type foo } from 'foo';");
 
     // Export type annotations
     check("export type { foo };");
@@ -69,9 +66,8 @@ describe("type syntax", function () {
         "  optionalNumber?: number;" +
         eol +
         "};",
-      flowParserParseOptions,
     );
-    check("type A = {| optionalNumber?: number |};", flowParserParseOptions);
+    check("type A = {| optionalNumber?: number |};");
     check(
       "type A = {|" +
         eol +
@@ -80,18 +76,14 @@ describe("type syntax", function () {
         "  optionalNumber?: number;" +
         eol +
         "|};",
-      flowParserParseOptions,
     );
 
     // Opaque types
-    check("opaque type A = B;", flowParserParseOptions);
-    check("opaque type A = B.C;", flowParserParseOptions);
-    check(
-      "opaque type A = { optionalNumber?: number };",
-      flowParserParseOptions,
-    );
-    check("opaque type A: X = B;", flowParserParseOptions);
-    check("opaque type A: X.Y = B.C;", flowParserParseOptions);
+    check("opaque type A = B;");
+    check("opaque type A = B.C;");
+    check("opaque type A = { optionalNumber?: number };");
+    check("opaque type A: X = B;");
+    check("opaque type A: X.Y = B.C;");
     check(
       "opaque type A: { stringProperty: string } = {" +
         eol +
@@ -100,10 +92,9 @@ describe("type syntax", function () {
         "  optionalNumber?: number;" +
         eol +
         "};",
-      flowParserParseOptions,
     );
-    check("opaque type A<T>: X<T> = B<T>;", flowParserParseOptions);
-    check("opaque type A<T>: X.Y<T> = B.C<T>;", flowParserParseOptions);
+    check("opaque type A<T>: X<T> = B<T>;");
+    check("opaque type A<T>: X.Y<T> = B.C<T>;");
     check(
       "opaque type A<T>: { optional?: T } = {" +
         eol +
@@ -112,7 +103,6 @@ describe("type syntax", function () {
         "  optional?: T;" +
         eol +
         "};",
-      flowParserParseOptions,
     );
 
     // Generic
@@ -163,16 +153,13 @@ describe("type syntax", function () {
         "}",
     );
 
-    check("declare opaque type A;", flowParserParseOptions);
-    check("declare opaque type A: X;", flowParserParseOptions);
-    check("declare opaque type A: X.Y;", flowParserParseOptions);
-    check(
-      "declare opaque type A: { stringProperty: string };",
-      flowParserParseOptions,
-    );
-    check("declare opaque type A<T>: X<T>;", flowParserParseOptions);
-    check("declare opaque type A<T>: X.Y<T>;", flowParserParseOptions);
-    check("declare opaque type A<T>: { property: T };", flowParserParseOptions);
+    check("declare opaque type A;");
+    check("declare opaque type A: X;");
+    check("declare opaque type A: X.Y;");
+    check("declare opaque type A: { stringProperty: string };");
+    check("declare opaque type A<T>: X<T>;");
+    check("declare opaque type A<T>: X.Y<T>;");
+    check("declare opaque type A<T>: { property: T };");
 
     // Classes
     check("class A {" + eol + "  a: number;" + eol + "}");
@@ -194,7 +181,7 @@ describe("type syntax", function () {
     check("class A<T: number> {}");
 
     // Inexact object types
-    check("type InexactFoo = { foo: number; ... };", flowParserParseOptions);
+    check("type InexactFoo = { foo: number; ... };");
     check(
       [
         "type MultiLineInexact = {",
@@ -203,26 +190,25 @@ describe("type syntax", function () {
         "  ...",
         "};",
       ].join(eol),
-      flowParserParseOptions,
     );
 
     // typeArguments
-    check("new A<string>();", flowParserParseOptions);
-    check("createPlugin<number>();", flowParserParseOptions);
+    check("new A<string>();");
+    check("createPlugin<number>();");
 
-    check("function myFunction([param1]: Params) {}", flowParserParseOptions);
+    check("function myFunction([param1]: Params) {}");
   });
 
   it("can pretty-print [Optional]IndexedAccessType AST nodes", () => {
-    check("type A = Obj?.['a'];", flowParserParseOptions);
-    check("type B = Array<string>?.[number];", flowParserParseOptions);
-    check("type C = Obj?.['bar']['baz'];", flowParserParseOptions);
-    check("type D = (Obj?.['bar'])['baz'];", flowParserParseOptions);
-    check("type E = Obj?.['bar'][];", flowParserParseOptions);
-    check("type F = Obj?.['bar'][boolean][];", flowParserParseOptions);
-    check("type G = Obj['bar']?.[boolean][];", flowParserParseOptions);
-    check("type H = (Obj?.['bar'])[string][];", flowParserParseOptions);
-    check("type I = Obj?.['bar']?.[string][];", flowParserParseOptions);
+    check("type A = Obj?.['a'];");
+    check("type B = Array<string>?.[number];");
+    check("type C = Obj?.['bar']['baz'];");
+    check("type D = (Obj?.['bar'])['baz'];");
+    check("type E = Obj?.['bar'][];");
+    check("type F = Obj?.['bar'][boolean][];");
+    check("type G = Obj['bar']?.[boolean][];");
+    check("type H = (Obj?.['bar'])[string][];");
+    check("type I = Obj?.['bar']?.[string][];");
 
     function checkEquiv(a: string, b: string) {
       const aAst = parse(a, flowParserParseOptions);


### PR DESCRIPTION
When printing a Flow type expression, we were mostly neglecting to print parentheses where they're needed. A few specific cases were covered, but many others were not.

I ran into one of those cases in practice: `A & (B | C)` was getting printed as `A & B | C`, which means something different. After looking into it, I decided to go about just fixing this whole class of issues. Turns out not to need all that much code!

This includes a thorough set of test cases, which I wrote up before writing the fix and helped me figure out what the fix should look like. If we run this PR's test cases without the fixes it makes in `lib/` (but with #1089, which enhances the test output and also fixes unrelated bugs that some of these tests would hit), the Mocha results summary is:

    parenthesizes correctly
      1) handles: type Num = number & (empty | mixed);
      ✔ handles: type Num = number | empty & mixed;
      2) handles: type T = (number | string)[];
      ✔ handles: type T = number | string[];
      3) handles: type T = (number & mixed)[];
      ✔ handles: type T = number & mixed[];
      ✔ handles: type T = ?(A & B);
      ✔ handles: type T = ?(A | B);
      4) handles: type T = (?number)[];
      ✔ handles: type T = ?number[];
      5) handles: type T = (O & P)['x'];
      6) handles: type T = (O | P)['x'];
      7) handles: type T = (O & P)?.['x'];
      8) handles: type T = (O | P)?.['x'];
      9) handles: type T = (?O)['x'];
      ✔ handles: type T = ?O['x'];
      10) handles: type T = (?O)?.['x'];
      ✔ handles: type T = ?O?.['x'];
      ✔ handles: type T = A[B & C];
      ✔ handles: type T = A[B | C];
      ✔ handles: type T = A[?B];
      ✔ handles: type T = A[B[]];
      ✔ handles: type T = A[B[C]];
      11) handles: type T = A[B?.[C]];
      ✔ handles: type T = A?.[B & C];
      ✔ handles: type T = A?.[B | C];
      ✔ handles: type T = A?.[?B];
      ✔ handles: type T = A?.[B[]];
      ✔ handles: type T = A?.[B[C]];
      ✔ handles: type T = A?.[B?.[C]];
      12) handles: type T = (O?.['x']['y'])['z'];
      ✔ handles: type T = O?.['x']['y']['z'];
      13) handles: type T = (() => number) & O;
      14) handles: type T = (() => number) | void;
      ✔ handles: type T = () => number | void;
      15) handles: type T = (() => void)['x'];
      ✔ handles: type T = () => void['x'];
      16) handles: type T = (() => void)?.['x'];
      ✔ handles: type T = () => void?.['x'];
      17) handles: type T = (() => void)[];
      ✔ handles: type T = () => void[];
      ✔ handles equivalently `type T = ?() => void;` vs. `type T = ?(() => void);`
      ✔ handles equivalently `type T = A | () => void;` vs. `type T = A | (() => void);`
      ✔ handles equivalently `type T = A & () => void;` vs. `type T = A & (() => void);`
      18) handles: type T = ?(() => void);
      19) handles: type T = A | (() => void);
      20) handles: type T = A & (() => void);
      ✔ handles: type T = A[() => void];
      ✔ handles: type T = A?.[() => void];
      21) handles: type T = ?(() => void) | A;
      ✔ handles equivalently `type T = ?() => void | A;` vs. `type T = ?() => (void | A);`
      22) handles: type T = ?(() => void) & A;
      ✔ handles equivalently `type T = ?() => void & A;` vs. `type T = ?() => (void & A);`
      23) handles: type T = ?(() => void)[];
      24) handles: type T = ?(() => void)['x'];
      25) handles: type T = ?(() => void)?.['x'];
      26) handles: type T = A & (() => void) | B;
      27) handles: type T = ???(() => void) | B;
      28) handles: type T = A & ?(() => void) | B;

Each of those numbered lines (with no ✔) is a case where the code before this PR would drop a pair of parentheses that shouldn't be dropped. For all but three of them (18, 19, 20), the resulting output wouldn't parse the same way. So the other 25 test cases represent situations where the existing code gets a wrong result.
