### PR TITLE
Fix arrow-function bodies getting excess parens

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -575,15 +575,6 @@ FPp.firstInStatement = function () {
       continue;
     }
 
-    if (
-      n.BlockStatement.check(parent) &&
-      parentName === "body" &&
-      childName === 0
-    ) {
-      assert.strictEqual(parent.body[0], child);
-      return true;
-    }
-
     if (n.ExpressionStatement.check(parent) && childName === "expression") {
       assert.strictEqual(parent.expression, child);
       return true;

--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -563,13 +563,14 @@ FPp.firstInStatement = function () {
   let childName, child;
 
   for (let i = s.length - 1; i >= 0; i -= 2) {
-    if (n.Node.check(s[i])) {
-      childName = parentName;
-      child = parent;
-      parentName = s[i - 1];
-      parent = s[i];
+    if (!n.Node.check(s[i])) {
+      continue;
     }
 
+    childName = parentName;
+    child = parent;
+    parentName = s[i - 1];
+    parent = s[i];
     if (!parent || !child) {
       continue;
     }

--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -41,7 +41,7 @@ interface FastPathType {
   hasParens(): any;
   getPrevToken(node: any): any;
   getNextToken(node: any): any;
-  needsParens(assumeExpressionContext?: boolean): any;
+  needsParens(): any;
   canBeFirstInStatement(): any;
   firstInStatement(): any;
 }
@@ -269,7 +269,7 @@ FPp.getNextToken = function (node) {
 
 // Inspired by require("ast-types").NodePath.prototype.needsParens, but
 // more efficient because we're iterating backwards through a stack.
-FPp.needsParens = function (assumeExpressionContext) {
+FPp.needsParens = function () {
   const node = this.getNode();
 
   // This needs to come before `if (!parent) { return false }` because
@@ -499,11 +499,7 @@ FPp.needsParens = function (assumeExpressionContext) {
     return containsCallExpression(node);
   }
 
-  if (
-    assumeExpressionContext !== true &&
-    !this.canBeFirstInStatement() &&
-    this.firstInStatement()
-  ) {
+  if (!this.canBeFirstInStatement() && this.firstInStatement()) {
     return true;
   }
 

--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -42,7 +42,6 @@ interface FastPathType {
   getPrevToken(node: any): any;
   getNextToken(node: any): any;
   needsParens(): any;
-  canBeFirstInStatement(): any;
   firstInStatement(): any;
 }
 
@@ -499,11 +498,14 @@ FPp.needsParens = function () {
     return containsCallExpression(node);
   }
 
-  if (!this.canBeFirstInStatement() && this.firstInStatement()) {
-    return true;
+  switch (node.type) {
+    case "FunctionExpression":
+    case "ObjectExpression":
+    case "ClassExpression":
+      return this.firstInStatement();
+    default:
+      return false;
   }
-
-  return false;
 };
 
 function isBinary(node: any) {
@@ -538,24 +540,6 @@ function containsCallExpression(node: any): any {
 
   return false;
 }
-
-FPp.canBeFirstInStatement = function () {
-  const node = this.getNode();
-
-  if (n.FunctionExpression.check(node)) {
-    return false;
-  }
-
-  if (n.ObjectExpression.check(node)) {
-    return false;
-  }
-
-  if (n.ClassExpression.check(node)) {
-    return false;
-  }
-
-  return true;
-};
 
 FPp.firstInStatement = function () {
   const s = this.stack;

--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -225,54 +225,12 @@ FPp.map = function map(callback /*, name1, name2, ... */) {
   return result;
 };
 
-// Returns true if the node at the tip of the path is wrapped with
-// parentheses, OR if the only reason the node needed parentheses was that
-// it couldn't be the first expression in the enclosing statement (see
-// FastPath#canBeFirstInStatement), and it has an opening `(` character.
-// For example, the FunctionExpression in `(function(){}())` appears to
-// need parentheses only because it's the first expression in the AST, but
-// since it happens to be preceded by a `(` (which is not apparent from
-// the AST but can be determined using FastPath#getPrevToken), there is no
-// ambiguity about how to parse it, so it counts as having parentheses,
-// even though it is not immediately followed by a `)`.
+// Returns true if the node at the tip of the path is preceded by an
+// open-paren token `(`.
 FPp.hasParens = function () {
   const node = this.getNode();
-
   const prevToken = this.getPrevToken(node);
-  if (!prevToken) {
-    return false;
-  }
-
-  const nextToken = this.getNextToken(node);
-  if (!nextToken) {
-    return false;
-  }
-
-  if (prevToken.value === "(") {
-    if (nextToken.value === ")") {
-      // If the node preceded by a `(` token and followed by a `)` token,
-      // then of course it has parentheses.
-      return true;
-    }
-
-    // If this is one of the few Expression types that can't come first in
-    // the enclosing statement because of parsing ambiguities (namely,
-    // FunctionExpression, ObjectExpression, and ClassExpression) and
-    // this.firstInStatement() returns true, and the node would not need
-    // parentheses in an expression context because this.needsParens(true)
-    // returns false, then it just needs an opening parenthesis to resolve
-    // the parsing ambiguity that made it appear to need parentheses.
-    const justNeedsOpeningParen =
-      !this.canBeFirstInStatement() &&
-      this.firstInStatement() &&
-      !this.needsParens(true);
-
-    if (justNeedsOpeningParen) {
-      return true;
-    }
-  }
-
-  return false;
+  return prevToken && prevToken.value === "(";
 };
 
 FPp.getPrevToken = function (node) {

--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -580,14 +580,14 @@ FPp.firstInStatement = function () {
       return true;
     }
 
-    if (n.AssignmentExpression.check(parent) && childName === "left") {
-      assert.strictEqual(parent.left, child);
-      return true;
-    }
-
     if (n.ArrowFunctionExpression.check(parent) && childName === "body") {
       assert.strictEqual(parent.body, child);
       return true;
+    }
+
+    if (n.AssignmentExpression.check(parent) && childName === "left") {
+      assert.strictEqual(parent.left, child);
+      continue;
     }
 
     // s[i + 1] and s[i + 2] represent the array between the parent

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -188,6 +188,25 @@ describe("parens", function () {
     check("const x = class { static f() { return 3; } }.f()");
   });
 
+  describe("ExpressionBody", () => {
+    // We need parens if an ExpressionBody starts with an ObjectExpression:
+    check("() => ({ x: 1 })"); // ExpressionBody, with an object literal
+    check("() => { x: 1 }"); // FunctionBody, with statement labelled "x"
+
+    // But we don't for other kinds of nodes -- even some that *would* need
+    // parens if they were the start of an ExpressionStatement.
+
+    // Issue #914: FunctionExpression at start of ExpressionBody
+    check("const e = () => function(g, h) { return i; };");
+    check("() => function(){}");
+    check("() => function(){}.call(this)");
+
+    // Issue #1082: ClassExpression at start of ExpressionBody
+    check("const D = (C) => class extends C {};");
+    check("() => class {}");
+    check("() => class {}.prototype");
+  });
+
   it("ReprintedParens", function () {
     const code = "a(function g(){}.call(this));";
     const ast1 = parse(code);

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -183,6 +183,11 @@ describe("parens", function () {
     check("function* test () { yield yield foo }");
   });
 
+  describe("ClassExpression", function () {
+    check("(class { static f() { return 3; } }).f()");
+    check("const x = class { static f() { return 3; } }.f()");
+  });
+
   it("ReprintedParens", function () {
     const code = "a(function g(){}.call(this));";
     const ast1 = parse(code);

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -183,16 +183,6 @@ describe("parens", function () {
     check("function* test () { yield yield foo }");
   });
 
-  describe("ArrowFunctionExpression", () => {
-    check("(() => {})()");
-    check("test(() => {})");
-
-    check("(() => {}).test");
-    check("test[() => {}]");
-
-    check("(() => {}) + (() => {})");
-  });
-
   it("ReprintedParens", function () {
     const code = "a(function g(){}.call(this));";
     const ast1 = parse(code);

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -188,6 +188,21 @@ describe("parens", function () {
     check("const x = class { static f() { return 3; } }.f()");
   });
 
+  describe("let-bracket ambiguity", () => {
+    // Test the `let [` lookahead constraint of:
+    //   https://tc39.es/ecma262/#prod-ExpressionStatement
+
+    // This prints "[5]" (try it!).  A MemberExpression `let [x]` appears twice.
+    check("{var let = [[3]], x = 0; (let [x] = [5]); console.log(let [x])}");
+
+    // This prints "[3]".  The first `let [x]` starts a LexicalDeclaration.
+    check("{var let = [[3]], x = 0; {let [x] = [5];} console.log(let [x])}");
+
+    // Focussing in on the key statements:
+    check("(let [x] = [5])"); // ExpressionStatement, with MemberExpression
+    check("let [x] = [5]"); // LexicalDeclaration
+  });
+
   describe("ExpressionBody", () => {
     // We need parens if an ExpressionBody starts with an ObjectExpression:
     check("() => ({ x: 1 })"); // ExpressionBody, with an object literal
@@ -205,6 +220,10 @@ describe("parens", function () {
     check("const D = (C) => class extends C {};");
     check("() => class {}");
     check("() => class {}.prototype");
+
+    // `let [` starting an ExpressionBody
+    check("() => let[x]");
+    check("() => let [x] = [5]");
   });
 
   it("ReprintedParens", function () {

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -22,7 +22,14 @@ function check_(expr: string) {
 
   const expressionAst = parseExpression(expr);
   const generic = printer.printGenerically(expressionAst).code;
-  types.astNodesAreEquivalent.assert(expressionAst, parseExpression(generic));
+
+  if (!types.astNodesAreEquivalent(expressionAst, parseExpression(generic))) {
+    throw new assert.AssertionError({
+      message: "Expected values to parse to equivalent ASTs",
+      actual: generic,
+      expected: expr,
+    });
+  }
 }
 
 function check(expr: string) {


### PR DESCRIPTION
Fixes #914.
Fixes #1082.

We were inserting parentheses unnecessarily in the bodies of some
arrow functions.  In particular, `() => function(){}` would become
`() => (function(){})`, and `() => class {}.foo.bar` would become
`() => (class {}).foo.bar`.

The cause turns out to be that we were taking the logic that
applies if you have an *expression statement* starting with a
FunctionExpression or ClassExpression -- which does indeed need
parens, to avoid getting parsed as a FunctionDeclaration or
ClassDeclaration respectively -- and applying it the same way if
one of those expressions is instead at the start of a braceless
arrow-function body, aka an ExpressionBody.

In fact, while an ExpressionBody does call for similar intervention
if it starts with a `{` token (so with an ObjectExpression node),
that is the only case where it does.

In the ES spec, this is expressed as lookahead constraints, on the
one hand at ExpressionStatement:
  https://tc39.es/ecma262/#prod-ExpressionStatement

and on the other hand at the two productions where ExpressionBody
appears:
  https://tc39.es/ecma262/#prod-ConciseBody
  https://tc39.es/ecma262/#prod-AsyncConciseBody

Adjust the logic accordingly to distinguish the two situations,
and add tests.

Then, fix the one remaining edge case in this area that comes up when looking at the spec. It's a pretty absurd case (the code we buggily emit is code that TC39 decided it was OK to completely change the meaning of when writing ES6, and you can see why), but fixing it allows us to compare our logic to the spec and conclude that it matches.

Along the way, make some refactors in the `needsParens` and `hasParens` code to support making these fixes, and some test-infrastructure improvements in `test/parens.ts`.
