### PR TITLE
Fix parens around comment at object-destructuring assignment

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -314,6 +314,13 @@ FPp.getNextToken = function (node) {
 FPp.needsParens = function (assumeExpressionContext) {
   const node = this.getNode();
 
+  // If the value of this path is some child of a Node and not a Node
+  // itself, then it doesn't need parentheses. Only Node objects (in fact,
+  // only Expression nodes) need parentheses.
+  if (this.getValue() !== node) {
+    return false;
+  }
+
   // This needs to come before `if (!parent) { return false }` because
   // an object destructuring assignment requires parens for
   // correctness even when it's the topmost expression.
@@ -327,13 +334,6 @@ FPp.needsParens = function (assumeExpressionContext) {
   const parent = this.getParentNode();
 
   const name = this.getName();
-
-  // If the value of this path is some child of a Node and not a Node
-  // itself, then it doesn't need parentheses. Only Node objects (in fact,
-  // only Expression nodes) need parentheses.
-  if (this.getValue() !== node) {
-    return false;
-  }
 
   // Only statements don't need parentheses.
   if (n.Statement.check(node)) {

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -360,6 +360,20 @@ describe("parens", function () {
     check("({ foo } = bar)");
   });
 
+  it("don't parenthesize comment (issue #575)", function () {
+    const source = "(/**/{foo} = 1)";
+    const ast = parse(source); // not esprima
+    const expressionAst = ast.program.body[0].expression;
+    const reprint = printer.print(expressionAst).code;
+    if (!types.astNodesAreEquivalent(parse(reprint), ast)) {
+      throw new assert.AssertionError({
+        message: "Expected values to parse to equivalent ASTs",
+        actual: reprint,
+        expected: source,
+      });
+    }
+  });
+
   it("regression test for issue #327", function () {
     const expr = "(function(){}())";
     check(expr);


### PR DESCRIPTION
Fixes #575.

We were taking code like the following:

    (/**/{foo} = 1)

and wrapping the comment in parens, which is invalid syntax:

    (/**/)({foo} = 1)

The symptom appears when using the default parser, but not esprima;
and only when you call the printer directly on the AST node for the
expression, not the whole program.

The bug here was that in needsParens, we check to see if `node` is
an AssignmentExpression with ObjectPattern, and if so we say that
we do need parens... but we were making that check at the very top
of the function, before we'd checked that `node` was actually the
thing we wanted to be operating on at all.

If in fact the path currently points to a comment -- as it can
when needsParens gets called by the printer invoked by the
`print(commentPath)` in printLeadingComment or printTrailingComment
-- then the comment doesn't count as a node, and so `getNode` will
actually return the parent.  If that parent meets the
AssignmentExpression / ObjectPattern condition, then we would
buggily decide that the comment needed parens too.

Fix it by checking that `node` is the actual top of the stack,
i.e. `this.getValue()`, before doing anything with `node`.
Also add a regression test.
