### PR TITLE
fix: additional commas in TsTypeLiteral

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -2186,7 +2186,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       ]);
 
     case "TSTypeLiteral": {
-      const memberLines = fromString(",\n").join(path.map(print, "members"));
+      const memberLines = fromString("\n").join(path.map(print, "members"));
 
       if (memberLines.isEmpty()) {
         return fromString("{}", options);

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -44,7 +44,7 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
       "type I = intrinsic;",
       "",
       "type J = {",
-      "  a: string,",
+      "  a: string",
       "  b?: number",
       "};",
     ]);
@@ -60,9 +60,9 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
 
     check([
       "type A<T, U> = {",
-      '  u: "cat",',
-      "  x: number,",
-      "  y: T,",
+      '  u: "cat"',
+      "  x: number",
+      "  y: T",
       "  z: U",
       "};",
     ]);
@@ -71,7 +71,7 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
       "type F = <T, U>(",
       "  a: string,",
       "  b: {",
-      "    y: T,",
+      "    y: T",
       "    z: U",
       "  }",
       ") => void;",

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -383,6 +383,25 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
       ["namespace Numbers {", "  export const five = 5;", "}"].join(eol),
     );
   });
+
+  it("TypeLiteral: unwanted comma", function () {
+    const code = [
+      "type A = {",
+      "  x: boolean;",
+      "  y: number;",
+      "  z: string;",
+      "}",
+    ].join(eol);
+
+    const ast = recast.parse(code, { parser });
+
+    ast.program.body[0].typeAnnotation.members.pop();
+
+    assert.strictEqual(
+      recast.print(ast).code,
+      ["type A = {", "  x: boolean;", "  y: number;", "}"].join(eol),
+    );
+  });
 });
 
 testReprinting(


### PR DESCRIPTION
This is very pretty similar to #868 but with `TsTypeLiteral`. We were working on a codemod that involves adding to a `type` and it was resulting in syntactically incorrect code like this (notice the `;,`):

```
type FooProps = {
  bar: string;,
  children?: React.ReactNode
}
```

We were able to `patch-package` but I figured I would make an upstream fix. Thank you!

