### PR TITLE
feature: improve support of ExportNamespaceSpecifiers

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -2919,13 +2919,13 @@ function printExportDeclaration(path: any, options: any, print: any) {
       parts.push("*");
     } else if (decl.specifiers.length === 0) {
       parts.push("{}");
-    } else if (decl.specifiers[0].type === "ExportDefaultSpecifier") {
+    } else if (/^Export(Default|Namespace)Specifier$/.test(decl.specifiers[0].type)) {
       const unbracedSpecifiers: any[] = [];
       const bracedSpecifiers: any[] = [];
 
       path.each(function (specifierPath: any) {
         const spec = specifierPath.getValue();
-        if (spec.type === "ExportDefaultSpecifier") {
+        if (/^Export(Namespace|Default)Specifier$/.test(spec.type)) {
           unbracedSpecifiers.push(print(specifierPath));
         } else {
           bracedSpecifiers.push(print(specifierPath));
@@ -2960,10 +2960,6 @@ function printExportDeclaration(path: any, options: any, print: any) {
           parts.push("{", lines, "}");
         }
       }
-    } else if (decl.specifiers[0].type === 'ExportNamespaceSpecifier') {
-      parts.push(
-        fromString(", ").join(path.map(print, "specifiers")),
-      );
     } else {
     parts.push(
       shouldPrintSpaces ? "{ " : "{",

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -2960,13 +2960,17 @@ function printExportDeclaration(path: any, options: any, print: any) {
           parts.push("{", lines, "}");
         }
       }
-    } else {
+    } else if (decl.specifiers[0].type === 'ExportNamespaceSpecifier') {
       parts.push(
-        shouldPrintSpaces ? "{ " : "{",
         fromString(", ").join(path.map(print, "specifiers")),
-        shouldPrintSpaces ? " }" : "}",
       );
-    }
+    } else {
+    parts.push(
+      shouldPrintSpaces ? "{ " : "{",
+      fromString(", ").join(path.map(print, "specifiers")),
+      shouldPrintSpaces ? " }" : "}",
+    );
+  }
 
     if (decl.source) {
       parts.push(

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "@babel/core": "7.14.8",
     "@babel/parser": "7.14.8",
     "@babel/preset-env": "7.16.11",
+    "@types/babel__template": "^7.4.1",
+    "@types/babel__traverse": "^7.18.1",
     "@types/esprima": "4.0.3",
     "@types/glob": "7.2.0",
     "@types/mocha": "8.2.0",

--- a/test/babel.ts
+++ b/test/babel.ts
@@ -474,4 +474,21 @@ describe("Babel", function () {
       'export * as fs from "xx";'
     );
   });
+
+  it("should not add curly braces in ExportNamedDeclaration used with ExportNamespaceSpecifier: couple specifiers", function () {
+    const code = 'export * as fs2, {x, y} from "fs/promises"';
+    const ast = recast.parse(code, parseOptions);
+
+    traverse(ast, {
+      ExportNamedDeclaration(path: NodePath) {
+        path.replaceWith(template.ast('export * as fs, {x, y} from "xx"') as Node);
+        path.stop();
+      }
+    })
+
+    assert.strictEqual(
+      recast.print(ast).code,
+      'export * as fs, { x, y } from "xx";'
+    );
+  });
 });

--- a/test/babel.ts
+++ b/test/babel.ts
@@ -3,6 +3,9 @@ import * as recast from "../main";
 const n = recast.types.namedTypes;
 const b = recast.types.builders;
 import { EOL as eol } from "os";
+import traverse, {NodePath, Node} from '@babel/traverse';
+import template from '@babel/template';
+
 const nodeMajorVersion = parseInt(process.versions.node, 10);
 
 describe("Babel", function () {
@@ -452,6 +455,23 @@ describe("Babel", function () {
     assert.strictEqual(
       recast.print(ast).code,
       ["class A {", "  declare public readonly x;", "}"].join(eol),
+    );
+  });
+
+  it("should not add curly braces in ExportNamedDeclaration used with ExportNamespaceSpecifier", function () {
+    const code = 'export * as fs2 from "fs/promises"';
+    const ast = recast.parse(code, parseOptions);
+
+    traverse(ast, {
+      ExportNamedDeclaration(path: NodePath) {
+        path.replaceWith(template.ast('export * as fs from "xx"') as Node);
+        path.stop();
+      }
+    })
+
+    assert.strictEqual(
+      recast.print(ast).code,
+      'export * as fs from "xx";'
     );
   });
 });


### PR DESCRIPTION
```js
 const code = 'export * as fs2 from "fs/promises"';
 const ast = recast.parse(code, parseOptions);

 traverse(ast, {
    ExportNamedDeclaration(path: NodePath) {
        path.replaceWith(template.ast('export * as fs from "xx"') as Node);
        path.stop();
    }
})

recast.print(ast).code;
// returns not valid
export {* as fs} from "xx"
```

Landed in [`@putout/recast v1.8.0`](https://github.com/putoutjs/recast/releases/tag/v1.8.0)