### PR TITLE
fix: printer: JSXText: remove trailing whitespaces

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1311,12 +1311,12 @@ function genericPrintNoParens(path: any, options: any, print: any) {
             typeof child.value === "string"
           ) {
             if (/\S/.test(child.value)) {
-              return child.value.replace(/^\s+|\s+$/g, "");
+              return child.value.replace(/^\s+/g, "");
             } else if (/\n/.test(child.value)) {
               return "\n";
             }
           }
-
+          
           return print(childPath);
         }, "children"),
       ).indentTail(options.tabWidth);

--- a/test/jsx.ts
+++ b/test/jsx.ts
@@ -3,6 +3,8 @@
 import { parse } from "../lib/parser";
 import { Printer } from "../lib/printer";
 import * as types from "ast-types";
+import assert from "assert";
+
 const nodeMajorVersion = parseInt(process.versions.node, 10);
 
 for (const { title, parser } of [
@@ -61,3 +63,35 @@ for (const { title, parser } of [
     });
   });
 }
+
+it("should not remove trailing whitespaces", function () {
+    const printer = new Printer({ tabWidth: 2 });
+    const source = 
+        'function App() {\n' +
+        '  const name = "world";\n' +
+        '\n' +
+        '  return (\n' +
+        '    <div className="app">\n' +
+        '        hello {name}\n' +
+        '    </div>\n' +
+        '  );\n' +
+        '}'
+    ;
+    
+    const ast = parse(source);
+    ast.program.body[0].body.body[1].argument.openingElement.attributes[0].name.name = 'abc';
+    
+    const code = printer.printGenerically(ast).code;
+    
+    assert.equal(
+      code,
+        'function App() {\n' +
+        '  const name = "world";\n' +
+        '\n' +
+        '  return (\n' + 
+        '    <div abc="app">hello {name}\n' +
+        '    </div>\n' +
+        '  );\n' +
+        '}'
+    );
+});


### PR DESCRIPTION
Fix #211: trailing whitespaces removed for now reason.

Landed in [@putout/recast v1.10.0](https://github.com/putoutjs/recast/releases/tag/v1.10.0).