### PR TITLE
ci: update node versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ['10.x', '12.x', '14.x', '15.x', '16.x']
+        node_version: ['12.x', '14.x', '16.x', '18.x', '19.x', '20.x']
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
10.x was EOL over two years ago, so I think it's okay to no longer test against it. Also adds 18.x, 19.x, and 20.x since they're the current releases per the NodeJS release schedule: https://github.com/nodejs/release#release-schedule.