### PR TITLE
fix: print ExportSpecifier.exportKind

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -483,6 +483,9 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return concat(parts);
 
     case "ExportSpecifier":
+      if (n.exportKind && n.exportKind !== "value") {
+        parts.push(n.exportKind + " ");
+      }
       if (n.local) {
         parts.push(path.call(print, "local"));
         if (n.exported && n.exported.name !== n.local.name) {

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -350,6 +350,12 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
       "type Blue = Color.b;",
       "type Alpha = Color.a;",
     ]);
+
+    check([
+      "type alias = boolean;",
+      "const value = 0;",
+      "export { type alias, value };"
+    ])
   });
 
   it("InterfaceBody: duplicate semicolon", function () {


### PR DESCRIPTION
This fixes a small oversight: `ExportSpecifier` supports `exportKind` in a similar fashion to `ImportSpecifier` supporting `importKind`, but the print logic was missing.

Without this change it's impossible to generate an ExportNamedDeclaration containing a mix of type and value exports.

See this [broken jscodeshift example in AST Explorer](https://astexplorer.net/#/gist/38d63e7f66c1d7a14014716483fca861/b50b4c4d23601c2f07bd634a3f9c0bd832b5d496)

This is in the spirit of changes described in the original [type-only PR for TypeScript](https://github.com/microsoft/TypeScript/pull/45998), as well as changes for [SWC in 1.2.92](https://github.com/swc-project/swc/pull/2309)