### PR TITLE
Update printer.ts to support `kind = 'get'/'set'` on `TSMethodSignature`

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -932,7 +932,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return fromString(getPossibleRaw(n) || n.value + "m", options);
 
     case "StringLiteral":
-        return fromString(nodeStr(n.value, options));
+      return fromString(nodeStr(n.value, options));
 
     case "BooleanLiteral": // Babel 6 Literal split
     case "Literal":
@@ -1474,10 +1474,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return concat(parts);
 
     case "ClassAccessorProperty": {
-      parts.push(
-        ...printClassMemberModifiers(n),
-        "accessor ",
-      );
+      parts.push(...printClassMemberModifiers(n), "accessor ");
 
       if (n.computed) {
         parts.push("[", path.call(print, "key"), "]");
@@ -2236,7 +2233,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
             return member.concat(";");
           }
           return member;
-        })
+        }),
       );
 
       if (members.isEmpty()) {
@@ -2289,8 +2286,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return concat([path.call(print, "left"), ".", path.call(print, "right")]);
 
     case "TSAsExpression":
-    case "TSSatisfiesExpression":
-    {
+    case "TSSatisfiesExpression": {
       const expression = path.call(print, "expression");
       parts.push(
         expression,
@@ -2335,10 +2331,10 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return concat(parts);
 
     case "TSMethodSignature":
-      if (n.kind === 'get') {
-        parts.push('get ')
-      } else if (n.kind === 'set') {
-        parts.push('set ')
+      if (n.kind === "get") {
+        parts.push("get ");
+      } else if (n.kind === "set") {
+        parts.push("set ");
       }
 
       if (n.computed) {
@@ -2484,7 +2480,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
             return element.concat(";");
           }
           return element;
-        })
+        }),
       );
       if (lines.isEmpty()) {
         return fromString("{}", options);
@@ -2590,7 +2586,6 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
       return concat(parts);
     }
-
 
     // https://github.com/babel/babel/pull/10148
     case "V8IntrinsicIdentifier":

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -2335,6 +2335,12 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return concat(parts);
 
     case "TSMethodSignature":
+      if (n.kind === 'get') {
+        parts.push('get ')
+      } else if (n.kind === 'set') {
+        parts.push('set ')
+      }
+
       if (n.computed) {
         parts.push("[", path.call(print, "key"), "]");
       } else {

--- a/test/babel.ts
+++ b/test/babel.ts
@@ -454,27 +454,32 @@ describe("Babel", function () {
       ["class A {", "  declare public readonly x;", "}"].join(eol),
     );
   });
-  
+
   it("should keep braces in !(a && b)", function () {
-    const code = '(options || !options.bidirectional) ? false : true;';
+    const code = "(options || !options.bidirectional) ? false : true;";
     const ast = recast.parse(code, parseOptions);
-    
-    ast.program.body[0].expression = b.unaryExpression('!', ast.program.body[0].expression.test);
+
+    ast.program.body[0].expression = b.unaryExpression(
+      "!",
+      ast.program.body[0].expression.test,
+    );
 
     assert.strictEqual(
       recast.print(ast).code,
-      '!(options || !options.bidirectional);',
+      "!(options || !options.bidirectional);",
     );
   });
 
   it("should use single quotes", function () {
-    const code = 'const a = 1;';
+    const code = "const a = 1;";
     const ast = recast.parse(code, parseOptions);
-    
-    ast.program.body.unshift(b.expressionStatement(b.stringLiteral('use strict')));
+
+    ast.program.body.unshift(
+      b.expressionStatement(b.stringLiteral("use strict")),
+    );
 
     assert.strictEqual(
-      recast.print(ast, {quote: 'single'}).code,
+      recast.print(ast, { quote: "single" }).code,
       `'use strict';\nconst a = 1;`,
     );
   });
@@ -490,9 +495,6 @@ describe("Babel", function () {
     ];
     const ast = recast.parse(code.join(eol), parseOptions);
 
-    assert.strictEqual(
-      recast.prettyPrint(ast).code,
-      code.join(eol),
-    );
+    assert.strictEqual(recast.prettyPrint(ast).code, code.join(eol));
   });
 });

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1174,11 +1174,7 @@ describe("printer", function () {
   });
 
   it("prints class property initializers with type annotations correctly", function () {
-    const code = [
-      "class A {",
-      "  foo = (a: b): void => {};",
-      "}",
-    ].join(eol);
+    const code = ["class A {", "  foo = (a: b): void => {};", "}"].join(eol);
 
     const arg = b.identifier("a");
     arg.typeAnnotation = b.typeAnnotation(
@@ -1204,11 +1200,7 @@ describe("printer", function () {
   });
 
   it("prints ClassProperty correctly", function () {
-    const code = [
-      "class A {",
-      "  foo: Type = Bar;",
-      "}",
-    ].join(eol);
+    const code = ["class A {", "  foo: Type = Bar;", "}"].join(eol);
 
     const ast = b.program([
       b.classDeclaration(
@@ -1234,11 +1226,7 @@ describe("printer", function () {
   });
 
   it("prints 'definite' ClassProperty correctly", function () {
-    const code = [
-      "class A {",
-      "  foo!: string;",
-      "}",
-    ].join(eol);
+    const code = ["class A {", "  foo!: string;", "}"].join(eol);
 
     const ast = b.program([
       b.classDeclaration(
@@ -1265,11 +1253,7 @@ describe("printer", function () {
   });
 
   it("prints static ClassProperty correctly", function () {
-    const code = [
-      "class A {",
-      "  static foo = Bar;",
-      "}",
-    ].join(eol);
+    const code = ["class A {", "  static foo = Bar;", "}"].join(eol);
 
     const ast = b.program([
       b.classDeclaration(
@@ -1289,11 +1273,7 @@ describe("printer", function () {
   });
 
   it("prints ClassAccessorProperty correctly", function () {
-    const code = [
-      "class A {",
-      "  accessor foo: Type = Bar;",
-      "}",
-    ].join(eol);
+    const code = ["class A {", "  accessor foo: Type = Bar;", "}"].join(eol);
 
     const ast = b.program([
       b.classDeclaration(
@@ -1304,8 +1284,8 @@ describe("printer", function () {
             value: b.identifier("Bar"),
             typeAnnotation: b.tsTypeAnnotation(
               b.tsTypeReference(b.identifier("Type")),
-            )
-          })
+            ),
+          }),
         ]),
       ),
     ]);
@@ -1319,11 +1299,7 @@ describe("printer", function () {
   });
 
   it("prints 'definite' ClassAccessorProperty correctly", function () {
-    const code = [
-      "class A {",
-      "  accessor foo!: string;",
-      "}",
-    ].join(eol);
+    const code = ["class A {", "  accessor foo!: string;", "}"].join(eol);
 
     const ast = b.program([
       b.classDeclaration(
@@ -1347,11 +1323,7 @@ describe("printer", function () {
   });
 
   it("prints static ClassAccessorProperty correctly", function () {
-    const code = [
-      "class A {",
-      "  static accessor foo = Bar;",
-      "}",
-    ].join(eol);
+    const code = ["class A {", "  static accessor foo = Bar;", "}"].join(eol);
 
     const ast = b.program([
       b.classDeclaration(
@@ -1375,11 +1347,7 @@ describe("printer", function () {
   });
 
   it("prints abstract ClassAccessorProperty correctly", function () {
-    const code = [
-      "class A {",
-      "  abstract accessor foo = Bar;",
-      "}",
-    ].join(eol);
+    const code = ["class A {", "  abstract accessor foo = Bar;", "}"].join(eol);
 
     const ast = b.program([
       b.classDeclaration(
@@ -1403,11 +1371,7 @@ describe("printer", function () {
   });
 
   it("prints override ClassAccessorProperty correctly", function () {
-    const code = [
-      "class A {",
-      "  override accessor foo = Bar;",
-      "}",
-    ].join(eol);
+    const code = ["class A {", "  override accessor foo = Bar;", "}"].join(eol);
 
     const ast = b.program([
       b.classDeclaration(

--- a/test/syntax.ts
+++ b/test/syntax.ts
@@ -43,7 +43,7 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
       },
     });
 
-    Object.keys(types.namedTypes).forEach(name => {
+    Object.keys(types.namedTypes).forEach((name) => {
       it(name, () => {
         assert.ok(hasOwn.call(typeNames, name), "unhandled type: " + name);
         assert.strictEqual(name, typeNames[name]);

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -252,6 +252,13 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
     ]);
 
     check([
+      "interface LabelledContainer<T> {",
+      "  get label(): string;",
+      "  set label(a: string);",
+      "}",
+    ]);
+
+    check([
       "class Button extends Control<T, U> implements SelectableControl<T, U>, ClickableControl<U> {",
       "  select() {}",
       "}",

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -285,16 +285,12 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
     check([
       "class Dog extends Animal {",
       "  protected override getSound() {",
-      "    return \"bark\";",
+      '    return "bark";',
       "  }",
       "}",
-    ])
-
-    check([
-      "export interface S {",
-      "  i(s: string): boolean;",
-      "}"
     ]);
+
+    check(["export interface S {", "  i(s: string): boolean;", "}"]);
 
     check([
       "namespace Validation {",
@@ -304,17 +300,9 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
       "}",
     ]);
 
-    check([
-      "export interface S {",
-      "  i(j: string): boolean;",
-      "}",
-    ]);
+    check(["export interface S {", "  i(j: string): boolean;", "}"]);
 
-    check([
-      "declare namespace D3 {",
-      "  export const f: number;",
-      "}",
-    ]);
+    check(["declare namespace D3 {", "  export const f: number;", "}"]);
 
     check(["declare function foo<K, V>(arg: T = getDefault()): R"]);
 
@@ -324,13 +312,7 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
       "}",
     ]);
 
-    check([
-      "function myFunction(",
-      "  {",
-      "    param1",
-      "  }: Params",
-      ") {}",
-    ]);
+    check(["function myFunction(", "  {", "    param1", "  }: Params", ") {}"]);
 
     check([
       'const unqualified: import("package") = 1;',
@@ -361,8 +343,8 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
     check([
       "type alias = boolean;",
       "const value = 0;",
-      "export { type alias, value };"
-    ])
+      "export { type alias, value };",
+    ]);
   });
 
   it("InterfaceBody: duplicate semicolon", function () {
@@ -468,11 +450,8 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
 
     const ast = recast.parse(code, { parser });
 
-    assert.strictEqual(
-      recast.prettyPrint(ast).code,
-      code
-    );
-  })
+    assert.strictEqual(recast.prettyPrint(ast).code, code);
+  });
 });
 
 testReprinting(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,5 @@
     "importHelpers": true,
     "stripInternal": true
   },
-  "exclude": [
-    "node_modules",
-    "test/data"
-  ]
+  "exclude": ["node_modules", "test/data"]
 }


### PR DESCRIPTION
`TSMethodSignature` has a `kind` property which can be set to `method` (the default), `get`, and `set`. When `get` and `set`, the method is a getter or a setter, and as such, should be prefixed with either `get ` or `set `.