### PR TITLE
refactor: replace `assert` with `tiny-invariant`

### DIFF
--- a/lib/comments.ts
+++ b/lib/comments.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import invariant from "tiny-invariant";
 import * as types from "ast-types";
 const n = types.namedTypes;
 const isArray = types.builtInTypes.array;
@@ -147,9 +147,9 @@ export function attach(comments: any[], ast: any, lines: any) {
       if (tieCount > 0) {
         const lastTie = tiesToBreak[tieCount - 1];
 
-        assert.strictEqual(
-          lastTie.precedingNode === comment.precedingNode,
-          lastTie.followingNode === comment.followingNode,
+        invariant(
+          (lastTie.precedingNode === comment.precedingNode) ===
+            (lastTie.followingNode === comment.followingNode),
         );
 
         if (lastTie.followingNode !== comment.followingNode) {
@@ -206,8 +206,8 @@ function breakTies(tiesToBreak: any[], lines: any) {
   let comment;
   for (; indexOfFirstLeadingComment > 0; --indexOfFirstLeadingComment) {
     comment = tiesToBreak[indexOfFirstLeadingComment - 1];
-    assert.strictEqual(comment.precedingNode, pn);
-    assert.strictEqual(comment.followingNode, fn);
+    invariant(comment.precedingNode === pn);
+    invariant(comment.followingNode === fn);
 
     const gap = lines.sliceString(comment.loc.end, gapEndPos);
     if (/\S/.test(gap)) {

--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import invariant from "tiny-invariant";
 import * as types from "ast-types";
 import * as util from "./util";
 
@@ -52,7 +52,7 @@ interface FastPathConstructor {
 }
 
 const FastPath = function FastPath(this: FastPathType, value: any) {
-  assert.ok(this instanceof FastPath);
+  invariant(this instanceof FastPath);
   this.stack = [value];
 } as any as FastPathConstructor;
 
@@ -402,7 +402,7 @@ FPp.needsParens = function (assumeExpressionContext) {
           }
 
           if (pp === np && name === "right") {
-            assert.strictEqual(parent.right, node);
+            invariant(parent.right === node);
             return true;
           }
 
@@ -636,22 +636,22 @@ FPp.firstInStatement = function () {
       parentName === "body" &&
       childName === 0
     ) {
-      assert.strictEqual(parent.body[0], child);
+      invariant(parent.body[0] === child);
       return true;
     }
 
     if (n.ExpressionStatement.check(parent) && childName === "expression") {
-      assert.strictEqual(parent.expression, child);
+      invariant(parent.expression === child);
       return true;
     }
 
     if (n.AssignmentExpression.check(parent) && childName === "left") {
-      assert.strictEqual(parent.left, child);
+      invariant(parent.left === child);
       return true;
     }
 
     if (n.ArrowFunctionExpression.check(parent) && childName === "body") {
-      assert.strictEqual(parent.body, child);
+      invariant(parent.body === child);
       return true;
     }
 
@@ -662,27 +662,27 @@ FPp.firstInStatement = function () {
       s[i + 1] === "expressions" &&
       childName === 0
     ) {
-      assert.strictEqual(parent.expressions[0], child);
+      invariant(parent.expressions[0] === child);
       continue;
     }
 
     if (n.CallExpression.check(parent) && childName === "callee") {
-      assert.strictEqual(parent.callee, child);
+      invariant(parent.callee === child);
       continue;
     }
 
     if (n.MemberExpression.check(parent) && childName === "object") {
-      assert.strictEqual(parent.object, child);
+      invariant(parent.object === child);
       continue;
     }
 
     if (n.ConditionalExpression.check(parent) && childName === "test") {
-      assert.strictEqual(parent.test, child);
+      invariant(parent.test === child);
       continue;
     }
 
     if (isBinary(parent) && childName === "left") {
-      assert.strictEqual(parent.left, child);
+      invariant(parent.left === child);
       continue;
     }
 
@@ -691,7 +691,7 @@ FPp.firstInStatement = function () {
       !parent.prefix &&
       childName === "argument"
     ) {
-      assert.strictEqual(parent.argument, child);
+      invariant(parent.argument === child);
       continue;
     }
 

--- a/lib/lines.ts
+++ b/lib/lines.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import invariant from "tiny-invariant";
 import sourceMap from "source-map";
 import { normalize as normalizeOptions, Options } from "./options";
 import { namedTypes } from "ast-types";
@@ -30,7 +30,7 @@ export class Lines {
   private cachedTabWidth: number | void = void 0;
 
   constructor(private infos: LineInfo[], sourceFileName: string | null = null) {
-    assert.ok(infos.length > 0);
+    invariant(infos.length > 0);
     this.length = infos.length;
     this.name = sourceFileName || null;
 
@@ -96,7 +96,7 @@ export class Lines {
       ) {
         const sourceChar = mapping.sourceLines.charAt(sourceCursor);
         const targetChar = targetLines.charAt(targetCursor);
-        assert.strictEqual(sourceChar, targetChar);
+        invariant(sourceChar === targetChar);
 
         const sourceName = mapping.sourceLines.name;
 
@@ -124,9 +124,9 @@ export class Lines {
   }
 
   bootstrapCharAt(pos: Pos) {
-    assert.strictEqual(typeof pos, "object");
-    assert.strictEqual(typeof pos.line, "number");
-    assert.strictEqual(typeof pos.column, "number");
+    invariant(typeof pos === "object");
+    invariant(typeof pos.line === "number");
+    invariant(typeof pos.column === "number");
 
     const line = pos.line,
       column = pos.column,
@@ -143,9 +143,9 @@ export class Lines {
   }
 
   charAt(pos: Pos) {
-    assert.strictEqual(typeof pos, "object");
-    assert.strictEqual(typeof pos.line, "number");
-    assert.strictEqual(typeof pos.column, "number");
+    invariant(typeof pos === "object");
+    invariant(typeof pos.line === "number");
+    invariant(typeof pos.column === "number");
 
     let line = pos.line,
       column = pos.column,
@@ -171,7 +171,7 @@ export class Lines {
   stripMargin(width: number, skipFirstLine: boolean) {
     if (width === 0) return this;
 
-    assert.ok(width > 0, "negative margin: " + width);
+    invariant(width > 0, "negative margin: " + width);
 
     if (skipFirstLine && this.length === 1) return this;
 
@@ -189,7 +189,7 @@ export class Lines {
 
     if (this.mappings.length > 0) {
       const newMappings = lines.mappings;
-      assert.strictEqual(newMappings.length, 0);
+      invariant(newMappings.length === 0);
       this.mappings.forEach(function (mapping: any) {
         newMappings.push(mapping.indent(width, skipFirstLine, true));
       });
@@ -217,7 +217,7 @@ export class Lines {
 
     if (this.mappings.length > 0) {
       const newMappings = lines.mappings;
-      assert.strictEqual(newMappings.length, 0);
+      invariant(newMappings.length === 0);
       this.mappings.forEach(function (mapping: any) {
         newMappings.push(mapping.indent(by));
       });
@@ -250,7 +250,7 @@ export class Lines {
 
     if (this.mappings.length > 0) {
       const newMappings = lines.mappings;
-      assert.strictEqual(newMappings.length, 0);
+      invariant(newMappings.length === 0);
       this.mappings.forEach(function (mapping: any) {
         newMappings.push(mapping.indent(by, true));
       });
@@ -273,7 +273,7 @@ export class Lines {
   }
 
   getIndentAt(line: number) {
-    assert.ok(line >= 1, "no line " + line + " (line numbers start from 1)");
+    invariant(line >= 1, "no line " + line + " (line numbers start from 1)");
     return Math.max(this.infos[line - 1].indent, 0);
   }
 
@@ -525,7 +525,7 @@ export class Lines {
     if (start.line === end.line) {
       sliced[0] = sliceInfo(sliced[0], start.column, end.column);
     } else {
-      assert.ok(start.line < end.line);
+      invariant(start.line < end.line);
       sliced[0] = sliceInfo(sliced[0], start.column);
       sliced.push(sliceInfo(sliced.pop(), 0, end.column));
     }
@@ -534,7 +534,7 @@ export class Lines {
 
     if (this.mappings.length > 0) {
       const newMappings = lines.mappings;
-      assert.strictEqual(newMappings.length, 0);
+      invariant(newMappings.length === 0);
       this.mappings.forEach(function (this: any, mapping: any) {
         const sliced = mapping.slice(this, start, end);
         if (sliced) {
@@ -695,7 +695,7 @@ export class Lines {
   concat(...args: (string | Lines)[]) {
     const list: typeof args = [this];
     list.push.apply(list, args);
-    assert.strictEqual(list.length, args.length + 1);
+    invariant(list.length === args.length + 1);
     return emptyLines.join(list);
   }
 }
@@ -712,8 +712,8 @@ export function countSpaces(spaces: any, tabWidth?: number) {
     switch (spaces.charCodeAt(i)) {
       case 9: {
         // '\t'
-        assert.strictEqual(typeof tabWidth, "number");
-        assert.ok(tabWidth! > 0);
+        invariant(typeof tabWidth === "number");
+        invariant(tabWidth! > 0);
 
         const next = Math.ceil(count / tabWidth!) * tabWidth!;
         if (next === count) {
@@ -761,7 +761,7 @@ export function fromString(string: string | Lines, options?: Options): Lines {
   const tabless = string.indexOf("\t") < 0;
   const cacheable = !options && tabless && string.length <= maxCacheKeyLen;
 
-  assert.ok(
+  invariant(
     tabWidth || tabless,
     "No tab width specified but encountered tabs in string\n" + string,
   );
@@ -826,9 +826,9 @@ function sliceInfo(info: any, startCol: number, endCol?: number) {
     sliceStart += startCol;
   }
 
-  assert.ok(indent >= 0);
-  assert.ok(sliceStart <= sliceEnd);
-  assert.strictEqual(lineLength, indent + sliceEnd - sliceStart);
+  invariant(indent >= 0);
+  invariant(sliceStart <= sliceEnd);
+  invariant(lineLength === indent + sliceEnd - sliceStart);
 
   if (
     info.indent === indent &&

--- a/lib/mapping.ts
+++ b/lib/mapping.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import invariant from "tiny-invariant";
 import { comparePos } from "./util";
 import { namedTypes } from "ast-types";
 import { Lines } from "./lines";
@@ -26,7 +26,7 @@ export default class Mapping {
       if (name === "end") {
         targetToPos = end;
       } else {
-        assert.strictEqual(name, "start");
+        invariant(name === "start");
       }
 
       return skipChars(
@@ -194,17 +194,16 @@ function skipChars(
       sourceCursor.column = 0;
       targetCursor.column = 0;
     } else {
-      assert.strictEqual(lineDiff, 0);
+      invariant(lineDiff === 0);
     }
 
     while (
       comparePos(targetCursor, targetToPos) < 0 &&
       targetLines.nextPos(targetCursor, true)
     ) {
-      assert.ok(sourceLines.nextPos(sourceCursor, true));
-      assert.strictEqual(
-        sourceLines.charAt(sourceCursor),
-        targetLines.charAt(targetCursor),
+      invariant(sourceLines.nextPos(sourceCursor, true));
+      invariant(
+        sourceLines.charAt(sourceCursor) === targetLines.charAt(targetCursor),
       );
     }
   } else {
@@ -224,17 +223,16 @@ function skipChars(
       sourceCursor.column = sourceLines.getLineLength(sourceCursor.line);
       targetCursor.column = targetLines.getLineLength(targetCursor.line);
     } else {
-      assert.strictEqual(lineDiff, 0);
+      invariant(lineDiff === 0);
     }
 
     while (
       comparePos(targetToPos, targetCursor) < 0 &&
       targetLines.prevPos(targetCursor, true)
     ) {
-      assert.ok(sourceLines.prevPos(sourceCursor, true));
-      assert.strictEqual(
-        sourceLines.charAt(sourceCursor),
-        targetLines.charAt(targetCursor),
+      invariant(sourceLines.prevPos(sourceCursor, true));
+      invariant(
+        sourceLines.charAt(sourceCursor) === targetLines.charAt(targetCursor),
       );
     }
   }

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import invariant from "tiny-invariant";
 import * as types from "ast-types";
 const b = types.builders;
 const isObject = types.builtInTypes.object;
@@ -143,7 +143,7 @@ const TreeCopier = function TreeCopier(
   lines: any,
   tokens: any,
 ) {
-  assert.ok(this instanceof TreeCopier);
+  invariant(this instanceof TreeCopier);
   this.lines = lines;
   this.tokens = tokens;
   this.startTokenIndex = 0;

--- a/lib/patcher.ts
+++ b/lib/patcher.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import invariant from "tiny-invariant";
 import * as linesModule from "./lines";
 import * as types from "ast-types";
 const Printable = types.namedTypes.Printable;
@@ -24,8 +24,8 @@ interface PatcherConstructor {
 }
 
 const Patcher = function Patcher(this: PatcherType, lines: any) {
-  assert.ok(this instanceof Patcher);
-  assert.ok(lines instanceof linesModule.Lines);
+  invariant(this instanceof Patcher);
+  invariant(lines instanceof linesModule.Lines);
 
   const self = this,
     replacements: any[] = [];
@@ -51,7 +51,7 @@ const Patcher = function Patcher(this: PatcherType, lines: any) {
       toConcat: any[] = [];
 
     function pushSlice(from: any, to: any) {
-      assert.ok(comparePos(from, to) <= 0);
+      invariant(comparePos(from, to) <= 0);
       toConcat.push(lines.slice(from, to));
     }
 
@@ -99,7 +99,7 @@ Pp.tryToReprintComments = function (newNode, oldNode, print) {
   if (ableToReprintComments && reprints.length > 0) {
     reprints.forEach(function (reprint) {
       const oldComment = reprint.oldPath.getValue();
-      assert.ok(oldComment.leading || oldComment.trailing);
+      invariant(oldComment.leading || oldComment.trailing);
       patcher.replace(
         oldComment.loc,
         // Comments can't have .comments, so it doesn't matter whether we
@@ -160,7 +160,7 @@ Pp.deleteComments = function (node) {
 };
 
 export function getReprinter(path: any) {
-  assert.ok(path instanceof FastPath);
+  invariant(path instanceof FastPath);
 
   // Make sure that this path refers specifically to a Node, rather than
   // some non-Node subproperty of a Node.
@@ -288,7 +288,7 @@ function findReprints(newPath: any, reprints: any) {
   const oldNode = newNode.original;
   Printable.assert(oldNode);
 
-  assert.deepEqual(reprints, []);
+  invariant(reprints.length === 0);
 
   if (newNode.type !== oldNode.type) {
     return false;

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import invariant from "tiny-invariant";
 import * as types from "ast-types";
 import { printComments } from "./comments";
 import FastPath from "./fast-path";
@@ -25,7 +25,7 @@ const PrintResult = function PrintResult(
   code: any,
   sourceMap?: any,
 ) {
-  assert.ok(this instanceof PrintResult);
+  invariant(this instanceof PrintResult);
 
   isString.assert(code);
   this.code = code;
@@ -65,7 +65,7 @@ interface PrinterConstructor {
 }
 
 const Printer = function Printer(this: PrinterType, config?: any) {
-  assert.ok(this instanceof Printer);
+  invariant(this instanceof Printer);
 
   const explicitTabWidth = config && config.tabWidth;
   config = normalizeOptions(config);
@@ -83,7 +83,7 @@ const Printer = function Printer(this: PrinterType, config?: any) {
   }
 
   function print(path: any, options: any) {
-    assert.ok(path instanceof FastPath);
+    invariant(path instanceof FastPath);
     options = options || {};
 
     if (options.includeComments) {
@@ -186,7 +186,7 @@ const Printer = function Printer(this: PrinterType, config?: any) {
 export { Printer };
 
 function genericPrint(path: any, config: any, options: any, printPath: any) {
-  assert.ok(path instanceof FastPath);
+  invariant(path instanceof FastPath);
 
   const node = path.getValue();
   const parts = [];
@@ -456,7 +456,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       parts.push("module", path.call(print, "id"));
 
       if (n.source) {
-        assert.ok(!n.body);
+        invariant(!n.body);
         parts.push("from", path.call(print, "source"));
       } else {
         parts.push(path.call(print, "body"));
@@ -932,7 +932,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return fromString(getPossibleRaw(n) || n.value + "m", options);
 
     case "StringLiteral":
-        return fromString(nodeStr(n.value, options));
+      return fromString(nodeStr(n.value, options));
 
     case "BooleanLiteral": // Babel 6 Literal split
     case "Literal":
@@ -1295,7 +1295,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       const openingLines = path.call(print, openingPropName);
 
       if (n[openingPropName].selfClosing) {
-        assert.ok(
+        invariant(
           !n[closingPropName],
           "unexpected " +
             closingPropName +
@@ -1345,7 +1345,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       if (needLineWrap) {
         attrParts.forEach(function (part, i) {
           if (part === " ") {
-            assert.strictEqual(i % 2, 0);
+            invariant(i % 2 === 0);
             attrParts[i] = "\n";
           }
         });
@@ -1698,7 +1698,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return fromString("boolean", options);
 
     case "BooleanLiteralTypeAnnotation":
-      assert.strictEqual(typeof n.value, "boolean");
+      invariant(typeof n.value === "boolean");
       return fromString("" + n.value, options);
 
     case "InterfaceTypeAnnotation":
@@ -1955,7 +1955,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
     case "NumberLiteralTypeAnnotation":
     case "NumericLiteralTypeAnnotation":
-      assert.strictEqual(typeof n.value, "number");
+      invariant(typeof n.value === "number");
       return fromString(JSON.stringify(n.value), options);
 
     case "BigIntLiteralTypeAnnotation":
@@ -2712,9 +2712,8 @@ function printStatementSequence(path: any, options: any, print: any) {
   });
 
   if (sawComment) {
-    assert.strictEqual(
-      sawStatement,
-      false,
+    invariant(
+      sawStatement === false,
       "Comments may appear as statements in otherwise empty statement " +
         "lists, but may not coexist with non-Comment nodes.",
     );
@@ -3090,7 +3089,7 @@ function printFlowDeclaration(path: any, parts: any) {
   const parentExportDecl = util.getParentExportDeclaration(path);
 
   if (parentExportDecl) {
-    assert.strictEqual(parentExportDecl.type, "DeclareExportDeclaration");
+    invariant(parentExportDecl.type === "DeclareExportDeclaration");
   } else {
     // If the parent node has type DeclareExportDeclaration, then it
     // will be responsible for printing the "declare" token. Otherwise

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import invariant from "tiny-invariant";
 import * as types from "ast-types";
 const n = types.namedTypes;
 import sourceMap from "source-map";
@@ -275,8 +275,8 @@ function fixTemplateLiteral(node: any, lines: any) {
     // First we need to exclude the opening ` from the .loc of the first
     // quasi element, in case the parser accidentally decided to include it.
     const afterLeftBackTickPos = copyPos(node.loc.start);
-    assert.strictEqual(lines.charAt(afterLeftBackTickPos), "`");
-    assert.ok(lines.nextPos(afterLeftBackTickPos));
+    invariant(lines.charAt(afterLeftBackTickPos) === "`");
+    invariant(lines.nextPos(afterLeftBackTickPos));
     const firstQuasi = node.quasis[0];
     if (comparePos(firstQuasi.loc.start, afterLeftBackTickPos) < 0) {
       firstQuasi.loc.start = afterLeftBackTickPos;
@@ -285,8 +285,8 @@ function fixTemplateLiteral(node: any, lines: any) {
     // Next we need to exclude the closing ` from the .loc of the last quasi
     // element, in case the parser accidentally decided to include it.
     const rightBackTickPos = copyPos(node.loc.end);
-    assert.ok(lines.prevPos(rightBackTickPos));
-    assert.strictEqual(lines.charAt(rightBackTickPos), "`");
+    invariant(lines.prevPos(rightBackTickPos));
+    invariant(lines.charAt(rightBackTickPos) === "`");
     const lastQuasi = node.quasis[node.quasis.length - 1];
     if (comparePos(rightBackTickPos, lastQuasi.loc.end) < 0) {
       lastQuasi.loc.end = rightBackTickPos;
@@ -317,7 +317,7 @@ function fixTemplateLiteral(node: any, lines: any) {
     // the expression in the .loc of the following quasi element.
     const rightCurlyPos = lines.skipSpaces(expr.loc.end, false, false);
     if (lines.charAt(rightCurlyPos) === "}") {
-      assert.ok(lines.nextPos(rightCurlyPos));
+      invariant(lines.nextPos(rightCurlyPos));
       // Now rightCurlyPos is technically the position just after the }.
       const quasiAfter = node.quasis[i + 1];
       if (comparePos(quasiAfter.loc.start, rightCurlyPos) < 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.23.4",
       "license": "MIT",
       "dependencies": {
-        "assert": "^2.0.0",
         "ast-types": "^0.16.1",
         "esprima": "~4.0.0",
         "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
         "tslib": "^2.0.1"
       },
       "devDependencies": {
@@ -2159,17 +2159,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/assert": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-      "dependencies": {
-        "es6-object-assign": "^1.1.0",
-        "is-nan": "^1.2.1",
-        "object-is": "^1.0.1",
-        "util": "^0.12.0"
-      }
-    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -2188,17 +2177,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -2318,18 +2296,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2655,17 +2621,6 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "node_modules/define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dependencies": {
-        "object-keys": "^1.0.12"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -2716,11 +2671,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "node_modules/es6-object-assign": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -3173,14 +3123,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dependencies": {
-        "is-callable": "^1.1.3"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3204,7 +3146,8 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -3222,19 +3165,6 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-stream": {
@@ -3330,17 +3260,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
@@ -3351,6 +3270,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -3365,31 +3285,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dependencies": {
-        "has-symbols": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/he": {
@@ -3466,22 +3361,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -3493,17 +3374,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -3536,20 +3406,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3560,21 +3416,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-nan": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-number": {
@@ -3614,24 +3455,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -4320,29 +4143,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/once": {
@@ -5055,6 +4855,11 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -5214,18 +5019,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5239,25 +5032,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.10"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/word-wrap": {
@@ -6896,17 +6670,6 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
-    "assert": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-      "requires": {
-        "es6-object-assign": "^1.1.0",
-        "is-nan": "^1.2.1",
-        "object-is": "^1.0.1",
-        "util": "^0.12.0"
-      }
-    },
     "ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -6920,11 +6683,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
-    },
-    "available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.3",
@@ -7011,15 +6769,6 @@
         "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
         "update-browserslist-db": "^1.0.9"
-      }
-    },
-    "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
       }
     },
     "callsites": {
@@ -7242,14 +6991,6 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
-    },
     "diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -7291,11 +7032,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "es6-object-assign": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
     },
     "escalade": {
       "version": "3.1.1",
@@ -7621,14 +7357,6 @@
       "integrity": "sha512-vO9b3GJQHHsRgwe2wB7lkKLhB+2Nw3QcpVKt/yYpoGVTJo51HS7GAvLE47XJ1u/5ILNQ41A+q+SZdyq+uRvkKQ==",
       "dev": true
     },
-    "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "requires": {
-        "is-callable": "^1.1.3"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -7645,7 +7373,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -7658,16 +7387,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
-    },
-    "get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
-      }
     },
     "get-stream": {
       "version": "6.0.1",
@@ -7737,14 +7456,6 @@
         "slash": "^3.0.0"
       }
     },
-    "gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "requires": {
-        "get-intrinsic": "^1.1.3"
-      }
-    },
     "grapheme-splitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
@@ -7755,6 +7466,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -7764,19 +7476,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
-    },
-    "has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "requires": {
-        "has-symbols": "^1.0.2"
-      }
     },
     "he": {
       "version": "1.2.0",
@@ -7831,16 +7530,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -7850,11 +7541,6 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
-    },
-    "is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
       "version": "2.11.0",
@@ -7877,14 +7563,6 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
-    "is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -7892,15 +7570,6 @@
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
-      }
-    },
-    "is-nan": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
       }
     },
     "is-number": {
@@ -7926,18 +7595,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true
-    },
-    "is-typed-array": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
-      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
-      }
     },
     "is-unicode-supported": {
       "version": "0.1.0",
@@ -8439,20 +8096,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
       "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true
-    },
-    "object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      }
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "once": {
       "version": "1.4.0",
@@ -8957,6 +8600,11 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -9062,18 +8710,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9081,19 +8717,6 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
-      }
-    },
-    "which-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.10"
       }
     },
     "word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recast",
-  "version": "0.23.4",
+  "version": "0.23.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recast",
-      "version": "0.23.4",
+      "version": "0.23.5",
       "license": "MIT",
       "dependencies": {
         "ast-types": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     "fs": false
   },
   "dependencies": {
-    "assert": "^2.0.0",
     "ast-types": "^0.16.1",
     "esprima": "~4.0.0",
     "source-map": "~0.6.1",
+    "tiny-invariant": "^1.3.3",
     "tslib": "^2.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Ben Newman <bn@cs.stanford.edu>",
   "name": "recast",
-  "version": "0.23.4",
+  "version": "0.23.5",
   "description": "JavaScript syntax tree transformer, nondestructive pretty-printer, and automatic source map generator",
   "keywords": [
     "ast",


### PR DESCRIPTION
This is the same as #1387, but without the unrelated formatting changes. When bundled using `esbuild`, this brings the file size down from 852KB to 712KB, a savings of 140KB (16%).