### PR TITLE
fix: print export namespace specifiers without braces

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -3005,13 +3005,19 @@ function printExportDeclaration(path: any, options: any, print: any) {
       parts.push("*");
     } else if (decl.specifiers.length === 0) {
       parts.push("{}");
-    } else if (decl.specifiers[0].type === "ExportDefaultSpecifier") {
+    } else if (
+      decl.specifiers[0].type === "ExportDefaultSpecifier" ||
+      decl.specifiers[0].type === "ExportNamespaceSpecifier"
+    ) {
       const unbracedSpecifiers: any[] = [];
       const bracedSpecifiers: any[] = [];
 
       path.each(function (specifierPath: any) {
         const spec = specifierPath.getValue();
-        if (spec.type === "ExportDefaultSpecifier") {
+        if (
+          spec.type === "ExportDefaultSpecifier" ||
+          spec.type === "ExportNamespaceSpecifier"
+        ) {
           unbracedSpecifiers.push(print(specifierPath));
         } else {
           bracedSpecifiers.push(print(specifierPath));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recast",
-  "version": "0.23.5",
+  "version": "0.23.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recast",
-      "version": "0.23.5",
+      "version": "0.23.6",
       "license": "MIT",
       "dependencies": {
         "ast-types": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Ben Newman <bn@cs.stanford.edu>",
   "name": "recast",
-  "version": "0.23.5",
+  "version": "0.23.6",
   "description": "JavaScript syntax tree transformer, nondestructive pretty-printer, and automatic source map generator",
   "keywords": [
     "ast",

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -508,6 +508,56 @@ describe("printer", function () {
     assert.strictEqual(printer.printGenerically(ast).code, code);
   });
 
+  it("export namespace", function () {
+    const printer = new Printer();
+
+    assert.strictEqual(
+      printer.print({
+        type: "ExportNamedDeclaration",
+        exportKind: "value",
+        specifiers: [
+          {
+            type: "ExportNamespaceSpecifier",
+            exported: {
+              type: "Identifier",
+              name: "Foobar",
+            },
+          },
+        ],
+        source: {
+          type: "StringLiteral",
+          value: "./foo",
+        },
+      }).code,
+      `export * as Foobar from "./foo";`,
+    );
+  });
+
+  it("export type namespace", function () {
+    const printer = new Printer();
+
+    assert.strictEqual(
+      printer.print({
+        type: "ExportNamedDeclaration",
+        exportKind: "type",
+        specifiers: [
+          {
+            type: "ExportNamespaceSpecifier",
+            exported: {
+              type: "Identifier",
+              name: "Foobar",
+            },
+          },
+        ],
+        source: {
+          type: "StringLiteral",
+          value: "./foo",
+        },
+      }).code,
+      `export type * as Foobar from "./foo";`,
+    );
+  });
+
   it("export default of IIFE", function () {
     const printer = new Printer();
     let ast = b.exportDefaultDeclaration(


### PR DESCRIPTION
@egasimus let me know if this fixes your issue (and doesn't cause different issues).

Fixes #1390