### PR TITLE
test: remove useless test code

### DIFF
--- a/test/lines.ts
+++ b/test/lines.ts
@@ -129,10 +129,6 @@ describe("lines", function () {
 
     lines.eachPos(compare);
 
-    // Try a bunch of crazy positions to verify equivalence for
-    // out-of-bounds input positions.
-    fromString(exports.testBasic).eachPos(compare);
-
     let original = fromString("  ab" + eol + "  c"),
       indented = original.indentTail(4),
       reference = fromString("  ab" + eol + "      c");


### PR DESCRIPTION
This was here since the `Lines` class was originally added in 1859d1441605516ecdad0a69be9c4242efae0513, but `exports.testBasic` was never defined and so this always was `undefined`.