### PR TITLE
printer: Support \n\n while printing JSXElement children

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1315,6 +1315,8 @@ function genericPrintNoParens(path: any, options: any, print: any) {
           ) {
             if (/\S/.test(child.value)) {
               return child.value.replace(/^\s+|\s+$/g, "");
+            } else if (/\n\n/.test(child.value)) {
+              return "\n\n";
             } else if (/\n/.test(child.value)) {
               return "\n";
             }

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1339,7 +1339,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
           ) {
             if (/\S/.test(child.value)) {
               return child.value.replace(/^\s+/g, "");
-            } else if (/\n\n/.test(child.value)) {
+            } else if (/\n\s*\n/.test(child.value)) {
               return "\n\n";
             } else if (/\n/.test(child.value)) {
               return "\n";

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1339,6 +1339,8 @@ function genericPrintNoParens(path: any, options: any, print: any) {
           ) {
             if (/\S/.test(child.value)) {
               return child.value.replace(/^\s+/g, "");
+            } else if (/\n\n/.test(child.value)) {
+              return "\n\n";
             } else if (/\n/.test(child.value)) {
               return "\n";
             }

--- a/test/jsx.ts
+++ b/test/jsx.ts
@@ -125,3 +125,48 @@ it("should not double parentheses in Babel", function () {
       "}",
   );
 });
+
+describe("should preserve blank lines between JSX children", function () {
+  // The blank line only survives if the whitespace-only JSXText between the
+  // two children is reprinted as "\n\n" rather than collapsed to "\n".
+  function build(gap: string, name: string) {
+    return (
+      "function App() {\n" +
+      "  return (\n" +
+      "    <div>\n" +
+      "      <" +
+      name +
+      " />\n" +
+      gap +
+      "      <Bar />\n" +
+      "    </div>\n" +
+      "  );\n" +
+      "}"
+    );
+  }
+
+  function check(between: string) {
+    const ast = parse(build(between, "Foo"), {
+      parser: require("../parsers/babel"),
+    });
+    ast.program.body[0].body.body[0].argument.children[1].openingElement.name.name =
+      "FooMutated";
+
+    assert.strictEqual(
+      new Printer({ tabWidth: 2 }).print(ast).code,
+      build("\n", "FooMutated"),
+    );
+  }
+
+  it("with a bare blank line", function () {
+    check("\n");
+  });
+
+  it("with a blank line containing whitespace", function () {
+    check("   \n");
+  });
+
+  it("with multiple blank lines collapsed to one", function () {
+    check("\n\n\n");
+  });
+});

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -2600,4 +2600,33 @@ describe("printer", function () {
       ),
     );
   });
+
+  it("can print JSXElement syntax with newlines", function () {
+    const code = ["<div>", "  <span />", "", "  <span />", "</div>;"].join(eol);
+
+    const ast = b.program([
+      b.expressionStatement(
+        b.jsxElement(
+          b.jsxOpeningElement(b.jsxIdentifier("div")),
+          b.jsxClosingElement(b.jsxIdentifier("div")),
+          [
+            b.jsxText("\n  "),
+            b.jsxElement(
+              b.jsxOpeningElement(b.jsxIdentifier("span"), [], true),
+            ),
+            b.jsxText("\n\n  "),
+            b.jsxElement(
+              b.jsxOpeningElement(b.jsxIdentifier("span"), [], true),
+            ),
+            b.jsxText("\n"),
+          ],
+        ),
+      ),
+    ]);
+
+    const printer = new Printer({ tabWidth: 2 });
+
+    const pretty = printer.print(ast).code;
+    assert.strictEqual(pretty, code);
+  });
 });

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -2726,4 +2726,33 @@ describe("printer", function () {
       assert.strictEqual(new Printer().printGenerically(ast).code, code);
     });
   });
+
+  it("can print JSXElement syntax with newlines", function () {
+    const code = ["<div>", "  <span />", "", "  <span />", "</div>;"].join(eol);
+
+    const ast = b.program([
+      b.expressionStatement(
+        b.jsxElement(
+          b.jsxOpeningElement(b.jsxIdentifier("div")),
+          b.jsxClosingElement(b.jsxIdentifier("div")),
+          [
+            b.jsxText("\n  "),
+            b.jsxElement(
+              b.jsxOpeningElement(b.jsxIdentifier("span"), [], true),
+            ),
+            b.jsxText("\n\n  "),
+            b.jsxElement(
+              b.jsxOpeningElement(b.jsxIdentifier("span"), [], true),
+            ),
+            b.jsxText("\n"),
+          ],
+        ),
+      ),
+    ]);
+
+    const printer = new Printer({ tabWidth: 2 });
+
+    const pretty = printer.print(ast).code;
+    assert.strictEqual(pretty, code);
+  });
 });


### PR DESCRIPTION
The printer seems to treat any number of newlines within a `JSXText` as a single newline. This causes any transform touching these elements to remove newlines that tooling such as Prettier would otherwise not remove.

Though I'm a little surprised to not see [the same formatting difference in ASTExplorer](https://astexplorer.net/#/gist/bb270b6009a00f697349916d90e15b2c/092182e6c8fc9c93f63a3811db9e5cc02bf10584), though it's running on 0.21.1 instead of the latest version (0.23.6), so maybe this was a regression at some point? I can reproduce it both within the test suite, and transforms using 0.23.6.

Edit: Oh, this was because by default the transform itself was using `parsers.esprima`. It's reproducible if you swap to `parsers.babel`, [example](https://astexplorer.net/#/gist/bb270b6009a00f697349916d90e15b2c/bb9a508b0f702b0e51ffca94e67295370e3e66d8).

Current behavior:

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tr>
<td>

```jsx
const SomeComponent = () => {
  return (
    <div>
      <Foo />

      <Bar />
    </div>
  );
}
```

</td>
<td>

```jsx
const SomeComponent = () => {
  return (
    <div>
      <FooMutated />
      <Bar />
    </div>
  );
}
```
</td>
</tr>
</table>

This PR updates the printer for `JSXElement` / `JSXFragment` to return two newlines instead of a single newline for any string children which include two adjacent newlines. 

Proposed behavior:

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tr>
<td>

```jsx
const SomeComponent = () => {
  return (
    <div>
      <Foo />

      <Bar />
    </div>
  );
}
```

</td>
<td>

```jsx
const SomeComponent = () => {
  return (
    <div>
      <FooMutated />

      <Bar />
    </div>
  );
}
```
</td>
</tr>
</table>

---

Thanks in advance for any review. This seems like an innocent enough change, but I'd entirely understand if it's more complicated than I'm imagining. Open to feedback and happy to iterate on this PR!