### PR TITLE
printer: Support type parameters on JSX components in TSX

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1331,6 +1331,8 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
     case "JSXOpeningElement": {
       parts.push("<", path.call(print, "name"));
+      const typeDefPart = path.call(print, "typeParameters");
+      if (typeDefPart.length) parts.push(typeDefPart);
       const attrParts: any[] = [];
 
       path.each(function (attrPath: any) {

--- a/test/run.ts
+++ b/test/run.ts
@@ -14,4 +14,5 @@ import "./printer";
 import "./syntax";
 import "./flow";
 import "./typescript";
+import "./tsx";
 import "./visit";

--- a/test/tsx.ts
+++ b/test/tsx.ts
@@ -1,0 +1,23 @@
+"use strict";
+
+const nodeMajorVersion = parseInt(process.versions.node, 10);
+import * as parser from "../parsers/babel-ts";
+import { EOL as eol } from "os";
+import * as recast from "../main";
+import assert from "assert";
+
+(nodeMajorVersion >= 6 ? describe : xdescribe)(
+  "Babel TSX Compatibility",
+  function () {
+    function check(lines: string[]) {
+      const code = lines.join(eol);
+      const ast = recast.parse(code, { parser });
+      const output = recast.prettyPrint(ast, { tabWidth: 2 }).code;
+      assert.strictEqual(code, output);
+    }
+
+    it("should parse and print typed JSX elements", function () {
+      check(["<Foo<Bar> />;"]);
+    });
+  },
+);


### PR DESCRIPTION
Supports actually parsing cases like `<Foo<Bar> />` instead of crashing.

Was unsure how to test this, since the existing code inherits from babel-parser's fixtures, and that doesn't currently have any tests of the sort (though it is a supported format).

Please let me know if there's any changes / modifications needed to the PR!

[Demonstration on Babel REPL](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=GYVwdgxgLglg9mABAERgNwDwBVEFMAeUuYAJgM6IDkAhgEYSUB8iAFAN6IAOATnJ4gF8AXIg48-InAICUogFCJE3XFBDckGEukQQANtTJkActQC2uALxs9B42dwDEAekYBuOQLlyMqTGSjcMGAA5sw2hibmFgBE0c5uckA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=true&timeTravel=false&sourceType=module&lineWrap=true&presets=react%2Ctypescript%2Cflow&prettier=false&targets=&version=7.23.2&externalPlugins=&assumptions=%7B%7D)