### PR TITLE
printer: Don't break on inline comments in JSX

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -6,6 +6,7 @@ import { concat, fromString, Lines } from "./lines";
 import { normalize as normalizeOptions } from "./options";
 import { getReprinter } from "./patcher";
 import * as util from "./util";
+import { CommentKind } from "ast-types/lib/gen/kinds";
 const namedTypes = types.namedTypes;
 const isString = types.builtInTypes.string;
 const isObject = types.builtInTypes.object;
@@ -2436,8 +2437,16 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
     case "TSTypeParameterDeclaration":
     case "TSTypeParameterInstantiation":
+      // If the first parameter has a comment, we want to insert a new line to avoid causing a syntax error:
       return concat([
         "<",
+        path
+          .getValue()
+          .params?.comments?.some(
+            (comment: CommentKind) => comment.type === "CommentLine",
+          )
+          ? fromString("\n")
+          : fromString(""),
         fromString(", ").join(path.map(print, "params")),
         ">",
       ]);

--- a/test/jsx.ts
+++ b/test/jsx.ts
@@ -22,6 +22,7 @@ for (const { title, parser } of [
     it("should parse and print attribute comments", function () {
       check("<b /* comment */ />");
       check("<b /* multi\nline\ncomment */ />");
+      check("<b // test comment\n/>")
     });
 
     it("should parse and print child comments", function () {


### PR DESCRIPTION
Allows rewriting JSX with inline comments without potentially generating invalid code.

Source Code:
```tsx
<Foo // comment
  prop1
  prop2
/>
```

Old Output:

```tsx
<Foo // comment prop1 prop2 />
```

New Output:

```tsx
<Foo // comment
  prop1
  prop2
/>
```