### PR TITLE
perf: avoid excessive linear scanning for large functions

### DIFF
--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -190,9 +190,6 @@ TCp.copy = function (node) {
   const oldIndent = this.indent;
   let newIndent = oldIndent;
 
-  const oldStartTokenIndex = this.startTokenIndex;
-  const oldEndTokenIndex = this.endTokenIndex;
-
   if (loc) {
     // When node is a comment, we set node.loc.indent to
     // node.loc.start.column so that, when/if we print the comment by
@@ -220,6 +217,9 @@ TCp.copy = function (node) {
     // all the tokens that make up this node.
     this.findTokenRange(loc);
   }
+
+  const oldStartTokenIndex = this.startTokenIndex;
+  const oldEndTokenIndex = this.endTokenIndex;
 
   const keys = Object.keys(node);
   const keyCount = keys.length;
@@ -262,7 +262,7 @@ TCp.findTokenRange = function (loc) {
   // *before* loc.end, we need to fast-forward this.endTokenIndex first.
   while (this.endTokenIndex < loc.tokens.length) {
     const token = loc.tokens[this.endTokenIndex];
-    if (util.comparePos(token.loc.end, loc.end) < 0) {
+    if (util.comparePos(token.loc.end, loc.end) <= 0) {
       ++this.endTokenIndex;
     } else break;
   }

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -1,5 +1,8 @@
 import assert from "assert";
+import fs from "fs";
+import path from "path";
 import { parse } from "../lib/parser";
+import * as util from "../lib/util";
 import { getReprinter } from "../lib/patcher";
 import { Printer } from "../lib/printer";
 import { fromString } from "../lib/lines";
@@ -235,3 +238,67 @@ function runTestsForParser(parserId: string) {
     check(" /* com\n\nment */ ");
   });
 }
+
+// The token indices recast records on every node.loc are computed incrementally
+// (see TreeCopier.findTokenRange), so they are only as good as the invariant
+// they are supposed to maintain: loc.tokens.slice(loc.start.token,
+// loc.end.token) must be exactly the tokens the node's loc covers. Checking
+// that against a brute-force scan keeps the incremental version honest.
+describe("token ranges", function () {
+  function checkTokenRanges(source: string) {
+    const ast = parse(source, { parser: require("../parsers/babel") });
+    const tokens = ast.tokens;
+    const seen = new Set();
+
+    (function walk(node: any, where: string) {
+      if (typeof node !== "object" || node === null || seen.has(node)) return;
+      seen.add(node);
+      if (Array.isArray(node)) {
+        node.forEach((item, i) => walk(item, `${where}[${i}]`));
+        return;
+      }
+
+      const loc = node.loc;
+      if (loc && loc.start && typeof loc.start.token === "number") {
+        const contained = [];
+        for (let i = 0; i < tokens.length; ++i) {
+          if (
+            util.comparePos(loc.start, tokens[i].loc.start) <= 0 &&
+            util.comparePos(tokens[i].loc.end, loc.end) <= 0
+          ) {
+            contained.push(i);
+          }
+        }
+        const claimed = [];
+        for (let i = loc.start.token; i < loc.end.token; ++i) claimed.push(i);
+        assert.deepEqual(
+          claimed,
+          contained,
+          `${node.type} at ${where} claims tokens ` +
+            `[${loc.start.token},${loc.end.token}) but contains [${contained}]`,
+        );
+      }
+
+      Object.keys(node).forEach(function (key) {
+        if (key !== "loc" && key !== "tokens" && key !== "original") {
+          walk(node[key], `${where}.${key}`);
+        }
+      });
+    })(ast, "");
+  }
+
+  it("cover exactly the tokens inside each node", function () {
+    checkTokenRanges(
+      fs.readFileSync(path.join(__dirname, "data", "backbone.js"), "utf8"),
+    );
+  });
+
+  it("include a node's final token", function () {
+    // A node whose last token ends exactly where the node ends used to be
+    // dropped from its own range, so a trailing comment ended up claiming no
+    // tokens at all (#1399).
+    checkTokenRanges("var x = 1; // c\n");
+    checkTokenRanges("if (x) {\n  y(); // c\n}\n");
+    checkTokenRanges("`before${x}middle${y}after`;\n");
+  });
+});

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -242,8 +242,12 @@ function runTestsForParser(parserId: string) {
 // The token indices recast records on every node.loc are computed incrementally
 // (see TreeCopier.findTokenRange), so they are only as good as the invariant
 // they are supposed to maintain: loc.tokens.slice(loc.start.token,
-// loc.end.token) must be exactly the tokens the node's loc covers. Checking
-// that against a brute-force scan keeps the incremental version honest.
+// loc.end.token) must be exactly the tokens the node's loc covers.
+//
+// Tokens are sorted and don't overlap, so the tokens a loc covers are always a
+// contiguous run, and checking the two tokens just inside the claimed range and
+// the two just outside it is equivalent to comparing the whole run -- but costs
+// O(1) per node instead of a scan over every token.
 describe("token ranges", function () {
   function checkTokenRanges(source: string) {
     const ast = parse(source, { parser: require("../parsers/babel") });
@@ -260,23 +264,30 @@ describe("token ranges", function () {
 
       const loc = node.loc;
       if (loc && loc.start && typeof loc.start.token === "number") {
-        const contained = [];
-        for (let i = 0; i < tokens.length; ++i) {
-          if (
-            util.comparePos(loc.start, tokens[i].loc.start) <= 0 &&
-            util.comparePos(tokens[i].loc.end, loc.end) <= 0
-          ) {
-            contained.push(i);
-          }
+        const first = loc.start.token;
+        const bound = loc.end.token;
+
+        const covers = (i: number) =>
+          util.comparePos(loc.start, tokens[i].loc.start) <= 0 &&
+          util.comparePos(tokens[i].loc.end, loc.end) <= 0;
+
+        const check = (i: number, expected: boolean) =>
+          assert.strictEqual(
+            covers(i),
+            expected,
+            `${node.type} at ${where} claims tokens [${first},${bound}) but ` +
+              `${expected ? "excludes covered" : "includes uncovered"} ` +
+              `token ${i} (${JSON.stringify(tokens[i].value)})`,
+          );
+
+        // Nothing outside the range may be covered...
+        if (first > 0) check(first - 1, false);
+        if (bound < tokens.length) check(bound, false);
+        // ...and everything inside it must be.
+        if (bound > first) {
+          check(first, true);
+          check(bound - 1, true);
         }
-        const claimed = [];
-        for (let i = loc.start.token; i < loc.end.token; ++i) claimed.push(i);
-        assert.deepEqual(
-          claimed,
-          contained,
-          `${node.type} at ${where} claims tokens ` +
-            `[${loc.start.token},${loc.end.token}) but contains [${contained}]`,
-        );
       }
 
       Object.keys(node).forEach(function (key) {

--- a/test/perf.ts
+++ b/test/perf.ts
@@ -1,6 +1,8 @@
 import path from "path";
 import fs from "fs";
+import assert from "assert";
 import * as recast from "../main";
+import * as babelParser from "../parsers/babel";
 
 const source = fs.readFileSync(
   path.join(__dirname, "data", "backbone.js"),
@@ -30,3 +32,70 @@ const printTime = +new Date() - start - visitTime - parseTime;
 console.log("print", printTime, "ms");
 
 console.log("total", +new Date() - start, "ms");
+
+// TreeCopier.findTokenRange finds each node's tokens by scanning outward from
+// the token range of the node it just finished copying, so the total number of
+// token lookups has to stay proportional to the number of tokens in the file.
+// If the scan ever restarts from an enclosing node's range instead, siblings
+// rescan their parent's whole span and the cost becomes quadratic: a 2.6MB
+// bundle took ~120s to parse that way, versus ~1.5s (see #1399).
+//
+// This counts lookups instead of measuring elapsed time so the result is exact
+// and identical on every machine.
+describe("parse token scanning", function () {
+  function tokenLookupsPerToken(source: string) {
+    let lookups = 0;
+    const ast = recast.parse(source, {
+      parser: {
+        parse(source: string) {
+          const ast: any = babelParser.parse(source);
+          ast.tokens = new Proxy(ast.tokens, {
+            get(tokens, key, receiver) {
+              // Indexed reads during parse() come from findTokenRange's scans,
+              // plus one pass over the array in recast's own parse().
+              if (typeof key === "string" && key >= "0" && key <= "9") {
+                lookups++;
+              }
+              return Reflect.get(tokens, key, receiver);
+            },
+          });
+          return ast;
+        },
+      },
+    });
+    return lookups / ast.tokens.length;
+  }
+
+  // One long function body, which is the shape that made the scanning quadratic.
+  function bigFunction(statementCount: number) {
+    let source = "function big() {\n";
+    for (let i = 0; i < statementCount; ++i) {
+      source += `  var v${i} = f(a${i}, b${i}) + g(c${i}, d${i});\n`;
+    }
+    return source + "}\n";
+  }
+
+  const small = tokenLookupsPerToken(bigFunction(250));
+  const large = tokenLookupsPerToken(bigFunction(1000));
+
+  it("does not rescan tokens as files grow", function () {
+    // Linear scanning holds this ratio at 1; quadratic scanning makes the
+    // larger file cost ~4x as much per token.
+    assert.ok(
+      large / small < 1.5,
+      `token lookups per token grew ${(large / small).toFixed(
+        2,
+      )}x between a 250- and a 1000-statement function ` +
+        `(${small.toFixed(1)} -> ${large.toFixed(
+          1,
+        )}), which means scanning is superlinear`,
+    );
+  });
+
+  it("scans a bounded number of tokens per token", function () {
+    assert.ok(
+      large < 50,
+      `${large.toFixed(1)} token lookups per token is far above the ~14 needed`,
+    );
+  });
+});


### PR DESCRIPTION
This commit restores the token indices for a node after they have been refined
to span the node, instead of before the refinement. This avoids the potential for
excessive searches for token indices, which is implemented using a linear scan.

It was attempted to convert the linear scans into binary searches (which an
accompanying comment on `findTokenRange` indicates shouldn't be needed) and that
also avoids the problem, but using the refined positions as implemented in this
commit is even more effective, to the point where using a binary search is less
efficient in my testing.

This change can achieve a substantial improvement, where an ~2.6MB file used to be
parsed and cloned in ~120s, now reduced to ~1.5s, almost two orders of magnitude
faster.

The perf test that tests the `backbone.js` file shows that performance improves
from ~60ms to ~53ms, only a slight improvement.

---

The offending file I used for testing was [ElkJS](https://github.com/kieler/elkjs) bundled into a single file: [elkjs.js.zip](https://github.com/benjamn/recast/files/15379902/elkjs.js.zip). It used to take ~120s on a MacBook Pro M1 Max to clone the parsed tree, which has now been reduced to 1.2s for a 100x improvement.