### PR TITLE
fix: TSTypeAnnotation printer when parent is a TSFunction type

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -2307,8 +2307,16 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     case "TSNonNullExpression":
       return concat([path.call(print, "expression"), "!"]);
 
-    case "TSTypeAnnotation":
-      return concat([": ", path.call(print, "typeAnnotation")]);
+    case "TSTypeAnnotation": {
+      const isFunctionType = namedTypes.TSFunctionType.check(
+        path.getParentNode(0),
+      );
+
+      return concat([
+        isFunctionType ? "=> " : ": ",
+        path.call(print, "typeAnnotation"),
+      ]);
+    }
 
     case "TSIndexSignature":
       return concat([

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -2357,8 +2357,21 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     case "TSNonNullExpression":
       return concat([path.call(print, "expression"), "!"]);
 
-    case "TSTypeAnnotation":
-      return concat([": ", path.call(print, "typeAnnotation")]);
+    case "TSTypeAnnotation": {
+      // The parents that print a separator other than ": " all reach through
+      // this node to print n.typeAnnotation directly, so this case runs for
+      // them only when the annotation is reprinted on its own.
+      const parent = path.getParentNode(0);
+      const separator =
+        namedTypes.TSFunctionType.check(parent) ||
+        namedTypes.TSConstructorType.check(parent)
+          ? "=> "
+          : namedTypes.TSTypePredicate.check(parent)
+          ? ""
+          : ": ";
+
+      return concat([separator, path.call(print, "typeAnnotation")]);
+    }
 
     case "TSIndexSignature":
       return concat([

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -2600,4 +2600,32 @@ describe("printer", function () {
       ),
     );
   });
+
+  it("should reprint TSTypeAnnotation correctly", function () {
+    const code = "type Foo = () => Bar;";
+
+    const ast = parse(code, {
+      parser: tsParser,
+    });
+
+    recast.visit(ast, {
+      visitTSTypeReference(path) {
+        if (
+          path.node.typeName.type === "Identifier" &&
+          path.node.typeName.name === "Bar" &&
+          path.parentPath.node.type === "TSTypeAnnotation"
+        ) {
+          path.replace(
+            b.tsQualifiedName(b.identifier("Bar"), b.identifier("Baz")),
+          );
+        }
+
+        this.traverse(path);
+      },
+    });
+
+    const pretty = new Printer().print(ast).code;
+
+    assert.strictEqual(pretty, "type Foo = () => Bar.Baz;");
+  });
 });

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -2755,4 +2755,43 @@ describe("printer", function () {
     const pretty = printer.print(ast).code;
     assert.strictEqual(pretty, code);
   });
+
+  it("should reprint TSTypeAnnotation with the separator its parent expects", function () {
+    // TSFunctionType, TSConstructorType, and TSTypePredicate print the
+    // separator themselves and reach through the TSTypeAnnotation, so the
+    // TSTypeAnnotation case of the printer runs only when a change of node
+    // type forces the annotation to be reprinted on its own.
+    function replaceTypeReference(code: string) {
+      const ast = parse(code, { parser: tsParser });
+
+      recast.visit(ast, {
+        visitTSTypeReference(path) {
+          path.replace(b.tsNumberKeyword());
+          return false;
+        },
+      });
+
+      return new Printer().print(ast).code;
+    }
+
+    assert.strictEqual(
+      replaceTypeReference("type Foo = () => Bar;"),
+      "type Foo = () => number;",
+    );
+
+    assert.strictEqual(
+      replaceTypeReference("type Foo = new () => Bar;"),
+      "type Foo = new () => number;",
+    );
+
+    assert.strictEqual(
+      replaceTypeReference("function f(x: any): x is Bar {}"),
+      "function f(x: any): x is number {}",
+    );
+
+    assert.strictEqual(
+      replaceTypeReference("function f(): Bar {}"),
+      "function f(): number {}",
+    );
+  });
 });


### PR DESCRIPTION
This is very similar to https://github.com/benjamn/recast/pull/815 but with a test that properly recreates the issue. I ran into the same issue today and needed to use `patch-package` to fix `recast` in my project. 

It appears that `TSTypeAnnotation` printer code does not run when you `print()` a AST with `TSTypeAnnotation` nodes unless you replace/modify a `TSTypeAnnotation` and change the `typeAnnotation` property to be a node of a different type. In my test I switch the `typeAnnotation` from a `TSTypeReference` to a `TSQualifiedName`. 

Thanks!