### PR TITLE
passes 'sourceFileName' option to the babel parser

### DIFF
--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -31,6 +31,7 @@ export function parse(source: string, options?: Partial<Options>) {
     tolerant: util.getOption(options, "tolerant", true),
     ecmaVersion: 6,
     sourceType: util.getOption(options, "sourceType", "module"),
+    sourceFileName: util.getOption(options, "sourceFileName", null),
   });
 
   // Use ast.tokens if possible, and otherwise fall back to the Esprima

--- a/parsers/_babel_options.ts
+++ b/parsers/_babel_options.ts
@@ -4,6 +4,7 @@ import { getOption } from "../lib/util";
 export type Overrides = Partial<{
   sourceType: ParserOptions["sourceType"];
   strictMode: ParserOptions["strictMode"];
+  sourceFileName: string;
 }>;
 
 export default function getBabelOptions(
@@ -16,6 +17,7 @@ export default function getBabelOptions(
   return {
     sourceType: getOption(options, "sourceType", "module"),
     strictMode: getOption(options, "strictMode", false),
+    sourceFilename: getOption(options, "sourceFileName", undefined),
     allowImportExportEverywhere: true,
     allowReturnOutsideFunction: true,
     startLine: 1,


### PR DESCRIPTION
Which fills in the `filename` part of the `node.loc` location object