### PR TITLE
print jsx children on newline when we have a multi-line opening element

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1305,7 +1305,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         return openingLines;
       }
 
-      const childLines = concat(
+      let childLines = concat(
         path.map(function (childPath: any) {
           const child = childPath.getValue();
 
@@ -1322,7 +1322,13 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
           return print(childPath);
         }, "children"),
-      ).indentTail(options.tabWidth);
+      );
+      if (openingLines.length > 1) {
+        // If we have a multiline opening element, start the child out on a newline
+        childLines = concat(["\n", childLines]).indent(options.tabWidth);
+      } else {
+        childLines = childLines.indentTail(options.tabWidth);
+      }
 
       const closingLines = path.call(print, closingPropName);
 
@@ -1351,10 +1357,10 @@ function genericPrintNoParens(path: any, options: any, print: any) {
             attrParts[i] = "\n";
           }
         });
+        attrParts.push("\n");
 
         attrLines = concat(attrParts).indentTail(options.tabWidth);
       }
-
       parts.push(attrLines, n.selfClosing ? " />" : ">");
 
       return concat(parts);

--- a/test/jsx.ts
+++ b/test/jsx.ts
@@ -93,3 +93,78 @@ it("should not remove trailing whitespaces", function () {
       "}",
   );
 });
+
+it("should print end jsx > on same line when not wrapping", function () {
+  const printer = new Printer({ tabWidth: 2 });
+  const source =
+    "function App() {\n" +
+    '  const name = "world";\n' +
+    "\n" +
+    "  return (\n" +
+    "    <div\n" +
+    '      className="app"\n' +
+    '      id="12345"\n' +
+    '      data-attribute="test-information"\n' +
+    "    >\n" +
+    "        hello {name}\n" +
+    "    </div>\n" +
+    "  );\n" +
+    "}";
+  const ast = parse(source);
+  ast.program.body[0].body.body[1].argument.openingElement.attributes[0].name.name =
+    "abc";
+
+  const code = printer.printGenerically(ast).code;
+
+  assert.equal(
+    code,
+    "function App() {\n" +
+      '  const name = "world";\n' +
+      "\n" +
+      "  return (\n" +
+      '    <div abc="app" id="12345" data-attribute="test-information">hello {name}\n' +
+      "    </div>\n" +
+      "  );\n" +
+      "}",
+  );
+});
+
+it("should print end jsx > on a new line when wrapping", function () {
+  const printer = new Printer({ tabWidth: 2, wrapColumn: 50 });
+  const source =
+    "function App() {\n" +
+    '  const name = "world";\n' +
+    "\n" +
+    "  return (\n" +
+    "    <div\n" +
+    '      className="app"\n' +
+    '      id="12345"\n' +
+    '      data-attribute="test-information"\n' +
+    "    >\n" +
+    "      hello {name}\n" +
+    "    </div>\n" +
+    "  );\n" +
+    "}";
+  const ast = parse(source);
+  ast.program.body[0].body.body[1].argument.openingElement.attributes[0].name.name =
+    "abc";
+
+  const code = printer.printGenerically(ast).code;
+
+  assert.equal(
+    code,
+    "function App() {\n" +
+      '  const name = "world";\n' +
+      "\n" +
+      "  return (\n" +
+      "    <div\n" +
+      '      abc="app"\n' +
+      '      id="12345"\n' +
+      '      data-attribute="test-information"\n' +
+      "    >\n" +
+      "      hello {name}\n" +
+      "    </div>\n" +
+      "  );\n" +
+      "}",
+  );
+});


### PR DESCRIPTION
Wrapped JSXElements with long JSXOpeningElements used to look like this:
```
<div 
  attr1="value1"
  attr2="value2"
  attr3="value3">Inner text here
</div>
```
  
  This changes it to look like:
```
<div 
  attr1="value1"
  attr2="value2"
  attr3="value3"
>
  Inner text here
</div>
```