### PR TITLE
Fix excess parens on awaits

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -459,7 +459,6 @@ FPp.needsParens = function (assumeExpressionContext) {
       );
 
     case "YieldExpression":
-    case "AwaitExpression":
     case "AssignmentExpression":
     case "ConditionalExpression":
       switch (parent.type) {


### PR DESCRIPTION
`recast` doesn't do what it says on the tin: preserve the formatting of the code. Any code using `async` and `await` syntax is very unlikely to be rendered the same coming out of recast as it went in.

On [this PR](https://github.com/benjamn/recast/pull/1257), @techLeadGuy suggested removing the `AwaitExpression` case in `needsParens()`. This worked for me. Maybe it works in all cases, but I'm not 100% sure. I think it's worth making this change to bring `recast` closer to its goal, and people like me should be expected to try and improve recast if our code breaks.