### PR TITLE
Feat: support Typescript type arguments on tagged template literals

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1579,7 +1579,12 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     }
 
     case "TaggedTemplateExpression":
-      return concat([path.call(print, "tag"), path.call(print, "quasi")]);
+      parts.push(path.call(print, "tag"));
+      if (n.typeParameters) {
+        parts.push(path.call(print, "typeParameters"));
+      }
+      parts.push(path.call(print, "quasi"));
+      return concat(parts);
 
     // These types are unprintable because they serve as abstract
     // supertypes for other (printable) types.

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -331,6 +331,14 @@ const nodeMajorVersion = parseInt(process.versions.node, 10);
     check(["type Class<T> = new (...args: any) => T;"]);
 
     check(["type T1 = [...Array<any>];", "type T2 = [...any[]];"]);
+    check([
+      "const a = styled.h1<{",
+      "  $upsideDown?: boolean;",
+      "}>`",
+      '  ${props => props.$upsideDown && "transform: rotate(180deg);"}',
+      "  text-align: center;",
+      "`;",
+    ]);
 
     check([
       "type Color = [r: number, g: number, b: number, a?: number];",


### PR DESCRIPTION
Typescript allows for type arguments tagged templates, which is used in several different styled component systems, e.g: 
 - Styled components ([example](https://styled-components.com/docs/advanced))
 - Compiled ([example](https://compiledcssinjs.com/docs/api-styled#typescript))


 
This was initially implemented by [@JakeLane](https://github.com/JakeLane) internally, to support developer codemods in typescript land!