### PR TITLE
fix: TSArrayType printer when element is a TSUnionType

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -2122,6 +2122,9 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return fromString("never", options);
 
     case "TSArrayType":
+      if (n.elementType.type === "TSUnionType") {
+        return concat(["(", path.call(print, "elementType"), ")", "[]"]);
+      }
       return concat([path.call(print, "elementType"), "[]"]);
 
     case "TSLiteralType":

--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -2151,6 +2151,9 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return fromString("never", options);
 
     case "TSArrayType":
+      if (n.elementType.type === "TSUnionType") {
+        return concat(["(", path.call(print, "elementType"), ")", "[]"]);
+      }
       return concat([path.call(print, "elementType"), "[]"]);
 
     case "TSLiteralType":

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -2600,4 +2600,12 @@ describe("printer", function () {
       ),
     );
   });
+
+  it("can print TSUnionType as element of TSArrayType", function () {
+    const node = b.tsArrayType(
+      b.tsUnionType([b.tsNumberKeyword(), b.tsStringKeyword()]),
+    );
+
+    assert.strictEqual(recast.print(node).code, "(number | string)[]");
+  });
 });

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -2601,6 +2601,14 @@ describe("printer", function () {
     );
   });
 
+  it("can print TSUnionType as element of TSArrayType", function () {
+    const node = b.tsArrayType(
+      b.tsUnionType([b.tsNumberKeyword(), b.tsStringKeyword()]),
+    );
+
+    assert.strictEqual(recast.print(node).code, "(number | string)[]");
+  });
+
   describe("modern TypeScript syntax", function () {
     function check(
       expected: string,


### PR DESCRIPTION
When a `TSUnionType` has an `elementType` of `TSUnionType` the brackets would only end up on the last member of the union (e.g `number | string[]` instead of `(number | string)[]`). Parsers seem to wrap the `TSUnionType` in a `TSParenthesizedType` which would get around this issue but in codemods and other scenarios where nodes are built by hand it could be easy to make this mistake.

It's possible that this is just a bug in `ast-types` and a `TSUnionType` should not be a valid `elementType`. 