### PR TITLE
fix: respect right-associativity of ** when adding parentheses

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -401,9 +401,20 @@ FPp.needsParens = function (assumeExpressionContext) {
             return true;
           }
 
-          if (pp === np && name === "right") {
-            invariant(parent.right === node);
-            return true;
+          if (pp === np) {
+            // `**` is right-associative, so `a ** b ** c` parses as
+            // `a ** (b ** c)`: the left operand needs parentheses
+            // (e.g. `(a ** b) ** c`), the right operand does not. Every other
+            // binary/logical operator is left-associative, so the right
+            // operand needs parentheses (e.g. `a - (b - c)`).
+            if (po === "**") {
+              return name === "left";
+            }
+
+            if (name === "right") {
+              invariant(parent.right === node);
+              return true;
+            }
           }
 
           break;

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -64,6 +64,17 @@ describe("parens", function () {
     });
   });
 
+  it("Exponentiation", function () {
+    // `**` is right-associative: `a ** b ** c` parses as `a ** (b ** c)`, so the
+    // left operand needs parentheses to override that while the right does not.
+    check("a ** b ** c");
+    check("a ** b ** c ** d");
+    check("(a ** b) ** c");
+    check("(a ** b ** c) ** d");
+    check("a ** b * c");
+    check("a * b ** c");
+  });
+
   it("Unary", function () {
     check("(-a).b");
     check("(+a).b");


### PR DESCRIPTION
## Bug

`**` is right-associative, so `a ** b ** c` parses as `a ** (b ** c)`. But `needsParens` (in `lib/fast-path.ts`) treats every binary operator as left-associative: at equal precedence it parenthesizes the **right** operand and leaves the **left** one bare. For `**` that is backwards, with two consequences:

```js
const recast = require("recast");
const print = code => recast.prettyPrint(recast.parse(code)).code;

print("a ** b ** c");   // => "a ** (b ** c);"   unnecessary parentheses
print("(a ** b) ** c"); // => "a ** b ** c;"     ⚠️ different value!
```

The second case is a correctness bug: `(a ** b) ** c` is `(a^b)^c`, but the reprinted `a ** b ** c` is `a^(b^c)`. Any transform that reprints an exponentiation tree can silently change the program's result. `print("a ** b ** c")` round-trips through `prettyPrint` to a different (though equivalent) string, and `(a ** b) ** c` round-trips to a non-equivalent one.

## Fix

At equal precedence, `**` needs parentheses around the **left** operand (to override right-associativity), not the right. Every other binary/logical operator is left-associative and is unchanged — the branch is byte-identical for `po !== "**"`.

## Tests

Added an `Exponentiation` case to `test/parens.ts` (the existing `operators` list omits `**`, which is why this went uncaught). It uses the existing `check()` helper, so it covers both the `print` round-trip and the `printGenerically` semantic-equivalence check. The cases fail on `master` (`a ** b ** c` reprints with extra parens; `(a ** b) ** c` reprints to a non-equivalent AST) and pass with this change.

> Related: #363 (open since 2017) fixes a *different* aspect — that `**` belongs in its own precedence tier above `*` `/` `%` — which already landed separately; this PR is about associativity, which #363 does not address (its test even asserts the buggy `x ** y ** (x ** y)` output).
>
> Note: I couldn't run `npm run mocha` locally — mocha's `yargs` dependency throws `require is not defined in ES module scope` under current Node (unrelated to this change). I verified the fix against the new `check()` cases and a broader print/prettyPrint round-trip battery, and confirmed the change only affects `**` at equal precedence (the existing `(x + y) ** (x || y)` / `(x * y) ** (x / y)` assertions in `test/babel.ts` are precedence-driven and still hold).