### PR TITLE
fix: add parentheses around operands of optional member/call expressions

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -370,8 +370,10 @@ FPp.needsParens = function (assumeExpressionContext) {
     case "UnaryExpression":
     case "SpreadElement":
     case "SpreadProperty":
+      // `n.MemberExpression.check` also matches `OptionalMemberExpression`, so
+      // e.g. `(-a)?.b` is parenthesized just like `(-a).b`.
       return (
-        parent.type === "MemberExpression" &&
+        n.MemberExpression.check(parent) &&
         name === "object" &&
         parent.object === node
       );
@@ -379,7 +381,11 @@ FPp.needsParens = function (assumeExpressionContext) {
     case "BinaryExpression":
     case "LogicalExpression":
       switch (parent.type) {
+        // `OptionalCallExpression` / `OptionalMemberExpression` are the
+        // optional-chaining counterparts of `CallExpression` /
+        // `MemberExpression` and parenthesize their operands the same way.
         case "CallExpression":
+        case "OptionalCallExpression":
           return name === "callee" && parent.callee === node;
 
         case "UnaryExpression":
@@ -388,6 +394,7 @@ FPp.needsParens = function (assumeExpressionContext) {
           return true;
 
         case "MemberExpression":
+        case "OptionalMemberExpression":
           return name === "object" && parent.object === node;
 
         case "BinaryExpression":
@@ -481,7 +488,9 @@ FPp.needsParens = function (assumeExpressionContext) {
         case "LogicalExpression":
           return true;
 
+        // Optional-chaining parents, e.g. `(await x)?.y` like `(await x).y`.
         case "CallExpression":
+        case "OptionalCallExpression":
         case "NewExpression":
           return name === "callee" && parent.callee === node;
 
@@ -489,6 +498,7 @@ FPp.needsParens = function (assumeExpressionContext) {
           return name === "test" && parent.test === node;
 
         case "MemberExpression":
+        case "OptionalMemberExpression":
           return name === "object" && parent.object === node;
 
         default:

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -399,4 +399,91 @@ describe("parens", function () {
 
     assert.strictEqual(printer.print(ast).code, "(typeof a ? b : c)()");
   });
+
+  it("should be added to operands of optional member and call expressions", function () {
+    // `OptionalMemberExpression` / `OptionalCallExpression` need the same
+    // parentheses around a lower-precedence operand as their non-optional
+    // counterparts, e.g. `(await x)?.y` like `(await x).y`.
+    assert.strictEqual(
+      printer.print(
+        b.optionalMemberExpression(
+          b.awaitExpression(b.identifier("x")),
+          b.identifier("y"),
+          false,
+          true,
+        ),
+      ).code,
+      "(await x)?.y",
+    );
+
+    assert.strictEqual(
+      printer.print(
+        b.optionalCallExpression(
+          b.awaitExpression(b.identifier("x")),
+          [],
+          true,
+        ),
+      ).code,
+      "(await x)?.()",
+    );
+
+    assert.strictEqual(
+      printer.print(
+        b.optionalMemberExpression(
+          b.assignmentExpression("=", b.identifier("a"), b.identifier("b")),
+          b.identifier("c"),
+          false,
+          true,
+        ),
+      ).code,
+      "(a = b)?.c",
+    );
+
+    assert.strictEqual(
+      printer.print(
+        b.optionalMemberExpression(
+          b.binaryExpression("+", b.identifier("a"), b.identifier("b")),
+          b.identifier("c"),
+          false,
+          true,
+        ),
+      ).code,
+      "(a + b)?.c",
+    );
+
+    // Issue #1410: wrapping a call's base in `await` inside an optional chain.
+    assert.strictEqual(
+      printer.print(
+        b.optionalCallExpression(
+          b.optionalMemberExpression(
+            b.awaitExpression(b.callExpression(b.identifier("asyncFn"), [])),
+            b.identifier("filter"),
+            false,
+            true,
+          ),
+          [b.arrowFunctionExpression([b.identifier("x")], b.identifier("x"))],
+          false,
+        ),
+      ).code,
+      "(await asyncFn())?.filter(x => x)",
+    );
+
+    // A continuing chain must not gain spurious parentheses.
+    assert.strictEqual(
+      printer.print(
+        b.optionalMemberExpression(
+          b.optionalMemberExpression(
+            b.identifier("a"),
+            b.identifier("b"),
+            false,
+            true,
+          ),
+          b.identifier("c"),
+          false,
+          true,
+        ),
+      ).code,
+      "a?.b?.c",
+    );
+  });
 });

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -451,6 +451,29 @@ describe("parens", function () {
       "(a + b)?.c",
     );
 
+    assert.strictEqual(
+      printer.print(
+        b.optionalMemberExpression(
+          b.unaryExpression("-", b.identifier("a")),
+          b.identifier("b"),
+          false,
+          true,
+        ),
+      ).code,
+      "(-a)?.b",
+    );
+
+    assert.strictEqual(
+      printer.print(
+        b.optionalCallExpression(
+          b.binaryExpression("+", b.identifier("a"), b.identifier("b")),
+          [],
+          true,
+        ),
+      ).code,
+      "(a + b)?.()",
+    );
+
     // Issue #1410: wrapping a call's base in `await` inside an optional chain.
     assert.strictEqual(
       printer.print(


### PR DESCRIPTION
`needsParens` decides whether an expression needs parentheses based on its parent. For `MemberExpression` and `CallExpression` parents it correctly parenthesizes a lower-precedence operand, but it never did the same for their optional-chaining counterparts, `OptionalMemberExpression` and `OptionalCallExpression`.

As a result, a transform that builds (or, as in #1410, mutates) an optional chain whose base is a lower-precedence expression drops the required parentheses and changes the meaning of the code:

```js
// start: asyncFn()?.filter(x => x), then wrap asyncFn() in `await`

// before
await asyncFn()?.filter(x => x)    // parses as await (asyncFn()?.filter(...))
// after
(await asyncFn())?.filter(x => x)
```

The same was true for every low-precedence operand of an optional member or call, for example `(a = b)?.c`, `(a + b)?.c`, `(a ? b : c)?.d` and `(-a)?.b`, all of which printed without the parentheses.

The fix mirrors the existing non-optional cases. In the three `needsParens` branches that already handle `MemberExpression` / `CallExpression` parents, the optional twins are now treated the same way. The `UnaryExpression` / `SpreadElement` branch uses `n.MemberExpression.check(parent)`, which already matches `OptionalMemberExpression` (the `ArrowFunctionExpression` branch relies on this too).

Continuing chains are unaffected, since their links are plain identifiers or optional members rather than low-precedence expressions: `a?.b?.c`, `a?.b.c` and `a?.b()` still print without extra parentheses.

I added a `test/parens.ts` case covering the await/assignment/binary operands, the #1410 reproduction, and the continuing-chain guard. The existing `parens` tests still pass.

Fixes #1410
