### PR TITLE
fix: parenthesize lower-precedence tagged template tags

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -366,6 +366,30 @@ FPp.needsParens = function (assumeExpressionContext) {
     return true;
   }
 
+  // The tag of a tagged template literal occupies a MemberExpression /
+  // CallExpression (LeftHandSideExpression) position, so a lower-precedence
+  // tag expression must be wrapped in parentheses, just like the callee of a
+  // call or new expression. Without this, e.g. the AST for `(a || b)`x``
+  // would print as `a || b`x``, which parses as `a || (b`x`)`.
+  if (
+    parent.type === "TaggedTemplateExpression" &&
+    name === "tag" &&
+    parent.tag === node
+  ) {
+    switch (node.type) {
+      case "UnaryExpression":
+      case "UpdateExpression":
+      case "BinaryExpression":
+      case "LogicalExpression":
+      case "ConditionalExpression":
+      case "AssignmentExpression":
+      case "AwaitExpression":
+      case "YieldExpression":
+      case "ArrowFunctionExpression":
+        return true;
+    }
+  }
+
   switch (node.type) {
     case "UnaryExpression":
     case "SpreadElement":

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -181,6 +181,18 @@ describe("parens", function () {
     check("function* test () { yield yield foo }");
   });
 
+  it("TaggedTemplateExpression", function () {
+    check("(a || b)`x`");
+    check("(a + b)`x`");
+    check("(a ? b : c)`x`");
+    check("(!a)`x`");
+    check("(a++)`x`");
+    check("(a = b)`x`");
+    check("(() => {})`x`");
+    check("async () => (await a)`x`");
+    check("function* test () { return (yield a)`x` }");
+  });
+
   it("ArrowFunctionExpression", () => {
     check("(() => {})()");
     check("test(() => {})");


### PR DESCRIPTION
The tag of a `TaggedTemplateExpression` occupies a MemberExpression/CallExpression position, so a lower-precedence tag must be parenthesized. `needsParens` had no case for it, so printing such a tag dropped the parentheses and changed meaning:

```
input:  (a || b)`x`
output: a || b`x`      // parses as a || (b`x`)
```

`(a++)`x`` even becomes invalid syntax. This adds a tag-position check returning true for the low-precedence operand types (Unary, Update, Binary, Logical, Conditional, Assignment, Await, Yield, Arrow).
