### PR TITLE
fix: parenthesize UpdateExpression in member and callee positions

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -376,6 +376,23 @@ FPp.needsParens = function (assumeExpressionContext) {
         parent.object === node
       );
 
+    case "UpdateExpression":
+      // An UpdateExpression binds looser than a MemberExpression /
+      // CallExpression, so it needs parentheses in those positions, e.g.
+      // `(a++).b`, `(a++)()`, `new (a++)`. Without them the output is invalid
+      // syntax (`a++.b`) or changes meaning (`++a.b` parses as `++(a.b)`).
+      switch (parent.type) {
+        case "MemberExpression":
+          return name === "object" && parent.object === node;
+
+        case "CallExpression":
+        case "NewExpression":
+          return name === "callee" && parent.callee === node;
+
+        default:
+          return false;
+      }
+
     case "BinaryExpression":
     case "LogicalExpression":
       switch (parent.type) {

--- a/test/parens.ts
+++ b/test/parens.ts
@@ -85,6 +85,15 @@ describe("parens", function () {
     check("(delete a.b).c");
   });
 
+  it("Update", function () {
+    check("(a++).b");
+    check("(a--).b");
+    check("(++a).b");
+    check("(--a).b");
+    check("(a++)()");
+    check("new (a++)");
+  });
+
   it("Binary", function () {
     check("(a && b)()");
     check("typeof (a && b)");


### PR DESCRIPTION
`needsParens` had no case for `UpdateExpression`, so an increment/decrement used as a MemberExpression object or a Call/New callee printed without parentheses:

```
(a++).b  ->  a++.b     // invalid syntax
(a++)()  ->  a++()     // invalid syntax
(++a).b  ->  ++a.b     // parses as ++(a.b), a semantics change
```

This adds an `UpdateExpression` case mirroring the existing low-precedence-operand handling. (Recast-side of issue #1362, which was closed via an acorn `preserveParens` workaround rather than a fix.)
