### PR TITLE
fix: preserve modern TypeScript syntax when printing

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -527,13 +527,18 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return printExportDeclaration(path, options, print);
 
     case "ExportAllDeclaration":
-      parts.push("export *");
+      parts.push(n.exportKind === "type" ? "export type *" : "export *");
 
       if (n.exported) {
         parts.push(" as ", path.call(print, "exported"));
       }
 
-      parts.push(" from ", path.call(print, "source"), ";");
+      parts.push(
+        " from ",
+        path.call(print, "source"),
+        maybePrintImportAssertions(path, options, print),
+        ";",
+      );
 
       return concat(parts);
 
@@ -695,19 +700,18 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     case "OptionalCallExpression":
       parts.push(path.call(print, "callee"));
 
+      // Optional calls place the chain operator before type arguments:
+      // fn?.<T>(), not fn<T>?.().
+      if (types.getFieldValue(n, "optional")) {
+        parts.push("?.");
+      }
+
       if (n.typeParameters) {
         parts.push(path.call(print, "typeParameters"));
       }
 
       if (n.typeArguments) {
         parts.push(path.call(print, "typeArguments"));
-      }
-
-      // Like n.optional, but defaults to true for OptionalCallExpression
-      // nodes that are missing an n.optional property (unusual),
-      // according to the OptionalCallExpression definition in ast-types.
-      if (types.getFieldValue(n, "optional")) {
-        parts.push("?.");
       }
 
       parts.push(printArgumentsList(path, options, print));
@@ -802,6 +806,10 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       if (i !== 0 && oneLine && options.objectCurlySpacing) {
         parts[leftBraceIndex] = leftBrace + " ";
         parts[parts.length - 1] = " " + rightBrace;
+      }
+
+      if (n.optional) {
+        parts.push("?");
       }
 
       if (n.typeAnnotation) {
@@ -907,6 +915,10 @@ function genericPrintNoParens(path: any, options: any, print: any) {
         parts.push(" ]");
       } else {
         parts.push("]");
+      }
+
+      if (n.optional) {
+        parts.push("?");
       }
 
       if (n.typeAnnotation) {
@@ -2182,7 +2194,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
     case "TSConstructorType":
       return concat([
-        "new ",
+        n.abstract ? "abstract new " : "new ",
         path.call(print, "typeParameters"),
         "(",
         printFunctionParams(path, options, print),
@@ -2191,12 +2203,20 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       ]);
 
     case "TSMappedType": {
+      const readonly =
+        n.readonly === true
+          ? "readonly "
+          : n.readonly
+          ? n.readonly + "readonly "
+          : "";
+      const optional =
+        n.optional === true ? "?" : n.optional ? n.optional + "?" : "";
       parts.push(
-        n.readonly ? "readonly " : "",
+        readonly,
         "[",
         path.call(print, "typeParameter"),
         "]",
-        n.optional ? "?" : "",
+        optional,
       );
 
       if (n.typeAnnotation) {
@@ -2272,11 +2292,19 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       return concat(parts);
 
     case "TSTypeQuery":
-      return concat(["typeof ", path.call(print, "exprName")]);
+      return concat([
+        "typeof ",
+        path.call(print, "exprName"),
+        path.call(print, "typeParameters"),
+      ]);
 
     case "TSParameterProperty":
       if (n.accessibility) {
         parts.push(n.accessibility, " ");
+      }
+
+      if (n.override) {
+        parts.push("override ");
       }
 
       if (n.export) {
@@ -2429,6 +2457,18 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       ]);
 
     case "TSTypeParameter": {
+      if (n.const) {
+        parts.push("const ");
+      }
+
+      if (n.in) {
+        parts.push("in ");
+      }
+
+      if (n.out) {
+        parts.push("out ");
+      }
+
       parts.push(path.call(print, "name"));
 
       // ambiguous because of TSMappedType
@@ -2508,7 +2548,13 @@ function genericPrintNoParens(path: any, options: any, print: any) {
     }
 
     case "TSImportType":
-      parts.push("import(", path.call(print, "argument"), ")");
+      parts.push("import(", path.call(print, "argument"));
+
+      if (n.options) {
+        parts.push(", ", path.call(print, "options"));
+      }
+
+      parts.push(")");
 
       if (n.qualifier) {
         parts.push(".", path.call(print, "qualifier"));
@@ -2526,7 +2572,7 @@ function genericPrintNoParens(path: any, options: any, print: any) {
       }
 
       parts.push(
-        "import ",
+        n.importKind === "type" ? "import type " : "import ",
         path.call(print, "id"),
         " = ",
         path.call(print, "moduleReference"),
@@ -2554,6 +2600,10 @@ function genericPrintNoParens(path: any, options: any, print: any) {
 
           if (isExternal) {
             parts.push("module ");
+          } else if (n.kind === "module") {
+            parts.push("module ");
+          } else if (n.kind === "namespace") {
+            parts.push("namespace ");
           } else if (n.loc && n.loc.lines && n.id.loc) {
             const prefix = n.loc.lines.sliceString(n.loc.start, n.id.loc.start);
 
@@ -2986,9 +3036,14 @@ function maybePrintImportAssertions(
   print: any,
 ): Lines {
   const n = path.getValue();
-  if (n.assertions && n.assertions.length > 0) {
-    const parts: (string | Lines)[] = [" assert {"];
+  if (n.assertions && (n.assertions.length > 0 || n.importAttributesKeyword)) {
+    const keyword =
+      n.importAttributesKeyword === "with" ? " with {" : " assert {";
+    const parts: (string | Lines)[] = [keyword];
     const printed = path.map(print, "assertions");
+    if (printed.length === 0) {
+      return concat([keyword, "}"]);
+    }
     const flat = fromString(", ").join(printed);
     if (flat.length > 1 || flat.getLineLength(1) > options.wrapColumn) {
       parts.push(

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -2600,4 +2600,122 @@ describe("printer", function () {
       ),
     );
   });
+
+  describe("modern TypeScript syntax", function () {
+    function check(
+      expected: string,
+      update?: (ast: any) => void,
+      source = expected,
+    ) {
+      const ast = parse(source, { parser: tsParser });
+      if (update) {
+        update(ast);
+      }
+      assert.strictEqual(new Printer().printGenerically(ast).code, expected);
+    }
+
+    it("prints optional calls, binding patterns, and modifiers", function () {
+      [
+        "const optional = factory?.<number>();",
+        "const array = ([value]?: [number]) => value;",
+        "type Factory = abstract new () => X;",
+        "type Query = typeof Foo<string>;",
+        "interface Variance<in T, out U> {}",
+        'import type X = require("x");',
+      ].forEach((code) => check(code));
+
+      check(
+        [
+          "class A extends B {",
+          "    constructor(public override x: number) {",
+          "        super();",
+          "    }",
+          "}",
+        ].join(eol),
+        undefined,
+        "class A extends B { constructor(public override x: number) { super(); } }",
+      );
+
+      check(
+        ["type M<T> = {", "    -readonly [K in keyof T]+?: T[K];", "};"].join(
+          eol,
+        ),
+        undefined,
+        "type M<T> = { -readonly [K in keyof T]+?: T[K] };",
+      );
+
+      check(
+        [
+          "const object = (",
+          "    {",
+          "        value",
+          "    }?: {",
+          "        value: number;",
+          "    }",
+          ") => value;",
+        ].join(eol),
+        undefined,
+        "const object = ({ value }?: { value: number }) => value;",
+      );
+
+      check(
+        "class Box<const T> {}",
+        (ast) => {
+          const declaration = ast.program.body[0];
+          declaration.typeParameters.params[0].const = true;
+        },
+        "class Box<T> {}",
+      );
+
+      check("module M {}", (ast) => {
+        const declaration = ast.program.body[0];
+        declaration.kind = "module";
+        declaration.loc = null;
+        declaration.id.loc = null;
+      });
+    });
+
+    it("prints type-only exports and import attributes", function () {
+      check(
+        'export type * from "types";',
+        (ast) => {
+          ast.program.body[0].exportKind = "type";
+        },
+        'export * from "types";',
+      );
+
+      check('export * from "x" assert { type: "json" };');
+
+      check(
+        'import data from "x" with {};',
+        (ast) => {
+          const declaration = ast.program.body[0];
+          declaration.assertions = [];
+          declaration.importAttributesKeyword = "with";
+        },
+        'import data from "x";',
+      );
+    });
+
+    it("prints options on TypeScript import types", function () {
+      const code = [
+        'type T = import("pkg", {',
+        "    with: {",
+        '        "resolution-mode": "import"',
+        "    }",
+        "}).Foo;",
+      ].join(eol);
+      const ast = parse('type T = import("pkg").Foo;', {
+        parser: tsParser,
+      }) as any;
+      const optionsAst = parse(
+        'const options = { with: { "resolution-mode": "import" } };',
+        { parser: tsParser },
+      ) as any;
+      ast.program.body[0].typeAnnotation.options =
+        optionsAst.program.body[0].declarations[0].init;
+
+      assert.strictEqual(new Printer().printGenerically(ast).code, code);
+    });
+  });
 });


### PR DESCRIPTION
This PR ensures that modern TS modifiers are preserved during printing. These include (non-exhaustive):

- optional generic calls and typed binding patterns
- type-only imports/exports and import attributes
- import-type options, mapped modifiers, and type-query generics


Tests are added to cover the changes.