### PR TITLE
feat: add oxc parser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,16 @@ const tsAst = recast.parse(source, {
 });
 ```
 
-**Note:** Some of these parsers import npm packages that Recast does not directly depend upon, so please be aware you may have to run `npm install @babel/parser` to use the `typescript`, `flow`, or `babel` parsers, or `npm install acorn` to use the `acorn` parser. Only Esprima is installed by default when Recast is installed.
+Oxc can be used for JavaScript, JSX, TypeScript, and TSX after installing
+`oxc-parser`:
+
+```js
+const oxcAst = recast.parse(source, {
+  parser: require("recast/parsers/oxc")
+});
+```
+
+**Note:** Some of these parsers import npm packages that Recast does not directly depend upon, so please be aware you may have to run `npm install @babel/parser` to use the `typescript`, `flow`, or `babel` parsers, `npm install acorn` to use the `acorn` parser, or `npm install oxc-parser` to use the `oxc` parser. Only Esprima is installed by default when Recast is installed.
 
 After calling `recast.parse`, if you're going to transform the AST, make sure that the `.original` property is preserved. With Babel, for instance, if you call `transformFromAST`, you must pass `cloneInputAst: false` in its options. ([More detail](https://github.com/babel/babel/issues/12882)).
 

--- a/README.md
+++ b/README.md
@@ -168,8 +168,7 @@ const tsAst = recast.parse(source, {
 });
 ```
 
-Oxc can be used for JavaScript, JSX, TypeScript, and TSX after installing
-`oxc-parser`:
+Oxc can be used for JavaScript, JSX, TypeScript, and TSX after installing `oxc-parser`:
 
 ```js
 const oxcAst = recast.parse(source, {
@@ -177,8 +176,7 @@ const oxcAst = recast.parse(source, {
 });
 ```
 
-The Oxc parser defaults to TSX syntax and a TypeScript-shaped AST. Use
-`createOxcParser` to select a stricter language or AST shape:
+The Oxc parser defaults to TSX syntax and a TypeScript-shaped AST. Use `createOxcParser` to select a stricter language or AST shape:
 
 ```js
 const oxcParser = require("recast/parsers/oxc").createOxcParser({
@@ -189,8 +187,7 @@ const oxcParser = require("recast/parsers/oxc").createOxcParser({
 ```
 
 Current versions of `oxc-parser` require Node.js `^20.19.0` or `>=22.12.0`.
-Because Oxc does not expose tokens, this parser preserves parentheses using
-Oxc's explicit `ParenthesizedExpression` nodes.
+Because Oxc does not expose tokens, this parser preserves parentheses using Oxc's explicit `ParenthesizedExpression` nodes.
 
 **Note:** Some of these parsers import npm packages that Recast does not directly depend upon, so please be aware you may have to run `npm install @babel/parser` to use the `typescript`, `flow`, or `babel` parsers, `npm install acorn` to use the `acorn` parser, or `npm install oxc-parser` to use the `oxc` parser. Only Esprima is installed by default when Recast is installed.
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,21 @@ const oxcAst = recast.parse(source, {
 });
 ```
 
+The Oxc parser defaults to TSX syntax and a TypeScript-shaped AST. Use
+`createOxcParser` to select a stricter language or AST shape:
+
+```js
+const oxcParser = require("recast/parsers/oxc").createOxcParser({
+  filename: "source.js",
+  lang: "js",
+  astType: "js"
+});
+```
+
+Current versions of `oxc-parser` require Node.js `^20.19.0` or `>=22.12.0`.
+Because Oxc does not expose tokens, this parser preserves parentheses using
+Oxc's explicit `ParenthesizedExpression` nodes.
+
 **Note:** Some of these parsers import npm packages that Recast does not directly depend upon, so please be aware you may have to run `npm install @babel/parser` to use the `typescript`, `flow`, or `babel` parsers, `npm install acorn` to use the `acorn` parser, or `npm install oxc-parser` to use the `oxc` parser. Only Esprima is installed by default when Recast is installed.
 
 After calling `recast.parse`, if you're going to transform the AST, make sure that the `.original` property is preserved. With Babel, for instance, if you call `transformFromAST`, you must pass `cloneInputAst: false` in its options. ([More detail](https://github.com/babel/babel/issues/12882)).

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "glob": "8.0.3",
         "lint-staged": "^13.2.2",
         "mocha": "^10.2.0",
+        "oxc-parser": "^0.141.0",
         "prettier": "^2.6.2",
         "reify": "0.20.12",
         "typescript": "^4.9.4"
@@ -1670,6 +1671,40 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -1821,6 +1856,25 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1854,6 +1908,393 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.141.0.tgz",
+      "integrity": "sha512-jk7086MFvR/T4DG9IY7MKBVt1PMxvSZoz/TvnifodvS0pjghVwJHRttnAExhlwdMOgHv1TmLdENnbNpYk2zjvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.141.0.tgz",
+      "integrity": "sha512-a4XDQ27ZT7e7zwAlxJDTiCA7IBGWDuy2+MhFq85Of7XlBSmpkfcBFml11q0Zx6f7RMuI0B4xCtt2ytBS4yOptg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.141.0.tgz",
+      "integrity": "sha512-m/kVk6rzYmBeHYnz+1Y5fod00AVTTxMbC71azFfm/zjx1j9XxwKtA0+VfkKuVMC8rbghb9TtfevnuWZa9OuPEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.141.0.tgz",
+      "integrity": "sha512-o0X+6KZlfucWU/v5oKRQPwdFXsXAjW8jmpo/Gpw/qyKsbKtlfkHoeH9Bjp/m13TwjewvJnCkwF0DWzgpC4HjTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.141.0.tgz",
+      "integrity": "sha512-W5KbTnNkTMMMylqj6dYqnsXvkmESVPodPKYLJ5zdzIPdl9fUJtolkpUeSzYEbGGYB4a4A4avl3EePnZ/wLIdJg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.141.0.tgz",
+      "integrity": "sha512-g3dtbJa8zeOGK36Sr9cQavsdi5H/ie2hVjrSjIxsNAR1qZA40ZYVXnfdfoMAlq8CmB9qFL1yhsSCUHeNmdmt8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.141.0.tgz",
+      "integrity": "sha512-e6hwQqd+3lvP13G2jxvFpoA7dzHcFLN+Mq47JCVMtdNHbbyBRo756JCtbbJH6ca8inTfyqZoqBmS3vhQlzAK2w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.141.0.tgz",
+      "integrity": "sha512-vXz2BLAuypA+4MLyBg94pzEo6THVnzYnCtAjXoihIIQo0t2pnp/AmW+SH1EI+4VbuJnC//KplIJ5yyaCGua4jA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.141.0.tgz",
+      "integrity": "sha512-jMkS/EztNW34HKsXIaT/SoHcmtocq/vWhwFOVduF9kduuuRIVwfwQ6uxzIO+qPKSXdd2TXt54of0BJ2zFMXnmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.141.0.tgz",
+      "integrity": "sha512-vo+MR+n3zQJ6Mq92hiP084NZcgDv5iJlVR02gMf28neMvVT1tKVm7VeiW/DxhdqOi3QLeaXIk9cUcLL1qrkngw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.141.0.tgz",
+      "integrity": "sha512-oh80w+7RuiO5gBp9Jnoa/H8Qlt3JsHL2MkW+0dwEdlDMdslVZX/YsekSK6EeyEenY66/mhCfypsNATQ7Ph3qlQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.141.0.tgz",
+      "integrity": "sha512-LOyEmFA8sCnYbEXP1+iQvCC/P1YXHMA/t6x1Ksp0Y9VwhLFsiBJFzV1zIxrOIE2LKaGGhDjQ29xq9cbq6omDXA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.141.0.tgz",
+      "integrity": "sha512-3wnwk/l1CvszVE5TJR1wSl/zSEfydRqrNhn6s7Vr9IzSJpUQIroqVsIoPARHRFA+FQwkxAFDAHDAasa7v8OobQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.141.0.tgz",
+      "integrity": "sha512-qtyQVAAebFq57B2tifTlel3TgGqUtsYNI/e+p6aya9rN9lOZVTDvr215fGYSA9XWooxzMxDiVxkBLk2jQHbsOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.141.0.tgz",
+      "integrity": "sha512-SkGV1nKw40roEc94pv5EaaeH2ay14G6+roe8Q0wIUC1LcEKxzKW921h7+ZuZX0D3q2Mb/7aSFmxEVqnko3lPRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.141.0.tgz",
+      "integrity": "sha512-cVgDM7n8QziQqOaP5hNgUYfMG7S/ZeuPxFWXnnHRv7rh025COk0rfQ6eEdKG3j/GaUuyvNZN4ifF1J8KmuXLLA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.141.0.tgz",
+      "integrity": "sha512-HggH++Fkn3OilBn+bs3jpgIFQa34oMAyUUHy0vpGum+gt1Eb5nyLc8dNU/RAPSw6lsLrx7ncKtHSZE+3Sp0l2g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.141.0.tgz",
+      "integrity": "sha512-KLSEH9GwgbrqbJOjtGHt9STw96s+78yDzp7IDN8Lno+7Ut9sNBfZ4jYZIz4mD50qmWUjoOI7i9I6UENbhNbMZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.141.0.tgz",
+      "integrity": "sha512-9UVWUOOCI/1YkiSSNjg2zyBJYM9E/t1A/8GNobd48JDn/fQ6mzxcVO3H08jb3rAaW/B1VBf8eCORTvSsO9T08g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.141.0.tgz",
+      "integrity": "sha512-HI/wsvbWT5RHHw5c37D0fEgeTd8/1Q4OJs5jUmEBc17VZFG6SsCIe4barq7NsAPPks/JW+3ayi3Rp+PQI5h4Kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.141.0.tgz",
+      "integrity": "sha512-S4as7z0j0xQkXcJlyY5ehntwK8/wRkQb9Cyqw+J/N2rkWGQGK0SxD6X6DhQTc7qsxVTBxXbxZtBJh3mr3PtIzQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/esprima": {
@@ -4186,6 +4627,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/oxc-parser": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.141.0.tgz",
+      "integrity": "sha512-uFkGGr1KMWd6aWv9UAqooYrN78trw8MWWmoPvgWokfBEUq1+eiIQ+qfj3wokhy0fxtZWZk+0dHoS7/yRTJtd6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.141.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.141.0",
+        "@oxc-parser/binding-android-arm64": "0.141.0",
+        "@oxc-parser/binding-darwin-arm64": "0.141.0",
+        "@oxc-parser/binding-darwin-x64": "0.141.0",
+        "@oxc-parser/binding-freebsd-x64": "0.141.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.141.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.141.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.141.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.141.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.141.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.141.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.141.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.141.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.141.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.141.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.141.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.141.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.141.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.141.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.141.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6325,6 +6804,37 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -6435,6 +6945,16 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@tybys/wasm-util": "^0.10.3"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -6459,6 +6979,167 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.141.0.tgz",
+      "integrity": "sha512-jk7086MFvR/T4DG9IY7MKBVt1PMxvSZoz/TvnifodvS0pjghVwJHRttnAExhlwdMOgHv1TmLdENnbNpYk2zjvA==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-android-arm64": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.141.0.tgz",
+      "integrity": "sha512-a4XDQ27ZT7e7zwAlxJDTiCA7IBGWDuy2+MhFq85Of7XlBSmpkfcBFml11q0Zx6f7RMuI0B4xCtt2ytBS4yOptg==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-darwin-arm64": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.141.0.tgz",
+      "integrity": "sha512-m/kVk6rzYmBeHYnz+1Y5fod00AVTTxMbC71azFfm/zjx1j9XxwKtA0+VfkKuVMC8rbghb9TtfevnuWZa9OuPEg==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-darwin-x64": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.141.0.tgz",
+      "integrity": "sha512-o0X+6KZlfucWU/v5oKRQPwdFXsXAjW8jmpo/Gpw/qyKsbKtlfkHoeH9Bjp/m13TwjewvJnCkwF0DWzgpC4HjTQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-freebsd-x64": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.141.0.tgz",
+      "integrity": "sha512-W5KbTnNkTMMMylqj6dYqnsXvkmESVPodPKYLJ5zdzIPdl9fUJtolkpUeSzYEbGGYB4a4A4avl3EePnZ/wLIdJg==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.141.0.tgz",
+      "integrity": "sha512-g3dtbJa8zeOGK36Sr9cQavsdi5H/ie2hVjrSjIxsNAR1qZA40ZYVXnfdfoMAlq8CmB9qFL1yhsSCUHeNmdmt8w==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.141.0.tgz",
+      "integrity": "sha512-e6hwQqd+3lvP13G2jxvFpoA7dzHcFLN+Mq47JCVMtdNHbbyBRo756JCtbbJH6ca8inTfyqZoqBmS3vhQlzAK2w==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.141.0.tgz",
+      "integrity": "sha512-vXz2BLAuypA+4MLyBg94pzEo6THVnzYnCtAjXoihIIQo0t2pnp/AmW+SH1EI+4VbuJnC//KplIJ5yyaCGua4jA==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.141.0.tgz",
+      "integrity": "sha512-jMkS/EztNW34HKsXIaT/SoHcmtocq/vWhwFOVduF9kduuuRIVwfwQ6uxzIO+qPKSXdd2TXt54of0BJ2zFMXnmw==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.141.0.tgz",
+      "integrity": "sha512-vo+MR+n3zQJ6Mq92hiP084NZcgDv5iJlVR02gMf28neMvVT1tKVm7VeiW/DxhdqOi3QLeaXIk9cUcLL1qrkngw==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.141.0.tgz",
+      "integrity": "sha512-oh80w+7RuiO5gBp9Jnoa/H8Qlt3JsHL2MkW+0dwEdlDMdslVZX/YsekSK6EeyEenY66/mhCfypsNATQ7Ph3qlQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.141.0.tgz",
+      "integrity": "sha512-LOyEmFA8sCnYbEXP1+iQvCC/P1YXHMA/t6x1Ksp0Y9VwhLFsiBJFzV1zIxrOIE2LKaGGhDjQ29xq9cbq6omDXA==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.141.0.tgz",
+      "integrity": "sha512-3wnwk/l1CvszVE5TJR1wSl/zSEfydRqrNhn6s7Vr9IzSJpUQIroqVsIoPARHRFA+FQwkxAFDAHDAasa7v8OobQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.141.0.tgz",
+      "integrity": "sha512-qtyQVAAebFq57B2tifTlel3TgGqUtsYNI/e+p6aya9rN9lOZVTDvr215fGYSA9XWooxzMxDiVxkBLk2jQHbsOQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.141.0.tgz",
+      "integrity": "sha512-SkGV1nKw40roEc94pv5EaaeH2ay14G6+roe8Q0wIUC1LcEKxzKW921h7+ZuZX0D3q2Mb/7aSFmxEVqnko3lPRw==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.141.0.tgz",
+      "integrity": "sha512-cVgDM7n8QziQqOaP5hNgUYfMG7S/ZeuPxFWXnnHRv7rh025COk0rfQ6eEdKG3j/GaUuyvNZN4ifF1J8KmuXLLA==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.141.0.tgz",
+      "integrity": "sha512-HggH++Fkn3OilBn+bs3jpgIFQa34oMAyUUHy0vpGum+gt1Eb5nyLc8dNU/RAPSw6lsLrx7ncKtHSZE+3Sp0l2g==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      }
+    },
+    "@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.141.0.tgz",
+      "integrity": "sha512-KLSEH9GwgbrqbJOjtGHt9STw96s+78yDzp7IDN8Lno+7Ut9sNBfZ4jYZIz4mD50qmWUjoOI7i9I6UENbhNbMZQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.141.0.tgz",
+      "integrity": "sha512-9UVWUOOCI/1YkiSSNjg2zyBJYM9E/t1A/8GNobd48JDn/fQ6mzxcVO3H08jb3rAaW/B1VBf8eCORTvSsO9T08g==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.141.0.tgz",
+      "integrity": "sha512-HI/wsvbWT5RHHw5c37D0fEgeTd8/1Q4OJs5jUmEBc17VZFG6SsCIe4barq7NsAPPks/JW+3ayi3Rp+PQI5h4Kg==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-project/types": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.141.0.tgz",
+      "integrity": "sha512-S4as7z0j0xQkXcJlyY5ehntwK8/wRkQb9Cyqw+J/N2rkWGQGK0SxD6X6DhQTc7qsxVTBxXbxZtBJh3mr3PtIzQ==",
+      "dev": true
+    },
+    "@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
       }
     },
     "@types/esprima": {
@@ -8127,6 +8808,35 @@
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
+      }
+    },
+    "oxc-parser": {
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.141.0.tgz",
+      "integrity": "sha512-uFkGGr1KMWd6aWv9UAqooYrN78trw8MWWmoPvgWokfBEUq1+eiIQ+qfj3wokhy0fxtZWZk+0dHoS7/yRTJtd6w==",
+      "dev": true,
+      "requires": {
+        "@oxc-parser/binding-android-arm-eabi": "0.141.0",
+        "@oxc-parser/binding-android-arm64": "0.141.0",
+        "@oxc-parser/binding-darwin-arm64": "0.141.0",
+        "@oxc-parser/binding-darwin-x64": "0.141.0",
+        "@oxc-parser/binding-freebsd-x64": "0.141.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.141.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.141.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.141.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.141.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.141.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.141.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.141.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.141.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.141.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.141.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.141.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.141.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.141.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.141.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.141.0",
+        "@oxc-project/types": "^0.141.0"
       }
     },
     "p-limit": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "glob": "8.0.3",
     "lint-staged": "^13.2.2",
     "mocha": "^10.2.0",
+    "oxc-parser": "^0.141.0",
     "prettier": "^2.6.2",
     "reify": "0.20.12",
     "typescript": "^4.9.4"

--- a/parsers/_oxc_ast_types.ts
+++ b/parsers/_oxc_ast_types.ts
@@ -1,0 +1,184 @@
+import * as types from "ast-types";
+
+interface MutableAstTypesDefinition {
+  finalized: boolean;
+  allFields: Record<
+    string,
+    {
+      type: {
+        check(value: unknown): boolean;
+      };
+    }
+  >;
+  field(
+    name: string,
+    type: unknown,
+    defaultFn?: () => unknown,
+  ): MutableAstTypesDefinition;
+}
+
+interface FieldExtension {
+  typeName: string;
+  fieldName: string;
+  fieldType: unknown;
+  defaultFn?: () => unknown;
+  unsupportedValue?: unknown;
+}
+
+function getMutableDefinition(typeName: string): MutableAstTypesDefinition {
+  const definition = types.Type.def(
+    typeName,
+  ) as unknown as Partial<MutableAstTypesDefinition>;
+
+  if (
+    typeof definition.field !== "function" ||
+    typeof definition.allFields !== "object" ||
+    definition.allFields === null
+  ) {
+    throw new Error(
+      `Cannot extend the ast-types ${typeName} definition for the Oxc parser`,
+    );
+  }
+
+  return definition as MutableAstTypesDefinition;
+}
+
+/**
+ * ast-types 0.16.1 predates these TypeScript fields. Without registering
+ * them, ast-types visitors silently skip normalized Oxc subtrees even though
+ * Recast's printer supports them.
+ *
+ * The default ast-types fork has already been finalized by the time a parser
+ * is loaded. Reopening only the affected definitions and finalizing the same
+ * fork preserves the identity of Recast's public `types` object.
+ *
+ * @internal
+ */
+export function registerOxcAstTypesExtensions(): void {
+  const typeParametersType = types.Type.or(
+    types.namedTypes.TSTypeParameterInstantiation,
+    null,
+  );
+  const typeAnnotationType = types.Type.or(
+    types.namedTypes.TypeAnnotation,
+    types.namedTypes.TSTypeAnnotation,
+    null,
+  );
+  const decoratorsType = types.Type.or(
+    types.Type.from([types.namedTypes.Decorator]),
+    null,
+  );
+  const fields: FieldExtension[] = [
+    {
+      typeName: "ArrayPattern",
+      fieldName: "optional",
+      fieldType: types.builtInTypes.boolean,
+      defaultFn: () => false,
+    },
+    {
+      typeName: "ArrayPattern",
+      fieldName: "typeAnnotation",
+      fieldType: typeAnnotationType,
+      defaultFn: () => null,
+    },
+    {
+      typeName: "AssignmentPattern",
+      fieldName: "optional",
+      fieldType: types.builtInTypes.boolean,
+      defaultFn: () => false,
+    },
+    {
+      typeName: "AssignmentPattern",
+      fieldName: "typeAnnotation",
+      fieldType: typeAnnotationType,
+      defaultFn: () => null,
+    },
+    {
+      typeName: "CallExpression",
+      fieldName: "typeParameters",
+      fieldType: typeParametersType,
+      defaultFn: () => null,
+    },
+    {
+      typeName: "ClassDeclaration",
+      fieldName: "decorators",
+      fieldType: decoratorsType,
+      defaultFn: () => null,
+    },
+    {
+      typeName: "ClassExpression",
+      fieldName: "decorators",
+      fieldType: decoratorsType,
+      defaultFn: () => null,
+    },
+    {
+      typeName: "JSXOpeningElement",
+      fieldName: "typeParameters",
+      fieldType: typeParametersType,
+      defaultFn: () => null,
+    },
+    {
+      typeName: "NewExpression",
+      fieldName: "typeParameters",
+      fieldType: typeParametersType,
+      defaultFn: () => null,
+    },
+    {
+      typeName: "OptionalCallExpression",
+      fieldName: "typeParameters",
+      fieldType: typeParametersType,
+      defaultFn: () => null,
+    },
+    {
+      typeName: "ObjectPattern",
+      fieldName: "optional",
+      fieldType: types.builtInTypes.boolean,
+      defaultFn: () => false,
+    },
+    {
+      typeName: "TaggedTemplateExpression",
+      fieldName: "typeParameters",
+      fieldType: typeParametersType,
+      defaultFn: () => null,
+    },
+    {
+      typeName: "TSImportType",
+      fieldName: "options",
+      fieldType: types.Type.or(types.namedTypes.Expression, null),
+      defaultFn: () => null,
+    },
+    {
+      typeName: "TSTypeQuery",
+      fieldName: "typeParameters",
+      fieldType: typeParametersType,
+      defaultFn: () => null,
+    },
+    {
+      typeName: "VariableDeclaration",
+      fieldName: "kind",
+      fieldType: types.Type.or("var", "let", "const", "using", "await using"),
+      unsupportedValue: "using",
+    },
+  ];
+  let changed = false;
+
+  fields.forEach(
+    ({ typeName, fieldName, fieldType, defaultFn, unsupportedValue }) => {
+      const definition = getMutableDefinition(typeName);
+      const existingField = definition.allFields[fieldName];
+      if (
+        !existingField ||
+        (unsupportedValue !== undefined &&
+          !existingField.type.check(unsupportedValue))
+      ) {
+        definition.finalized = false;
+        definition.field(fieldName, fieldType, defaultFn);
+        changed = true;
+      }
+    },
+  );
+
+  if (changed) {
+    types.finalize();
+  }
+}

--- a/parsers/oxc.ts
+++ b/parsers/oxc.ts
@@ -5,6 +5,8 @@
 //     parser: require("recast/parsers/oxc")
 //   });
 //
+import { registerOxcAstTypesExtensions } from "./_oxc_ast_types";
+
 export interface OxcParserOptions {
   /**
    * Oxc uses the filename in diagnostics. Syntax selection is controlled by
@@ -71,6 +73,8 @@ const parseSync: (
   options: OxcParserOptions,
 ) => OxcParseResult = require("oxc-parser").parseSync;
 
+registerOxcAstTypesExtensions();
+
 export function createOxcParser(parserOptions: OxcParserOptions = {}) {
   const {
     filename = "source.tsx",
@@ -89,8 +93,8 @@ export function createOxcParser(parserOptions: OxcParserOptions = {}) {
         // Oxc does not currently expose tokens. Explicit parenthesis nodes
         // let Recast preserve parentheses without token look-behind/ahead.
         preserveParens,
-        range: recastOptions.range ?? baseOptions.range,
-        sourceType: recastOptions.sourceType ?? baseOptions.sourceType,
+        range: baseOptions.range ?? recastOptions.range,
+        sourceType: baseOptions.sourceType ?? recastOptions.sourceType,
       });
 
       if (result.errors.length > 0) {
@@ -99,6 +103,7 @@ export function createOxcParser(parserOptions: OxcParserOptions = {}) {
 
       const getLocation = createLocationResolver(source);
       const program = result.program;
+      normalizeAst(program, source);
       addLocations(program, getLocation);
 
       const hashbang = program.hashbang as OffsetNode | null;
@@ -107,7 +112,7 @@ export function createOxcParser(parserOptions: OxcParserOptions = {}) {
           source,
           hashbang.end!,
         );
-        program.interpreter = {
+        const interpreter: OffsetNode = {
           type: "InterpreterDirective",
           value: hashbang.value,
           start: hashbang.start,
@@ -117,6 +122,10 @@ export function createOxcParser(parserOptions: OxcParserOptions = {}) {
             end: getLocation(interpreterEnd),
           },
         };
+        if (Array.isArray(hashbang.range)) {
+          interpreter.range = [hashbang.start, interpreterEnd];
+        }
+        program.interpreter = interpreter;
         // Oxc excludes the hashbang from Program.start. Recast expects the
         // Program location to contain its interpreter, or a changed Program
         // can preserve the original hashbang and print the interpreter again.
@@ -163,6 +172,311 @@ export function parse(
   options?: RecastParserOptions,
 ): OffsetNode {
   return parser.parse(source, options);
+}
+
+function normalizeAst(
+  value: unknown,
+  source: string,
+  seen = new Set<object>(),
+): void {
+  if (!value || typeof value !== "object" || seen.has(value)) {
+    return;
+  }
+  seen.add(value);
+
+  const node = value as OffsetNode;
+
+  switch (node.type) {
+    case "PropertyDefinition":
+      node.type = "ClassProperty";
+      break;
+
+    case "TSAbstractPropertyDefinition":
+      node.type = "ClassProperty";
+      node.abstract = true;
+      break;
+
+    case "AccessorProperty":
+      node.type = "ClassAccessorProperty";
+      break;
+
+    case "TSAbstractAccessorProperty":
+      node.type = "ClassAccessorProperty";
+      node.abstract = true;
+      break;
+
+    case "TSInterfaceHeritage":
+    case "TSClassImplements":
+      node.type = "TSExpressionWithTypeArguments";
+      normalizeTypeArguments(node);
+      break;
+
+    case "ClassDeclaration":
+    case "ClassExpression":
+      node.superTypeParameters = node.superTypeArguments;
+      delete node.superTypeArguments;
+      break;
+
+    case "TSTypeReference":
+    case "TSInstantiationExpression":
+    case "TSTypeQuery":
+    case "JSXOpeningElement":
+    case "TaggedTemplateExpression":
+    case "CallExpression":
+    case "OptionalCallExpression":
+    case "NewExpression":
+      normalizeTypeArguments(node);
+      break;
+
+    case "TSFunctionType":
+    case "TSConstructorType":
+    case "TSMethodSignature":
+    case "TSCallSignatureDeclaration":
+    case "TSConstructSignatureDeclaration":
+      node.parameters = node.params;
+      node.typeAnnotation = node.returnType;
+      delete node.params;
+      delete node.returnType;
+      break;
+
+    case "TSEnumDeclaration": {
+      const body = node.body as OffsetNode;
+      node.members = body.members;
+      delete node.body;
+      break;
+    }
+
+    case "TSMappedType":
+      normalizeMappedType(node);
+      break;
+
+    case "TSTypeParameter":
+      if (node.constraint === null) {
+        delete node.constraint;
+      }
+      if (node.default === null) {
+        delete node.default;
+      }
+      break;
+
+    case "MethodDefinition":
+      if (
+        (node.value as OffsetNode | undefined)?.type ===
+        "TSEmptyBodyFunctionExpression"
+      ) {
+        normalizeDeclareMethod(node, false);
+      }
+      break;
+
+    case "TSAbstractMethodDefinition":
+      normalizeDeclareMethod(node, true);
+      break;
+
+    case "PrivateIdentifier": {
+      const name = node.name;
+      node.type = "PrivateName";
+      node.id = {
+        type: "Identifier",
+        name,
+        start: node.start! + 1,
+        end: node.end,
+      };
+      if (Array.isArray(node.range)) {
+        (node.id as OffsetNode).range = [node.start! + 1, node.end];
+      }
+      delete node.name;
+      break;
+    }
+
+    case "ImportExpression":
+      if (node.options || node.phase) {
+        normalizeDynamicImport(node);
+      }
+      break;
+
+    case "TSImportType":
+      node.argument = node.source;
+      node.typeParameters = node.typeArguments;
+      delete node.source;
+      delete node.typeArguments;
+      break;
+
+    case "TSTemplateLiteralType":
+      normalizeTemplateLiteralType(node);
+      break;
+
+    case "TSLiteralType":
+      normalizeTsLiteral(node);
+      break;
+
+    case "ImportDeclaration":
+    case "ExportAllDeclaration":
+    case "ExportNamedDeclaration": {
+      if (Array.isArray(node.attributes)) {
+        const attributes = node.attributes as OffsetNode[];
+        node.assertions = attributes;
+        node.importAttributesKeyword = getImportAttributesKeyword(
+          node,
+          attributes,
+          source,
+        );
+        delete node.attributes;
+      }
+      break;
+    }
+  }
+
+  Object.keys(node).forEach((key) => {
+    const child = node[key];
+    if (Array.isArray(child)) {
+      child.forEach((item) => normalizeAst(item, source, seen));
+    } else {
+      normalizeAst(child, source, seen);
+    }
+  });
+}
+
+function normalizeDeclareMethod(node: OffsetNode, abstract: boolean): void {
+  const value = node.value as OffsetNode;
+  node.type = "TSDeclareMethod";
+  node.abstract = abstract;
+  node.async = value.async;
+  node.generator = value.generator;
+  node.params = value.params;
+  node.returnType = value.returnType;
+  node.typeParameters = value.typeParameters;
+  if (node.accessibility === null) {
+    delete node.accessibility;
+  }
+  delete node.value;
+}
+
+function normalizeTypeArguments(node: OffsetNode): void {
+  node.typeParameters = node.typeArguments;
+  delete node.typeArguments;
+}
+
+function normalizeMappedType(node: OffsetNode): void {
+  const key = node.key as OffsetNode;
+  const constraint = node.constraint as OffsetNode;
+  const typeParameter: OffsetNode = {
+    type: "TSTypeParameter",
+    name: key,
+    constraint,
+    start: key.start,
+    end: constraint.end,
+  };
+  if (Array.isArray(node.range)) {
+    typeParameter.range = [key.start, constraint.end];
+  }
+
+  node.typeParameter = typeParameter;
+  delete node.key;
+  delete node.constraint;
+}
+
+function normalizeTemplateLiteralType(node: OffsetNode): void {
+  const literal: OffsetNode = {
+    type: "TemplateLiteral",
+    quasis: node.quasis,
+    expressions: node.types,
+    start: node.start,
+    end: node.end,
+  };
+  if (Array.isArray(node.range)) {
+    literal.range = [...node.range];
+  }
+
+  node.type = "TSLiteralType";
+  node.literal = literal;
+  delete node.quasis;
+  delete node.types;
+}
+
+function normalizeTsLiteral(node: OffsetNode): void {
+  const literal = node.literal as OffsetNode;
+  if (literal.type !== "Literal") {
+    return;
+  }
+
+  if (typeof literal.value === "string") {
+    literal.type = "StringLiteral";
+  } else if (typeof literal.value === "number") {
+    literal.type = "NumericLiteral";
+  } else if (typeof literal.value === "boolean") {
+    literal.type = "BooleanLiteral";
+  } else if (typeof literal.value === "bigint") {
+    literal.type = "BigIntLiteral";
+    literal.value = String(literal.bigint ?? literal.value);
+    delete literal.bigint;
+  }
+}
+
+function normalizeDynamicImport(node: OffsetNode): void {
+  const source = node.source;
+  const options = node.options;
+  const phase = node.phase;
+  const calleeEnd = node.start! + "import".length;
+  const importCallee: OffsetNode = {
+    type: "Import",
+    start: node.start,
+    end: calleeEnd,
+  };
+  if (Array.isArray(node.range)) {
+    importCallee.range = [node.start, calleeEnd];
+  }
+
+  let callee = importCallee;
+  if (typeof phase === "string") {
+    const propertyStart = calleeEnd + 1;
+    const propertyEnd = propertyStart + phase.length;
+    const property: OffsetNode = {
+      type: "Identifier",
+      name: phase,
+      start: propertyStart,
+      end: propertyEnd,
+    };
+    callee = {
+      type: "MemberExpression",
+      object: importCallee,
+      property,
+      computed: false,
+      optional: false,
+      start: node.start,
+      end: propertyEnd,
+    };
+    if (Array.isArray(node.range)) {
+      property.range = [propertyStart, propertyEnd];
+      callee.range = [node.start, propertyEnd];
+    }
+  }
+
+  node.type = "CallExpression";
+  node.callee = callee;
+  node.arguments = options ? [source, options] : [source];
+  node.optional = false;
+  delete node.source;
+  delete node.options;
+  delete node.phase;
+}
+
+function getImportAttributesKeyword(
+  node: OffsetNode,
+  attributes: OffsetNode[],
+  source: string,
+): "assert" | "with" | undefined {
+  const sourceNode = node.source as OffsetNode;
+  const clauseEnd = attributes[0]?.start ?? node.end;
+  if (typeof sourceNode?.end === "number" && typeof clauseEnd === "number") {
+    const clause = source
+      .slice(sourceNode.end, clauseEnd)
+      .replace(/\/\*[\s\S]*?\*\/|\/\/[^\r\n]*/g, " ");
+    const match = /\b(assert|with)\s*\{/.exec(clause);
+    if (match) {
+      return match[1] as "assert" | "with";
+    }
+  }
+  return attributes.length > 0 ? "assert" : undefined;
 }
 
 function addLocations(

--- a/parsers/oxc.ts
+++ b/parsers/oxc.ts
@@ -1,0 +1,262 @@
+// This module is suitable for passing as options.parser when calling
+// recast.parse to process JavaScript and TypeScript code with Oxc:
+//
+//   const ast = recast.parse(source, {
+//     parser: require("recast/parsers/oxc")
+//   });
+//
+export interface OxcParserOptions {
+  /**
+   * Oxc uses the filename in diagnostics. Syntax selection is controlled by
+   * `lang`, which defaults to `tsx` so the parser accepts JavaScript, JSX,
+   * TypeScript, and TSX syntax.
+   */
+  filename?: string;
+  lang?: "js" | "jsx" | "ts" | "tsx" | "dts";
+  sourceType?: "script" | "module" | "commonjs" | "unambiguous";
+  astType?: "js" | "ts";
+  range?: boolean;
+  preserveParens?: boolean;
+  showSemanticErrors?: boolean;
+}
+
+interface RecastParserOptions {
+  range?: boolean;
+  sourceType?: OxcParserOptions["sourceType"];
+}
+
+interface Position {
+  line: number;
+  column: number;
+}
+
+interface SourceLocation {
+  start: Position;
+  end: Position;
+}
+
+interface OffsetNode {
+  type?: string;
+  start?: number;
+  end?: number;
+  loc?: SourceLocation;
+  [key: string]: unknown;
+}
+
+interface OxcComment {
+  type: "Line" | "Block";
+  value: string;
+  start: number;
+  end: number;
+}
+
+interface OxcError {
+  message: string;
+  labels: Array<{
+    message: string | null;
+    start: number;
+    end: number;
+  }>;
+}
+
+interface OxcParseResult {
+  program: OffsetNode;
+  comments: OxcComment[];
+  errors: OxcError[];
+}
+
+const parseSync: (
+  filename: string,
+  source: string,
+  options: OxcParserOptions,
+) => OxcParseResult = require("oxc-parser").parseSync;
+
+export function createOxcParser(parserOptions: OxcParserOptions = {}) {
+  const {
+    filename = "source.tsx",
+    lang = "tsx",
+    astType = "ts",
+    preserveParens = true,
+    ...baseOptions
+  } = parserOptions;
+
+  return {
+    parse(source: string, recastOptions: RecastParserOptions = {}) {
+      const result = parseSync(filename, source, {
+        ...baseOptions,
+        lang,
+        astType,
+        // Oxc does not currently expose tokens. Explicit parenthesis nodes
+        // let Recast preserve parentheses without token look-behind/ahead.
+        preserveParens,
+        range: recastOptions.range ?? baseOptions.range,
+        sourceType: recastOptions.sourceType ?? baseOptions.sourceType,
+      });
+
+      if (result.errors.length > 0) {
+        throw toSyntaxError(result.errors[0], source);
+      }
+
+      const getLocation = createLocationResolver(source);
+      const program = result.program;
+      addLocations(program, getLocation);
+
+      const hashbang = program.hashbang as OffsetNode | null;
+      if (hashbang) {
+        const interpreterEnd = includeFollowingLineTerminator(
+          source,
+          hashbang.end!,
+        );
+        program.interpreter = {
+          type: "InterpreterDirective",
+          value: hashbang.value,
+          start: hashbang.start,
+          end: interpreterEnd,
+          loc: {
+            start: hashbang.loc!.start,
+            end: getLocation(interpreterEnd),
+          },
+        };
+        // Oxc excludes the hashbang from Program.start. Recast expects the
+        // Program location to contain its interpreter, or a changed Program
+        // can preserve the original hashbang and print the interpreter again.
+        program.start = hashbang.start;
+        program.loc!.start = hashbang.loc!.start;
+        if (Array.isArray(program.range)) {
+          program.range[0] = hashbang.start;
+        }
+        delete program.hashbang;
+      }
+
+      const comments = result.comments
+        // Oxc reports a hashbang both as Program.hashbang and as a line
+        // comment. Recast prints it through Program.interpreter.
+        .filter(
+          (comment) =>
+            !hashbang ||
+            comment.start !== hashbang.start ||
+            comment.end !== hashbang.end,
+        )
+        .map((comment) => ({
+          ...comment,
+          loc: {
+            start: getLocation(comment.start),
+            end: getLocation(comment.end),
+          },
+        }));
+
+      program.comments = comments;
+      // Supplying an empty array prevents Recast from falling back to
+      // Esprima's tokenizer, which cannot tokenize TypeScript. Explicit
+      // ParenthesizedExpression nodes cover Recast's main use of tokens.
+      program.tokens = [];
+
+      return program;
+    },
+  };
+}
+
+const parser = createOxcParser();
+
+export function parse(
+  source: string,
+  options?: RecastParserOptions,
+): OffsetNode {
+  return parser.parse(source, options);
+}
+
+function addLocations(
+  value: unknown,
+  getLocation: (offset: number) => Position,
+  seen = new Set<object>(),
+): void {
+  if (!value || typeof value !== "object" || seen.has(value)) {
+    return;
+  }
+  seen.add(value);
+
+  const node = value as OffsetNode;
+  if (typeof node.start === "number" && typeof node.end === "number") {
+    node.loc = {
+      start: getLocation(node.start),
+      end: getLocation(node.end),
+    };
+  }
+
+  Object.keys(node).forEach((key) => {
+    if (key === "loc") {
+      return;
+    }
+    const child = node[key];
+    if (Array.isArray(child)) {
+      child.forEach((item) => addLocations(item, getLocation, seen));
+    } else {
+      addLocations(child, getLocation, seen);
+    }
+  });
+}
+
+function createLocationResolver(source: string) {
+  const lineStarts = [0];
+  for (let index = 0; index < source.length; index++) {
+    const character = source.charCodeAt(index);
+    if (character === 13 && source.charCodeAt(index + 1) === 10) {
+      lineStarts.push(index + 2);
+      index++;
+    } else if (
+      character === 10 ||
+      character === 13 ||
+      character === 0x2028 ||
+      character === 0x2029
+    ) {
+      lineStarts.push(index + 1);
+    }
+  }
+
+  return (offset: number): Position => {
+    let low = 0;
+    let high = lineStarts.length;
+    while (low + 1 < high) {
+      const middle = (low + high) >>> 1;
+      if (lineStarts[middle] <= offset) {
+        low = middle;
+      } else {
+        high = middle;
+      }
+    }
+    return {
+      line: low + 1,
+      column: offset - lineStarts[low],
+    };
+  };
+}
+
+function includeFollowingLineTerminator(
+  source: string,
+  offset: number,
+): number {
+  if (source[offset] === "\r" && source[offset + 1] === "\n") {
+    return offset + 2;
+  }
+  if (source[offset] === "\r" || source[offset] === "\n") {
+    return offset + 1;
+  }
+  return offset;
+}
+
+function toSyntaxError(diagnostic: OxcError, source: string): SyntaxError {
+  const error = new SyntaxError(diagnostic.message);
+  const label = diagnostic.labels[0];
+  if (label) {
+    const position = createLocationResolver(source)(label.start);
+    Object.assign(error, {
+      loc: position,
+      pos: label.start,
+    });
+  }
+  Object.defineProperty(error, "cause", {
+    value: diagnostic,
+    configurable: true,
+  });
+  return error;
+}

--- a/test/comments.ts
+++ b/test/comments.ts
@@ -19,15 +19,24 @@ const annotated = [
 ];
 
 const nodeMajorVersion = parseInt(process.versions.node, 10);
+const nodeMinorVersion = parseInt(process.versions.node.split(".")[1], 10);
+const supportsOxcParser =
+  (nodeMajorVersion === 20 && nodeMinorVersion >= 19) ||
+  nodeMajorVersion > 22 ||
+  (nodeMajorVersion === 22 && nodeMinorVersion >= 12);
 
 describe("comments", function () {
-  [
+  const parserIds = [
     "../parsers/acorn",
     "../parsers/babel",
     "../parsers/esprima",
     "../parsers/flow",
     "../parsers/typescript",
-  ].forEach(runTestsForParser);
+  ];
+  if (supportsOxcParser) {
+    parserIds.push("../parsers/oxc");
+  }
+  parserIds.forEach(runTestsForParser);
 });
 
 function runTestsForParser(parserId: any) {
@@ -183,6 +192,7 @@ function runTestsForParser(parserId: any) {
         babel: babelInfo,
         esprima: esprimaInfo,
         flow: babelInfo,
+        oxc: esprimaInfo,
         typescript: babelInfo,
       } as any
     )[parserName];
@@ -842,7 +852,10 @@ function runTestsForParser(parserId: any) {
       const args = ast.program.body[0].expression.arguments;
 
       args.unshift(args[1]);
-      const expected = "testFunc(b, /** @type {string} */ a, b);";
+      const expected =
+        parserName === "oxc"
+          ? "testFunc(b, /** @type {string} */ (a), b);"
+          : "testFunc(b, /** @type {string} */ a, b);";
 
       assert.strictEqual(recast.print(ast).code, expected);
     },

--- a/test/oxc-compat.ts
+++ b/test/oxc-compat.ts
@@ -1,0 +1,755 @@
+import assert from "assert";
+import * as types from "ast-types";
+import fs from "fs";
+import path from "path";
+import { parse } from "../lib/parser";
+import { Printer } from "../lib/printer";
+
+const nodeMajorVersion = parseInt(process.versions.node, 10);
+const nodeMinorVersion = parseInt(process.versions.node.split(".")[1], 10);
+const supportsOxcParser =
+  (nodeMajorVersion === 20 && nodeMinorVersion >= 19) ||
+  nodeMajorVersion > 22 ||
+  (nodeMajorVersion === 22 && nodeMinorVersion >= 12);
+
+interface Fixture {
+  name: string;
+  source: string;
+}
+
+const fixtures: Fixture[] = [
+  {
+    name: "type-only import equals",
+    source: 'import type X = require("x");',
+  },
+  {
+    name: "import types with options and arguments",
+    source:
+      'type T = import("pkg", { with: { "resolution-mode": "import" } }).Foo<string>;',
+  },
+  {
+    name: "type queries and abstract constructors",
+    source: [
+      "type Query = typeof Foo<string>;",
+      "type Factory = abstract new () => Query;",
+    ].join("\n"),
+  },
+  {
+    name: "type parameter modifiers and signatures",
+    source: [
+      "interface Variance<in T, out U> {",
+      "  method(value: T): U;",
+      "  (value: T): U;",
+      "}",
+      "class Box<const T> extends Base<T> implements Container<T> {}",
+    ].join("\n"),
+  },
+  {
+    name: "class members and parameter properties",
+    source: [
+      "class Base { value = 1; }",
+      "class Derived extends Base {",
+      "  #privateValue: number;",
+      "  accessor item: string;",
+      "  constructor(public override value: number) { super(); }",
+      "  optional?(): void;",
+      "}",
+    ].join("\n"),
+  },
+  {
+    name: "phased dynamic imports",
+    source: 'const value = import.source("x", { with: { type: "bytes" } });',
+  },
+  {
+    name: "static import attributes",
+    source: [
+      'import data from "x" with { type: "json" };',
+      'export * from "x" with {};',
+    ].join("\n"),
+  },
+  {
+    name: "mapped, template literal, and enum types",
+    source: [
+      "type M<T> = { -readonly [K in keyof T]+?: T[K] };",
+      "type Event = `on${string}`;",
+      "enum E { A, B = 2 }",
+    ].join("\n"),
+  },
+  {
+    name: "typed optional patterns and module kinds",
+    source: [
+      "namespace N {}",
+      "module M {}",
+      "const array = ([value]?: [number]) => value;",
+      "const object = ({ value }?: { value: number }) => value;",
+    ].join("\n"),
+  },
+  {
+    name: "decorated classes and members",
+    source: [
+      "@sealed",
+      "export class Service {",
+      "  @tracked accessor value: string;",
+      "  @bound method(input: string): void {}",
+      "}",
+    ].join("\n"),
+  },
+  {
+    name: "explicit resource management",
+    source: [
+      "using resource = acquire();",
+      "await using asyncResource = acquireAsync();",
+    ].join("\n"),
+  },
+  {
+    name: "satisfies and instantiation expressions",
+    source: [
+      "const config = { mode: 'strict' } satisfies Config;",
+      "const specialized = factory<string>;",
+    ].join("\n"),
+  },
+  {
+    name: "literal types and typed calls",
+    source: [
+      'type Literals = "text" | 1 | true | 1n | -1;',
+      "const called = factory<string>();",
+      "const optional = factory?.<number>();",
+      "const created = new Box<boolean>();",
+    ].join("\n"),
+  },
+  {
+    name: "type-only import and export specifiers",
+    source: [
+      'import { type Input, output as value } from "pkg";',
+      "export { type Input, value };",
+      'export type * from "types";',
+    ].join("\n"),
+  },
+  {
+    name: "ambient and abstract declarations",
+    source: [
+      "declare namespace Runtime {",
+      "  abstract class Base { abstract method(): void; }",
+      "}",
+      'declare module "virtual" { export const value: string; }',
+    ].join("\n"),
+  },
+  {
+    name: "complex typed binding patterns",
+    source: [
+      "function consume(",
+      "  { value = 1, ...rest }: { value?: number; rest?: unknown },",
+      "  [head, ...tail]: [string, ...number[]],",
+      "): void {}",
+    ].join("\n"),
+  },
+  {
+    name: "modern tuple types",
+    source: [
+      "type Named = readonly [name?: string, ...values: number[]];",
+      "type Variadic<T extends unknown[]> = [head: string, ...tail: T];",
+    ].join("\n"),
+  },
+  {
+    name: "TSX and typed tagged templates",
+    source: [
+      "const element = <Component<string> />;",
+      "const output = tag<number>`value`;",
+    ].join("\n"),
+  },
+  {
+    name: "hashbang metadata",
+    source: "#!/usr/bin/env node\nconst value = 1;",
+  },
+];
+
+const metadataFields = new Set([
+  "start",
+  "end",
+  "loc",
+  "range",
+  "raw",
+  "comments",
+]);
+
+// These fields are emitted by Oxc and retained because they are semantically
+// meaningful or useful parser metadata, but ast-types 0.16.1 does not declare
+// them. The semantic round-trip tests below ensure printer support for the
+// meaningful fields, while this allowlist makes newly observed fields fail.
+const knownAstTypeExtensions = new Set([
+  "ClassAccessorProperty.declare",
+  "ClassDeclaration.abstract",
+  "ClassDeclaration.declare",
+  "ClassProperty.accessibility",
+  "ClassProperty.declare",
+  "ClassProperty.decorators",
+  "ClassProperty.definite",
+  "ClassProperty.optional",
+  "ClassProperty.override",
+  "ClassProperty.readonly",
+  "ExportAllDeclaration.exportKind",
+  "ExportAllDeclaration.importAttributesKeyword",
+  "ExportDefaultDeclaration.exportKind",
+  "ExportNamedDeclaration.exportKind",
+  "ExportNamedDeclaration.importAttributesKeyword",
+  "ExportSpecifier.exportKind",
+  "ExpressionStatement.directive",
+  "File.tokens",
+  "FunctionDeclaration.declare",
+  "FunctionExpression.declare",
+  "Identifier.decorators",
+  "ImportDeclaration.importAttributesKeyword",
+  "ImportDeclaration.phase",
+  "ImportSpecifier.importKind",
+  "Literal.regex",
+  "MethodDefinition.accessibility",
+  "MethodDefinition.optional",
+  "MethodDefinition.override",
+  "Program.hashbang",
+  "Program.sourceType",
+  "Property.optional",
+  "RestElement.decorators",
+  "RestElement.optional",
+  "RestElement.value",
+  "ArrayPattern.decorators",
+  "AssignmentPattern.decorators",
+  "ClassExpression.abstract",
+  "ClassExpression.declare",
+  "TSConstructorType.abstract",
+  "TSDeclareMethod.override",
+  "TSEnumMember.computed",
+  "TSImportEqualsDeclaration.importKind",
+  "TSMappedType.nameType",
+  "TSMethodSignature.accessibility",
+  "TSMethodSignature.kind",
+  "TSMethodSignature.readonly",
+  "TSMethodSignature.static",
+  "TSModuleDeclaration.kind",
+  "TSParameterProperty.decorators",
+  "TSParameterProperty.override",
+  "TSParameterProperty.static",
+  "TSIndexSignature.accessibility",
+  "TSIndexSignature.static",
+  "TSPropertySignature.accessibility",
+  "TSPropertySignature.static",
+  "TSTypeParameter.const",
+  "TSTypeParameter.in",
+  "TSTypeParameter.out",
+  "VariableDeclaration.declare",
+  "VariableDeclarator.definite",
+]);
+
+if (supportsOxcParser) {
+  const oxcParser = require("../parsers/oxc");
+  const parseSync = require("oxc-parser").parseSync;
+  const corpusFixtures = loadCorpusFixtures().filter((fixture) =>
+    canParseFixture(fixture, parseSync),
+  );
+  const auditedFixtures = fixtures.concat(corpusFixtures);
+
+  describe("Oxc compatibility audit", function () {
+    it("registers ast-types extensions idempotently on Recast's shared types", function () {
+      const recast = require("../main");
+      const {
+        registerOxcAstTypesExtensions,
+      } = require("../parsers/_oxc_ast_types");
+      const callDefinition = types.Type.def("CallExpression") as any;
+      const typeParametersField = callDefinition.allFields.typeParameters;
+
+      registerOxcAstTypesExtensions();
+      registerOxcAstTypesExtensions();
+
+      assert.strictEqual(recast.types, types);
+      assert.strictEqual(
+        callDefinition.allFields.typeParameters,
+        typeParametersField,
+      );
+      assert.strictEqual(
+        types.builders.variableDeclaration("const", []).kind,
+        "const",
+      );
+    });
+
+    fixtures.forEach((fixture) => {
+      it(`preserves semantics when generically printing ${fixture.name}`, function () {
+        assert.strictEqual(
+          assertSemanticRoundTrip(fixture, oxcParser, parseSync),
+          true,
+          `${fixture.name} should be valid Oxc input`,
+        );
+      });
+    });
+
+    it("preserves semantics across the existing TypeScript fixture corpus", function () {
+      corpusFixtures.forEach((fixture) => {
+        assert.strictEqual(
+          assertSemanticRoundTrip(fixture, oxcParser, parseSync),
+          true,
+          `${fixture.name} should remain valid Oxc input`,
+        );
+      });
+
+      assert.ok(
+        corpusFixtures.length >= 60,
+        `Expected at least 60 valid Oxc fixtures, checked ${corpusFixtures.length}`,
+      );
+    });
+
+    it("preserves semantics when mutated nodes use Recast's patching path", function () {
+      auditedFixtures.forEach((fixture) => {
+        assert.ok(
+          assertMutationRoundTrip(fixture, oxcParser, parseSync) > 0,
+          `Expected at least one statement mutation in ${fixture.name}`,
+        );
+      });
+    });
+
+    it("recognizes every node and detects new ast-types field gaps", function () {
+      const unknownFields = new Set<string>();
+
+      auditedFixtures.forEach((fixture) => {
+        const ast = parse(fixture.source, {
+          parser: oxcParser,
+          range: true,
+        });
+        collectNodes(ast).forEach(({ node }) => {
+          assert.ok(
+            (types.namedTypes as Record<string, unknown>)[node.type],
+            `ast-types does not recognize ${node.type} in ${fixture.name}`,
+          );
+
+          const knownFields = new Set(types.getFieldNames(node));
+          Object.keys(node).forEach((field) => {
+            if (!metadataFields.has(field) && !knownFields.has(field)) {
+              unknownFields.add(`${node.type}.${field}`);
+            }
+          });
+        });
+      });
+
+      const unexpected = Array.from(unknownFields).filter(
+        (field) => !knownAstTypeExtensions.has(field),
+      );
+      assert.deepStrictEqual(
+        unexpected,
+        [],
+        `New Oxc fields need normalization or printer support:\n${unexpected.join(
+          "\n",
+        )}`,
+      );
+    });
+
+    it("deeply matches the ast-types schema", function () {
+      const mismatches: string[] = [];
+
+      auditedFixtures.forEach((fixture) => {
+        const ast = parse(fixture.source, {
+          parser: oxcParser,
+          range: true,
+        });
+        const schemaMismatches = collectSchemaMismatches(ast);
+        schemaMismatches.forEach((mismatch) => {
+          mismatches.push(`${fixture.name}: ${mismatch}`);
+        });
+
+        if (schemaMismatches.length === 0) {
+          try {
+            types.namedTypes.File.assert(ast, true);
+          } catch (error) {
+            mismatches.push(
+              `${fixture.name}: deep assertion failed: ${
+                (error as Error).message
+              }`,
+            );
+          }
+        }
+      });
+
+      assert.deepStrictEqual(
+        mismatches,
+        [],
+        `Normalized Oxc AST does not match ast-types:\n${mismatches.join(
+          "\n",
+        )}`,
+      );
+    });
+
+    it("detects new ast-types traversal gaps", function () {
+      const traversalGaps = new Set<string>();
+
+      auditedFixtures.forEach((fixture) => {
+        const ast = parse(fixture.source, { parser: oxcParser });
+        const nodes = collectNodes(ast);
+        const visited = new Set<object>();
+        types.visit(ast, {
+          visitNode(path) {
+            visited.add(path.node);
+            this.traverse(path);
+          },
+        });
+
+        nodes.forEach(({ node, parent, field }) => {
+          if (parent && field && visited.has(parent) && !visited.has(node)) {
+            traversalGaps.add(`${parent.type}.${field}`);
+          }
+        });
+      });
+
+      assert.deepStrictEqual(
+        Array.from(traversalGaps),
+        [],
+        `Child fields are not traversed by ast-types:\n${Array.from(
+          traversalGaps,
+        ).join("\n")}`,
+      );
+    });
+
+    it("provides complete locations and ranges", function () {
+      auditedFixtures.forEach((fixture) => {
+        const ast = oxcParser.parse(fixture.source, {
+          range: true,
+        });
+
+        collectNodes(ast).forEach(({ node }) => {
+          if (typeof node.start !== "number" || typeof node.end !== "number") {
+            return;
+          }
+
+          assert.deepStrictEqual(
+            node.range,
+            [node.start, node.end],
+            `${node.type} has an invalid range in ${fixture.name}`,
+          );
+          assert.ok(
+            node.loc,
+            `${node.type} has no location in ${fixture.name}`,
+          );
+        });
+      });
+    });
+  });
+}
+
+function loadCorpusFixtures(): Fixture[] {
+  const files = new Set<string>();
+  [
+    "data/babel-parser/test/fixtures/typescript/**/input.js",
+    "data/graphql-tools-src/**/*.ts",
+  ].forEach((pattern) => {
+    require("glob")
+      .sync(pattern, { cwd: __dirname })
+      .forEach((file: string) => files.add(file));
+  });
+
+  return Array.from(files)
+    .sort()
+    .map((file) => ({
+      name: file,
+      source: fs.readFileSync(path.join(__dirname, file), "utf8"),
+    }));
+}
+
+interface AuditedNode {
+  type: string;
+  start?: number;
+  end?: number;
+  range?: [number, number];
+  loc?: unknown;
+  [key: string]: any;
+}
+
+interface CollectedNode {
+  node: AuditedNode;
+  parent: AuditedNode | null;
+  field: string | null;
+}
+
+function collectSchemaMismatches(value: unknown): string[] {
+  const mismatches: string[] = [];
+  const seen = new Set<object>();
+
+  function visit(child: unknown, path: string): void {
+    if (!child || typeof child !== "object" || seen.has(child)) {
+      return;
+    }
+    seen.add(child);
+
+    const possibleNode = child as AuditedNode;
+    if (typeof possibleNode.type === "string") {
+      const definition = types.Type.def(possibleNode.type);
+      definition.fieldNames.forEach((fieldName) => {
+        const field = definition.allFields[fieldName];
+        const fieldValue = field.getValue(possibleNode);
+        if (!field.type.check(fieldValue)) {
+          mismatches.push(
+            `${path}.${fieldName}: expected ${
+              field.type
+            }, received ${formatSchemaValue(fieldValue)}`,
+          );
+        }
+      });
+    }
+
+    Object.keys(possibleNode).forEach((key) => {
+      if (key === "loc" || key === "comments") {
+        return;
+      }
+      const nested = possibleNode[key];
+      if (Array.isArray(nested)) {
+        nested.forEach((item, index) =>
+          visit(item, `${path}.${key}[${index}]`),
+        );
+      } else {
+        visit(nested, `${path}.${key}`);
+      }
+    });
+  }
+
+  visit(value, "$");
+  return mismatches;
+}
+
+function formatSchemaValue(value: unknown): string {
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value
+      .map((item) =>
+        item && typeof item === "object" && "type" in item
+          ? (item as AuditedNode).type
+          : typeof item,
+      )
+      .join(", ")}]`;
+  }
+  if (typeof value === "object" && "type" in value) {
+    return String((value as AuditedNode).type);
+  }
+  return JSON.stringify(value);
+}
+
+function collectNodes(value: unknown): CollectedNode[] {
+  const nodes: CollectedNode[] = [];
+  const seen = new Set<object>();
+
+  function visit(
+    child: unknown,
+    parent: AuditedNode | null,
+    field: string | null,
+  ): void {
+    if (!child || typeof child !== "object" || seen.has(child)) {
+      return;
+    }
+    seen.add(child);
+
+    const possibleNode = child as AuditedNode;
+    const childIsNode = typeof possibleNode.type === "string";
+    const nextParent = childIsNode ? possibleNode : parent;
+    if (childIsNode) {
+      nodes.push({
+        node: possibleNode,
+        parent,
+        field,
+      });
+    }
+
+    Object.keys(possibleNode).forEach((key) => {
+      if (key === "loc" || key === "comments") {
+        return;
+      }
+      const nested = possibleNode[key];
+      if (Array.isArray(nested)) {
+        nested.forEach((item) => visit(item, nextParent, key));
+      } else {
+        visit(nested, nextParent, key);
+      }
+    });
+  }
+
+  visit(value, null, null);
+  return nodes;
+}
+
+function semanticProjection(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(semanticProjection);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  if ((value as Record<string, unknown>).type === "ParenthesizedExpression") {
+    return semanticProjection((value as Record<string, unknown>).expression);
+  }
+
+  const projected: Record<string, unknown> = {};
+  Object.keys(value)
+    .sort()
+    .forEach((key) => {
+      if (
+        !metadataFields.has(key) &&
+        key !== "parent" &&
+        (value as Record<string, unknown>)[key] !== undefined
+      ) {
+        projected[key] = semanticProjection(
+          (value as Record<string, unknown>)[key],
+        );
+      }
+    });
+  return projected;
+}
+
+function canParseFixture(fixture: Fixture, parseSync: any): boolean {
+  return (
+    parseSync("source.tsx", fixture.source, getOxcParseOptions()).errors
+      .length === 0
+  );
+}
+
+function getOxcParseOptions() {
+  return {
+    astType: "ts",
+    lang: "tsx",
+    preserveParens: true,
+  };
+}
+
+function assertSemanticRoundTrip(
+  fixture: Fixture,
+  oxcParser: any,
+  parseSync: any,
+): boolean {
+  const parseOptions = getOxcParseOptions();
+  const before = parseSync("source.tsx", fixture.source, parseOptions);
+  if (before.errors.length > 0) {
+    return false;
+  }
+
+  const ast = parse(fixture.source, { parser: oxcParser });
+  const printed = new Printer().printGenerically(ast).code;
+  const after = parseSync("source.tsx", printed, parseOptions);
+  assert.deepStrictEqual(
+    after.errors,
+    [],
+    `Generic output for ${fixture.name} no longer parses:\n${printed}`,
+  );
+  assert.deepStrictEqual(
+    semanticProjection(after.program),
+    semanticProjection(before.program),
+    `Semantic AST changed for ${fixture.name}:\n${printed}`,
+  );
+  return true;
+}
+
+function assertMutationRoundTrip(
+  fixture: Fixture,
+  oxcParser: any,
+  parseSync: any,
+): number {
+  const patchedAst = parse(fixture.source, { parser: oxcParser }) as any;
+  const genericAst = parse(fixture.source, { parser: oxcParser }) as any;
+  const patchedMutationCount = mutateAst(patchedAst);
+  const genericMutationCount = mutateAst(genericAst);
+  if (patchedMutationCount === 0 || genericMutationCount === 0) {
+    return 0;
+  }
+  assert.strictEqual(patchedMutationCount, genericMutationCount);
+
+  const patched = new Printer().print(patchedAst).code;
+  const generic = new Printer().printGenerically(genericAst).code;
+  const parseOptions = getOxcParseOptions();
+  const originalResult = parseSync("source.tsx", fixture.source, parseOptions);
+  const patchedResult = parseSync("source.tsx", patched, parseOptions);
+  const genericResult = parseSync("source.tsx", generic, parseOptions);
+
+  assert.deepStrictEqual(
+    patchedResult.errors,
+    [],
+    `Patched output for ${fixture.name} no longer parses:\n${patched}`,
+  );
+  assert.deepStrictEqual(
+    genericResult.errors,
+    [],
+    `Generic mutated output for ${fixture.name} no longer parses:\n${generic}`,
+  );
+  assert.notDeepStrictEqual(
+    semanticProjection(genericResult.program),
+    semanticProjection(originalResult.program),
+    `Mutation did not change the semantic AST for ${fixture.name}`,
+  );
+  assert.deepStrictEqual(
+    semanticProjection(patchedResult.program),
+    semanticProjection(genericResult.program),
+    `Patched and generic output differ after mutating ${fixture.name}:\n${patched}`,
+  );
+  return patchedMutationCount;
+}
+
+function mutateAst(ast: any): number {
+  const body = ast.program.body as AuditedNode[];
+  let mutationCount = 0;
+
+  for (let index = 0; index < body.length; index++) {
+    const statement = { ...body[index] };
+    if (mutateFirstLeaf(statement)) {
+      body[index] = statement;
+      mutationCount++;
+    }
+  }
+
+  return mutationCount;
+}
+
+function mutateFirstLeaf(value: unknown): boolean {
+  const nodes = collectNodes(value);
+  const identifierLocations = new Map<string, number>();
+  nodes.forEach(({ node }) => {
+    if (
+      node.type === "Identifier" &&
+      typeof node.start === "number" &&
+      typeof node.end === "number"
+    ) {
+      const location = `${node.start}:${node.end}`;
+      identifierLocations.set(
+        location,
+        (identifierLocations.get(location) || 0) + 1,
+      );
+    }
+  });
+  const identifier = nodes.find(
+    ({ node }) =>
+      node.type === "Identifier" &&
+      typeof node.name === "string" &&
+      identifierLocations.get(`${node.start}:${node.end}`) === 1,
+  );
+  if (identifier) {
+    identifier.node.name += "Audit";
+    return true;
+  }
+
+  const literal = nodes.find(
+    ({ node }) =>
+      (node.type === "Literal" || node.type === "StringLiteral") &&
+      typeof node.value === "string",
+  );
+  if (literal) {
+    literal.node.value += "-audit";
+    delete literal.node.raw;
+    return true;
+  }
+
+  const numericLiteral = nodes.find(
+    ({ node }) =>
+      (node.type === "Literal" || node.type === "NumericLiteral") &&
+      typeof node.value === "number",
+  );
+  if (numericLiteral) {
+    numericLiteral.node.value++;
+    delete numericLiteral.node.raw;
+    return true;
+  }
+
+  return false;
+}

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -8,18 +8,27 @@ const namedTypes = types.namedTypes;
 import FastPath from "../lib/fast-path";
 import { EOL as eol } from "os";
 const nodeMajorVersion = parseInt(process.versions.node, 10);
+const nodeMinorVersion = parseInt(process.versions.node.split(".")[1], 10);
+const supportsOxcParser =
+  (nodeMajorVersion === 20 && nodeMinorVersion >= 19) ||
+  nodeMajorVersion > 22 ||
+  (nodeMajorVersion === 22 && nodeMinorVersion >= 12);
 
 // Esprima seems unable to handle unnamed top-level functions, so declare
 // test functions with names and then export them later.
 
 describe("parser", function () {
-  [
+  const parserIds = [
     "../parsers/acorn",
     "../parsers/babel",
     "../parsers/esprima",
     "../parsers/flow",
     "../parsers/typescript",
-  ].forEach(runTestsForParser);
+  ];
+  if (supportsOxcParser) {
+    parserIds.push("../parsers/oxc");
+  }
+  parserIds.forEach(runTestsForParser);
 
   it("AlternateParser", function () {
     const b = types.builders;
@@ -44,6 +53,90 @@ describe("parser", function () {
     check({ esprima: parser });
     check({ parser: parser });
   });
+
+  if (supportsOxcParser) {
+    describe("oxc", function () {
+      const oxcParser = require("../parsers/oxc");
+
+      it("parses and reprints TypeScript, comments, and parentheses", function () {
+        const code = [
+          "// config",
+          "export default {",
+          "  foo: (1 + 2) * 3,",
+          "} satisfies Record<string, unknown>;",
+        ].join("\n");
+        const ast = parse(code, { parser: oxcParser });
+
+        assert.strictEqual(new Printer().print(ast).code, code);
+
+        ast.program.body[0].declaration.expression.properties.push(
+          types.builders.property(
+            "init",
+            types.builders.identifier("added"),
+            types.builders.literal(true),
+          ),
+        );
+
+        assert.strictEqual(
+          new Printer().print(ast).code,
+          [
+            "// config",
+            "export default {",
+            "  foo: (1 + 2) * 3,",
+            "  added: true",
+            "} satisfies Record<string, unknown>;",
+          ].join("\n"),
+        );
+      });
+
+      it("preserves hashbangs when inserting statements", function () {
+        const code = "#!/usr/bin/env node\nexport default {};";
+        const ast = parse(code, { parser: oxcParser });
+        ast.program.body.unshift(
+          types.builders.importDeclaration(
+            [
+              types.builders.importSpecifier(
+                types.builders.identifier("value"),
+              ),
+            ],
+            types.builders.literal("module"),
+          ),
+        );
+
+        assert.strictEqual(
+          new Printer().print(ast).code,
+          [
+            "#!/usr/bin/env node",
+            'import { value } from "module";',
+            "export default {};",
+          ].join("\n"),
+        );
+      });
+
+      it("reports syntax errors with locations", function () {
+        assert.throws(
+          () => parse("export default {", { parser: oxcParser }),
+          (error: SyntaxError & { loc?: types.namedTypes.Position }) => {
+            assert.strictEqual(error.name, "SyntaxError");
+            assert.deepStrictEqual(error.loc, { line: 1, column: 16 });
+            return true;
+          },
+        );
+      });
+
+      it("supports explicit language configuration", function () {
+        const parser = oxcParser.createOxcParser({
+          filename: "source.js",
+          lang: "js",
+        });
+
+        assert.throws(
+          () => parse("const value: number = 1", { parser }),
+          SyntaxError,
+        );
+      });
+    });
+  }
 });
 
 function runTestsForParser(parserId: string) {
@@ -87,6 +180,7 @@ function runTestsForParser(parserId: string) {
     babel: "CommentLine",
     esprima: "Line",
     flow: "CommentLine",
+    oxc: "Line",
     typescript: "CommentLine",
   };
 

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -113,6 +113,20 @@ describe("parser", function () {
         );
       });
 
+      it("calculates Unicode locations and ranges across CRLF", function () {
+        const code = '// café 😀\r\nconst first = "😀"; const second = 2;';
+        const program = oxcParser.parse(code, { range: true });
+        const declaration = program.body[1];
+        const start = code.indexOf("const second");
+
+        assert.strictEqual(declaration.start, start);
+        assert.deepStrictEqual(declaration.range, [start, code.length]);
+        assert.strictEqual(declaration.loc.start.line, 2);
+        assert.strictEqual(declaration.loc.start.column, 20);
+        assert.strictEqual(declaration.loc.end.line, 2);
+        assert.strictEqual(declaration.loc.end.column, 37);
+      });
+
       it("reports syntax errors with locations", function () {
         assert.throws(
           () => parse("export default {", { parser: oxcParser }),

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -149,6 +149,553 @@ describe("parser", function () {
           SyntaxError,
         );
       });
+
+      it("normalizes class and TypeScript nodes for traversal and printing", function () {
+        const code = [
+          "class A implements Contract<number> {",
+          "  x: number;",
+          "  #secret: string;",
+          "  accessor value: string;",
+          "  optional?(): void;",
+          "}",
+          "interface I extends B<string> {}",
+          "abstract class C {",
+          "  abstract foo(): void;",
+          "  abstract count: number;",
+          "  abstract accessor item: string;",
+          "}",
+        ].join("\n");
+        const ast = parse(code, { parser: oxcParser });
+        const field = ast.program.body[0].body.body[0];
+        const implementation = ast.program.body[0].implements[0];
+        const privateField = ast.program.body[0].body.body[1];
+        const accessor = ast.program.body[0].body.body[2];
+        const optionalMethod = ast.program.body[0].body.body[3];
+        const heritage = ast.program.body[1].extends[0];
+        const abstractMethod = ast.program.body[2].body.body[0];
+        const abstractField = ast.program.body[2].body.body[1];
+        const abstractAccessor = ast.program.body[2].body.body[2];
+
+        assert.strictEqual(field.type, "ClassProperty");
+        assert.strictEqual(
+          implementation.type,
+          "TSExpressionWithTypeArguments",
+        );
+        assert.strictEqual(privateField.type, "ClassProperty");
+        assert.strictEqual(privateField.key.type, "PrivateName");
+        assert.strictEqual(accessor.type, "ClassAccessorProperty");
+        assert.strictEqual(optionalMethod.type, "TSDeclareMethod");
+        assert.strictEqual(heritage.type, "TSExpressionWithTypeArguments");
+        assert.strictEqual(abstractMethod.type, "TSDeclareMethod");
+        assert.strictEqual(abstractField.type, "ClassProperty");
+        assert.strictEqual(abstractAccessor.type, "ClassAccessorProperty");
+
+        assert.doesNotThrow(() => {
+          types.visit(ast, {
+            visitNode(path) {
+              this.traverse(path);
+            },
+          });
+        });
+
+        field.key.name = "y";
+        implementation.expression.name = "OtherContract";
+        privateField.key.id.name = "privateValue";
+        accessor.key.name = "result";
+        optionalMethod.key.name = "maybe";
+        heritage.expression.name = "D";
+        abstractMethod.key.name = "bar";
+        abstractField.key.name = "total";
+        abstractAccessor.key.name = "entry";
+
+        assert.strictEqual(
+          new Printer().print(ast).code,
+          [
+            "class A implements OtherContract<number> {",
+            "  y: number;",
+            "  #privateValue: string;",
+            "  accessor result: string;",
+            "  maybe?(): void;",
+            "}",
+            "interface I extends D<string> {}",
+            "abstract class C {",
+            "  abstract bar(): void;",
+            "  abstract total: number;",
+            "  abstract accessor entry: string;",
+            "}",
+          ].join("\n"),
+        );
+      });
+
+      it("preserves static import attributes during generic printing", function () {
+        [
+          'import data from "./data.json" assert { type: "json" };',
+          'import data from "./data.json" with { type: "json" };',
+          'import data from "./data.json" with {};',
+          'export { default as data } from "./data.json" assert { type: "json" };',
+          'export * from "./data.json" with { type: "json" };',
+        ].forEach((code) => {
+          const ast = parse(code, { parser: oxcParser });
+
+          assert.strictEqual(new Printer().printGenerically(ast).code, code);
+        });
+      });
+
+      it("preserves type-only export-all declarations", function () {
+        const code = 'export type * from "types";';
+        const ast = parse(code, { parser: oxcParser });
+
+        assert.strictEqual(ast.program.body[0].exportKind, "type");
+        assert.strictEqual(new Printer().printGenerically(ast).code, code);
+      });
+
+      it("exposes class decorators to ast-types visitors", function () {
+        const code = [
+          "@sealed",
+          "export class Service {",
+          "  @tracked accessor value: string;",
+          "  @bound method(input: string): void {}",
+          "}",
+        ].join("\n");
+        const ast = parse(code, { parser: oxcParser });
+        const decorators: string[] = [];
+
+        types.visit(ast, {
+          visitDecorator(path) {
+            decorators.push((path.node.expression as any).name);
+            this.traverse(path);
+          },
+        });
+
+        assert.deepStrictEqual(decorators.sort(), [
+          "bound",
+          "sealed",
+          "tracked",
+        ]);
+        assert.strictEqual(
+          new Printer().printGenerically(ast).code,
+          [
+            "@sealed",
+            "export class Service {",
+            "    @tracked",
+            "    accessor value: string;",
+            "",
+            "    @bound",
+            "    method(input: string): void {}",
+            "}",
+          ].join("\n"),
+        );
+      });
+
+      it("ignores comments when detecting import attribute keywords", function () {
+        const code =
+          'import data from "./data.json" /* with compatibility */ assert { type: "json" };';
+        const ast = parse(code, { parser: oxcParser });
+
+        assert.strictEqual(new Printer().printGenerically(ast).code, code);
+      });
+
+      it("preserves dynamic import options during generic printing", function () {
+        const code =
+          'const data = import("./data.json", { with: { type: "json" } });';
+        const ast = parse(code, { parser: oxcParser });
+        const importCall = ast.program.body[0].declarations[0].init;
+        let visitedOptions = false;
+
+        assert.strictEqual(importCall.type, "CallExpression");
+        assert.strictEqual(importCall.callee.type, "Import");
+        assert.strictEqual(importCall.arguments.length, 2);
+
+        types.visit(importCall, {
+          visitObjectExpression(path) {
+            visitedOptions = true;
+            this.traverse(path);
+          },
+        });
+        assert.strictEqual(visitedOptions, true);
+
+        assert.strictEqual(
+          new Printer().printGenerically(ast).code,
+          [
+            'const data = import("./data.json", {',
+            "    with: {",
+            '        type: "json"',
+            "    }",
+            "});",
+          ].join("\n"),
+        );
+      });
+
+      it("normalizes TypeScript generic type arguments", function () {
+        const code = [
+          "type T = Promise<string>;",
+          "const value = create<number>;",
+          "class C extends Base<boolean> {}",
+          "const D = class extends Other<Date> {};",
+        ].join("\n");
+        const ast = parse(code, { parser: oxcParser });
+        const typeReference = ast.program.body[0].typeAnnotation;
+        const instantiation = ast.program.body[1].declarations[0].init;
+        const classDeclaration = ast.program.body[2];
+        const classExpression = ast.program.body[3].declarations[0].init;
+
+        assert.strictEqual(typeReference.typeArguments, undefined);
+        assert.strictEqual(typeReference.typeParameters.params.length, 1);
+        assert.strictEqual(instantiation.typeArguments, undefined);
+        assert.strictEqual(instantiation.typeParameters.params.length, 1);
+        [classDeclaration, classExpression].forEach((classNode) => {
+          assert.strictEqual(classNode.superTypeArguments, undefined);
+          assert.strictEqual(classNode.superTypeParameters.params.length, 1);
+        });
+        assert.strictEqual(new Printer().printGenerically(ast).code, code);
+      });
+
+      it("normalizes JSX and tagged template type arguments", function () {
+        const code = [
+          "const element = <Component<string> />;",
+          "const output = tag<number>`value`;",
+        ].join("\n");
+        const ast = parse(code, { parser: oxcParser });
+        const openingElement =
+          ast.program.body[0].declarations[0].init.openingElement;
+        const taggedTemplate = ast.program.body[1].declarations[0].init;
+
+        [openingElement, taggedTemplate].forEach((node) => {
+          assert.strictEqual(node.typeArguments, undefined);
+          assert.strictEqual(node.typeParameters.params.length, 1);
+        });
+        assert.strictEqual(new Printer().printGenerically(ast).code, code);
+      });
+
+      it("normalizes TypeScript signatures", function () {
+        const code = [
+          "type F = (x: string) => number;",
+          "type C = new (x: string) => number;",
+          "interface I {",
+          "  foo(): number;",
+          "  (x: string): number;",
+          "  new(x: string): I;",
+          "}",
+        ].join("\n");
+        const ast = parse(code, { parser: oxcParser });
+        const functionType = ast.program.body[0].typeAnnotation;
+        const constructorType = ast.program.body[1].typeAnnotation;
+        const signatures = ast.program.body[2].body.body;
+
+        [functionType, constructorType, ...signatures].forEach((signature) => {
+          assert.strictEqual(signature.params, undefined);
+          assert.ok(Array.isArray(signature.parameters));
+          assert.strictEqual(signature.returnType, undefined);
+          assert.strictEqual(signature.typeAnnotation.type, "TSTypeAnnotation");
+        });
+
+        assert.strictEqual(
+          new Printer().printGenerically(ast).code,
+          [
+            "type F = (x: string) => number;",
+            "type C = new (x: string) => number;",
+            "",
+            "interface I {",
+            "    foo(): number;",
+            "    (x: string): number;",
+            "    new (x: string): I;",
+            "}",
+          ].join("\n"),
+        );
+      });
+
+      it("flattens TypeScript enum bodies", function () {
+        const code = "enum E { A, B = 2 }";
+        const ast = parse(code, { parser: oxcParser });
+        const declaration = ast.program.body[0];
+
+        assert.strictEqual(declaration.body, undefined);
+        assert.strictEqual(declaration.members.length, 2);
+        assert.strictEqual(
+          new Printer().printGenerically(ast).code,
+          ["enum E {", "    A,", "    B = 2", "}"].join("\n"),
+        );
+      });
+
+      it("normalizes TypeScript mapped types and their modifiers", function () {
+        const code = "type M<T> = { -readonly [K in keyof T]+?: T[K] };";
+        const ast = parse(code, { parser: oxcParser });
+        const mappedType = ast.program.body[0].typeAnnotation;
+
+        assert.strictEqual(mappedType.key, undefined);
+        assert.strictEqual(mappedType.constraint, undefined);
+        assert.strictEqual(mappedType.typeParameter.type, "TSTypeParameter");
+        assert.strictEqual(mappedType.typeParameter.name.name, "K");
+        assert.strictEqual(
+          mappedType.typeParameter.constraint.type,
+          "TSTypeOperator",
+        );
+        assert.strictEqual(
+          new Printer().printGenerically(ast).code,
+          ["type M<T> = {", "    -readonly [K in keyof T]+?: T[K];", "};"].join(
+            "\n",
+          ),
+        );
+      });
+
+      it("normalizes TypeScript import types", function () {
+        const code = 'type T = import("pkg").Foo<string>;';
+        const ast = parse(code, { parser: oxcParser });
+        const importType = ast.program.body[0].typeAnnotation;
+
+        assert.strictEqual(importType.source, undefined);
+        assert.strictEqual(importType.argument.value, "pkg");
+        assert.strictEqual(importType.typeArguments, undefined);
+        assert.strictEqual(importType.typeParameters.params.length, 1);
+        assert.strictEqual(new Printer().printGenerically(ast).code, code);
+      });
+
+      it("preserves options on TypeScript import types", function () {
+        const code =
+          'type T = import("pkg", { with: { "resolution-mode": "import" } }).Foo;';
+        const ast = parse(code, { parser: oxcParser });
+        const importType = ast.program.body[0].typeAnnotation;
+
+        assert.strictEqual(importType.options.type, "ObjectExpression");
+        assert.strictEqual(
+          new Printer().printGenerically(ast).code,
+          [
+            'type T = import("pkg", {',
+            "    with: {",
+            '        "resolution-mode": "import"',
+            "    }",
+            "}).Foo;",
+          ].join("\n"),
+        );
+      });
+
+      it("normalizes type arguments on TypeScript type queries", function () {
+        const code = "type T = typeof Foo<string>;";
+        const ast = parse(code, { parser: oxcParser });
+        const query = ast.program.body[0].typeAnnotation;
+        let visitedStringType = false;
+
+        types.visit(query, {
+          visitTSStringKeyword(path) {
+            visitedStringType = true;
+            this.traverse(path);
+          },
+        });
+
+        assert.strictEqual(query.typeArguments, undefined);
+        assert.strictEqual(query.typeParameters.params.length, 1);
+        assert.strictEqual(visitedStringType, true);
+        assert.strictEqual(new Printer().printGenerically(ast).code, code);
+      });
+
+      it("exposes normalized Oxc extension fields to ast-types visitors", function () {
+        const code = [
+          'type T = import("pkg", { with: { mode: option } }).Foo;',
+          "const element = <Component<string> />;",
+          "const output = tag<number>`value`;",
+        ].join("\n");
+        const ast = parse(code, { parser: oxcParser });
+        const visited = new Set<string>();
+
+        types.visit(ast, {
+          visitIdentifier(path) {
+            visited.add(path.node.name);
+            this.traverse(path);
+          },
+          visitTSStringKeyword(path) {
+            visited.add("string");
+            this.traverse(path);
+          },
+          visitTSNumberKeyword(path) {
+            visited.add("number");
+            this.traverse(path);
+          },
+        });
+
+        ["mode", "option", "string", "number"].forEach((name) => {
+          assert.ok(visited.has(name), `expected ast-types to visit ${name}`);
+        });
+      });
+
+      it("prints type arguments in typed call and constructor expressions", function () {
+        const code = [
+          "const called = factory<string>();",
+          "const optional = factory?.<number>();",
+          "const created = new Box<boolean>();",
+        ].join("\n");
+        const ast = parse(code, { parser: oxcParser });
+
+        assert.strictEqual(new Printer().printGenerically(ast).code, code);
+      });
+
+      it("preserves typed optional binding patterns", function () {
+        const cases = [
+          {
+            code: "const array = ([value]?: [number]) => value;",
+            expected: "const array = ([value]?: [number]) => value;",
+          },
+          {
+            code: "const object = ({ value }?: { value: number }) => value;",
+            expected: [
+              "const object = (",
+              "    {",
+              "        value",
+              "    }?: {",
+              "        value: number;",
+              "    }",
+              ") => value;",
+            ].join("\n"),
+          },
+        ];
+
+        cases.forEach(({ code, expected }) => {
+          const ast = parse(code, { parser: oxcParser });
+          const pattern = ast.program.body[0].declarations[0].init.params[0];
+          let visitedNumberType = false;
+
+          types.visit(pattern, {
+            visitTSNumberKeyword(path) {
+              visitedNumberType = true;
+              this.traverse(path);
+            },
+          });
+
+          assert.strictEqual(pattern.optional, true);
+          assert.strictEqual(visitedNumberType, true);
+          assert.strictEqual(
+            new Printer().printGenerically(ast).code,
+            expected,
+          );
+        });
+      });
+
+      it("preserves TypeScript module declaration kinds without source locations", function () {
+        const code = "namespace N {}\nmodule M {}";
+        const ast = parse(code, { parser: oxcParser });
+        const [namespaceDeclaration, moduleDeclaration] = ast.program.body;
+
+        assert.strictEqual(namespaceDeclaration.kind, "namespace");
+        assert.strictEqual(moduleDeclaration.kind, "module");
+        namespaceDeclaration.loc = null;
+        moduleDeclaration.loc = null;
+        assert.strictEqual(new Printer().printGenerically(ast).code, code);
+      });
+
+      it("preserves TypeScript-only declaration modifiers", function () {
+        const code = [
+          'import type X = require("x");',
+          "type Factory = abstract new () => X;",
+          "interface Variance<in T, out U> {}",
+          "class Box<const T> {}",
+        ].join("\n");
+        const ast = parse(code, { parser: oxcParser });
+
+        assert.strictEqual(new Printer().printGenerically(ast).code, code);
+      });
+
+      it("preserves override on TypeScript parameter properties", function () {
+        const code = [
+          "class Base { value = 1; }",
+          "class Derived extends Base {",
+          "  constructor(public override value: number) {",
+          "    super();",
+          "  }",
+          "}",
+        ].join("\n");
+        const ast = parse(code, { parser: oxcParser });
+
+        assert.strictEqual(
+          new Printer().printGenerically(ast).code,
+          [
+            "class Base {",
+            "    value = 1;",
+            "}",
+            "",
+            "class Derived extends Base {",
+            "    constructor(public override value: number) {",
+            "        super();",
+            "    }",
+            "}",
+          ].join("\n"),
+        );
+      });
+
+      it("preserves phased dynamic imports with options", function () {
+        [
+          {
+            code: 'const value = import.source("x", { with: { type: "bytes" } });',
+            phase: "source",
+          },
+          {
+            code: 'const value = import.defer("x", { with: { type: "json" } });',
+            phase: "defer",
+          },
+        ].forEach(({ code, phase }) => {
+          const ast = parse(code, { parser: oxcParser });
+          const importCall = ast.program.body[0].declarations[0].init;
+
+          assert.strictEqual(importCall.type, "CallExpression");
+          assert.strictEqual(importCall.callee.type, "MemberExpression");
+          assert.strictEqual(importCall.callee.object.type, "Import");
+          assert.strictEqual(importCall.callee.property.name, phase);
+          assert.strictEqual(
+            new Printer().printGenerically(ast).code,
+            [
+              `const value = import.${phase}("x", {`,
+              "    with: {",
+              `        type: "${phase === "source" ? "bytes" : "json"}"`,
+              "    }",
+              "});",
+            ].join("\n"),
+          );
+        });
+      });
+
+      it("normalizes template literal types for traversal", function () {
+        const code = "type Event = `on${string}`;";
+        const ast = parse(code, { parser: oxcParser });
+        const literalType = ast.program.body[0].typeAnnotation;
+
+        assert.strictEqual(literalType.type, "TSLiteralType");
+        assert.strictEqual(literalType.literal.type, "TemplateLiteral");
+        assert.doesNotThrow(() => {
+          types.visit(ast, {
+            visitNode(path) {
+              this.traverse(path);
+            },
+          });
+        });
+        assert.strictEqual(new Printer().printGenerically(ast).code, code);
+      });
+
+      it("honors sourceType configured on the parser factory", function () {
+        const parser = oxcParser.createOxcParser({
+          sourceType: "commonjs",
+        });
+        const code = "return new.target;";
+        const ast = parse(code, { parser });
+
+        assert.strictEqual(new Printer().print(ast).code, code);
+      });
+
+      it("honors range configured on the parser factory", function () {
+        const parser = oxcParser.createOxcParser({ range: true });
+        const code = "#!/usr/bin/env node\nclass A { #value: number; }";
+        const ast = parse(code, { parser });
+        const privateId = ast.program.body[0].body.body[0].key.id;
+        const privateIdStart = code.indexOf("value");
+        const interpreterEnd = code.indexOf("\n") + 1;
+
+        assert.deepStrictEqual(ast.program.range, [0, code.length]);
+        assert.deepStrictEqual(ast.program.interpreter.range, [
+          0,
+          interpreterEnd,
+        ]);
+        assert.deepStrictEqual(privateId.range, [
+          privateIdStart,
+          privateIdStart + "value".length,
+        ]);
+      });
     });
   }
 });

--- a/test/run.ts
+++ b/test/run.ts
@@ -5,6 +5,7 @@ import "./identity";
 import "./jsx";
 import "./lines";
 import "./mapping";
+import "./oxc-compat";
 import "./parens-extra";
 import "./parens";
 import "./parser";


### PR DESCRIPTION
Based on #1435 (optionally #1434)
Closes #1424 

This PR adds support for Oxc as parser. It normalizes Oxc AST nodes into Recast-compatible shapes.
To support currently unsupported modern fields, the PR also extends `ast-types` (can be upstreamed as well)
  
I've added various test types to make sure that the Oxc integration is working as expected.