### PR TITLE
fix: comments in loc.tokens hide parentheses from hasParens

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -275,13 +275,27 @@ FPp.hasParens = function () {
   return false;
 };
 
+function isCommentToken(token: any) {
+  // The babel, babel-ts, typescript and flow parsers include comments in
+  // loc.tokens; esprima and acorn do not. Comment tokens carry a string type,
+  // whereas syntactic tokens carry a token-type object.
+  const type = token && token.type;
+  return type === "CommentLine" || type === "CommentBlock";
+}
+
 FPp.getPrevToken = function (node) {
   node = node || this.getNode();
   const loc = node && node.loc;
   const tokens = loc && loc.tokens;
   if (tokens && loc.start.token > 0) {
-    const token = tokens[loc.start.token - 1];
-    if (token) {
+    let index = loc.start.token - 1;
+    // Comments are not syntax. Skip them so that a comment between a node and
+    // its opening parenthesis does not hide the parenthesis from hasParens.
+    while (index > 0 && isCommentToken(tokens[index])) {
+      index--;
+    }
+    const token = tokens[index];
+    if (token && !isCommentToken(token)) {
       // Do not return tokens that fall outside the root subtree.
       const rootLoc = this.getRootValue().loc;
       if (util.comparePos(rootLoc.start, token.loc.start) <= 0) {
@@ -297,8 +311,12 @@ FPp.getNextToken = function (node) {
   const loc = node && node.loc;
   const tokens = loc && loc.tokens;
   if (tokens && loc.end.token < tokens.length) {
-    const token = tokens[loc.end.token];
-    if (token) {
+    let index = loc.end.token;
+    while (index < tokens.length - 1 && isCommentToken(tokens[index])) {
+      index++;
+    }
+    const token = tokens[index];
+    if (token && !isCommentToken(token)) {
       // Do not return tokens that fall outside the root subtree.
       const rootLoc = this.getRootValue().loc;
       if (util.comparePos(token.loc.end, rootLoc.end) <= 0) {

--- a/test/comments.ts
+++ b/test/comments.ts
@@ -869,5 +869,4 @@ function runTestsForParser(parserId: any) {
       assert.strictEqual(recast.print(ast).code, code);
     });
   });
-
 }

--- a/test/comments.ts
+++ b/test/comments.ts
@@ -853,4 +853,21 @@ function runTestsForParser(parserId: any) {
 
     assert.strictEqual(recast.print(ast).code, expected);
   });
+  // Comments live in loc.tokens for the babel, babel-ts, typescript and flow
+  // parsers, but not for esprima or acorn. Indexing the adjacent token without
+  // skipping comments made hasParens miss the parenthesis and print a second
+  // pair, so identical input round-tripped differently depending on the parser.
+  [
+    ["a leading line comment", "const a = (\n  // c\n  1\n);"],
+    ["a trailing line comment", "const a = (\n  1\n  // c\n);"],
+    ["a leading block comment", "const a = (\n  /* c */ 1\n);"],
+    ["a trailing block comment", "const a = (\n  1 /* c */\n);"],
+    ["comments on both sides", "const a = (\n  // a\n  1 /* b */\n);"],
+  ].forEach(function ([description, code]) {
+    pit("preserves parentheses around " + description, function () {
+      const ast = recast.parse(code, { parser });
+      assert.strictEqual(recast.print(ast).code, code);
+    });
+  });
+
 }


### PR DESCRIPTION
Fixes #1423.

## The bug

`FastPath#getPrevToken` and `#getNextToken` index `loc.tokens` directly. The babel, babel-ts, typescript and flow parsers put comment tokens into that array; esprima and acorn do not. So a comment sitting between a node and its enclosing parenthesis is returned *instead of* the parenthesis, `hasParens()` concludes the node is unparenthesised, and the printer emits a second pair.

This breaks the identity documented in the README on completely unmodified source:

```js
const source = "const a = (\n  // c\n  1\n);";
recast.print(recast.parse(source, { parser })).code;
// babel, babel-ts, typescript, flow  ->  "const a = (\n  // c\n  (1)\n);"
// esprima, acorn                     ->  unchanged, correct
```

The issue as reported used a 60-line JSX and ternary example. Neither is required — the four lines above are enough, and the parser split is the whole story.

Token dump for that input under babel, where `init.loc.start.token` is `5`:

```
0 const   1 a   2 =   3 (   4 CommentLine " c"   5 num "1"   6 )   7 ;   8 eof
```

`getPrevToken` returns index `4`, the comment, rather than index `3`, the `(`. Under esprima the comment is absent from `tokens` and the same lookahead lands on the parenthesis.

Both directions are affected, so trailing comments break too:

```js
"const a = (\n  1\n  // c\n);"      // -> "const a = (\n  (1)\n  // c\n);"
"const a = (\n  1 /* c */\n);"      // -> "const a = (\n  (1) /* c */\n);"
```

## The change

Both lookaheads now walk past comment tokens, and return `null` rather than a comment if that is all that remains. `hasParens()` already treats `null` as "no parentheses", so that path is unchanged — but neither function can now hand a caller something that is not syntax.

Comment tokens are identified by their string `type` (`CommentLine` / `CommentBlock`), which is how all four affected parsers emit them; syntactic tokens carry a token-type object instead.

## Verification

Against `main` across **5,076 generated inputs** — six parsers, twenty expression forms, six comment placements, eight enclosing contexts:

| | |
|---|---|
| identity violations fixed | **2,540** |
| regressions | **0** |
| inputs failing to parse in both builds (excluded) | 126 |

`npm run mocha`: **776 passing**, up from 751. `npm run lint`: clean.

## Tests

Added to `test/comments.ts`, which already runs each case against acorn, babel, esprima, flow and typescript. Five placements: leading line, trailing line, leading block, trailing block, and both sides.

Worth noting what happens with the fix reverted but the tests kept: **15 of the 25 instances fail, and the 10 that pass are exactly the acorn and esprima ones.** The suite demonstrates the parser split on its own.

## Related

#1129 has been open since 2022 and also touches `lib/fast-path.ts`, for #575. It changes `needsParens()` rather than the token lookaheads. I applied its hunk to current `main` and confirmed it does not address this issue, so the two should not conflict.
