### PR TITLE
fix(printer): preserve significant JSX whitespace around expressions when reprinting elements

### DIFF
--- a/lib/printer.ts
+++ b/lib/printer.ts
@@ -1338,7 +1338,17 @@ function genericPrintNoParens(path: any, options: any, print: any) {
             typeof child.value === "string"
           ) {
             if (/\S/.test(child.value)) {
-              return child.value.replace(/^\s+/g, "");
+              // Collapse leading whitespace on JSXText children. Leading
+              // whitespace that contains a newline is source indentation and
+              // is safe to strip entirely (indentation is reapplied via
+              // indentTail below). Leading whitespace with no newline is
+              // significant inline whitespace adjacent to a sibling (typically
+              // a {expression} container); per JSX text semantics it collapses
+              // to a single space and must be preserved, otherwise e.g.
+              // `foo {bar} baz` would reprint as `foo {bar}baz`.
+              return child.value.replace(/^\s+/, (whitespace: string) =>
+                /\n/.test(whitespace) ? "" : " ",
+              );
             } else if (/\n\s*\n/.test(child.value)) {
               return "\n\n";
             } else if (/\n/.test(child.value)) {

--- a/test/jsx.ts
+++ b/test/jsx.ts
@@ -125,6 +125,96 @@ it("should not double parentheses in Babel", function () {
   );
 });
 
+describe("should preserve significant whitespace around JSX expressions", function () {
+  // When a JSXElement subtree is reprinted generically (for example because an
+  // identifier inside it changed), the printer collapses source indentation on
+  // JSXText children. It must not collapse a *significant* inline space that
+  // sits between text and an adjacent {expression}, otherwise
+  // `hello {name} world` would be reprinted as `hello {name}world`.
+  const printer = new Printer({ tabWidth: 2 });
+
+  function renameAndPrint(source: string, from: string, to: string) {
+    const ast = parse(source, { parser: require("../parsers/babel") });
+    types.visit(ast, {
+      visitJSXIdentifier(path: any) {
+        if (path.node.name === from) {
+          path.node.name = to;
+        }
+        this.traverse(path);
+      },
+    });
+    return printer.print(ast).code;
+  }
+
+  it("preserves the space before text that follows an expression", function () {
+    assert.strictEqual(
+      renameAndPrint(
+        "function C() {\n  return (\n    <Text>hello {name} world</Text>\n  );\n}",
+        "Text",
+        "Label",
+      ),
+      "function C() {\n  return (<Label>hello {name} world</Label>);\n}",
+    );
+  });
+
+  it("preserves the space before an expression that follows text", function () {
+    assert.strictEqual(
+      renameAndPrint(
+        "function C() {\n  return (\n    <Text>hello {name}</Text>\n  );\n}",
+        "Text",
+        "Label",
+      ),
+      "function C() {\n  return (<Label>hello {name}</Label>);\n}",
+    );
+  });
+
+  it("preserves the space after an expression at the start of an element", function () {
+    assert.strictEqual(
+      renameAndPrint(
+        "function C() {\n  return (\n    <Text>{name} world</Text>\n  );\n}",
+        "Text",
+        "Label",
+      ),
+      "function C() {\n  return (<Label>{name} world</Label>);\n}",
+    );
+  });
+
+  it("preserves spaces around multiple adjacent expressions", function () {
+    assert.strictEqual(
+      renameAndPrint(
+        "function C() {\n  return (\n    <Text>a {x} b {y} c</Text>\n  );\n}",
+        "Text",
+        "Label",
+      ),
+      "function C() {\n  return (<Label>a {x} b {y} c</Label>);\n}",
+    );
+  });
+
+  it("still strips indentation whitespace containing a newline", function () {
+    // A JSXText child whose leading whitespace contains a newline is source
+    // indentation and should continue to be stripped entirely.
+    const source =
+      "function C() {\n" +
+      "  return (\n" +
+      "    <Text>\n" +
+      "      hello {name}\n" +
+      "    </Text>\n" +
+      "  );\n" +
+      "}";
+    assert.strictEqual(
+      renameAndPrint(source, "Text", "Label"),
+      "function C() {\n  return (\n    <Label>hello {name}\n    </Label>\n  );\n}",
+    );
+  });
+
+  it("leaves an unchanged tree byte-for-byte (no-change control)", function () {
+    const source =
+      "function C() {\n  return (\n    <Text>hello {name} world</Text>\n  );\n}";
+    const ast = parse(source, { parser: require("../parsers/babel") });
+    assert.strictEqual(printer.print(ast).code, source);
+  });
+});
+
 describe("should preserve blank lines between JSX children", function () {
   // The blank line only survives if the whitespace-only JSXText between the
   // two children is reprinted as "\n\n" rather than collapsed to "\n".


### PR DESCRIPTION
## Problem

When recast reprints a `JSXElement` subtree generically (for example because an identifier inside it changed), a significant space between text and an adjacent `{expression}` is dropped.

```js
const recast = require("recast");

const src = `function C() {
  return (
    <Text>hello {name} world</Text>
  );
}`;

const ast = recast.parse(src, { parser: require("recast/parsers/babel") });

// rename <Text> -> <Label>
recast.visit(ast, {
  visitJSXIdentifier(path) {
    if (path.node.name === "Text") path.node.name = "Label";
    this.traverse(path);
  },
});

console.log(recast.print(ast).code);
// Actual:   return (<Label>hello {name}world</Label>);
// Expected: return (<Label>hello {name} world</Label>);
```

The space before `world` disappears, which changes the rendered output (`hello world` becomes `helloworld`).

## Root cause

In the `JSXElement`/`JSXFragment` generic printer (`lib/printer.ts`), string `JSXText` children have their leading whitespace stripped unconditionally:

```js
if (/\S/.test(child.value)) {
  return child.value.replace(/^\s+/g, "");
}
```

That strip is meant to remove *source indentation* (the newline + spaces that precede text written on its own line, since indentation is reapplied later via `indentTail`). But it also removes a **significant inline space** that sits between a preceding sibling — typically a `{expression}` container — and the text. In the example above the third child is the `JSXText` `" world"`, and its leading space is stripped to `"world"`.

Per JSX text semantics, inline whitespace with no newline collapses to a single space and is preserved; only whitespace containing a newline is treated as insignificant formatting.

## Fix

Make the leading-whitespace collapse newline-aware:

```js
return child.value.replace(/^\s+/, (whitespace) =>
  /\n/.test(whitespace) ? "" : " ",
);
```

- Leading whitespace **containing a newline** → stripped entirely (unchanged behavior; indentation is reapplied by `indentTail`).
- Leading whitespace with **no newline** → collapsed to a single significant space and preserved.

Trailing-whitespace behavior is unchanged (the original code only touched leading whitespace).

## Tests

Added a `should preserve significant whitespace around JSX expressions` block in `test/jsx.ts` covering:

- text before an expression (`hello {name}`)
- text after an expression (`{name} world`)
- text on both sides (`hello {name} world`)
- multiple adjacent expressions (`a {x} b {y} c`)
- the newline-indentation case still collapses (regression guard)
- a no-change control that must round-trip byte-for-byte

Full suite: `npm test` passes (783 passing, 1 pre-existing pending). The existing `should not remove trailing whitespaces` and `should not double parentheses in Babel` tests, which exercise this same branch, continue to pass unchanged.
