### PR TITLE
fix: respect the ecmaVersion option instead of hardcoding ES6

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -96,6 +96,14 @@ export interface Options extends DeprecatedOptions {
   tolerant?: boolean;
 
   /**
+   * The ECMAScript version passed through to the parser. Parsers that do not
+   * accept an ecmaVersion option, such as esprima and @babel/parser, ignore
+   * it.
+   * @default 2020
+   */
+  ecmaVersion?: number | "latest";
+
+  /**
    * If you want to override the quotes used in string literals, specify
    * either "single", "double", or "auto" here ("auto" will select the one
    * which results in the shorter literal) Otherwise, use double quotes.
@@ -177,6 +185,7 @@ const defaults: Options = {
   inputSourceMap: null,
   range: false,
   tolerant: true,
+  ecmaVersion: 2020,
   quote: null,
   trailingComma: false,
   arrayBracketSpacing: false,
@@ -212,6 +221,7 @@ export function normalize(opts?: Options): NormalizedOptions {
     parser: get("esprima") || get("parser"),
     range: get("range"),
     tolerant: get("tolerant"),
+    ecmaVersion: get("ecmaVersion"),
     quote: get("quote"),
     trailingComma: get("trailingComma"),
     arrayBracketSpacing: get("arrayBracketSpacing"),

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -29,7 +29,7 @@ export function parse(source: string, options?: Partial<Options>) {
     comment: true,
     onComment: comments,
     tolerant: util.getOption(options, "tolerant", true),
-    ecmaVersion: 6,
+    ecmaVersion: util.getOption(options, "ecmaVersion", 2020),
     sourceType: util.getOption(options, "sourceType", "module"),
   });
 

--- a/parsers/acorn.ts
+++ b/parsers/acorn.ts
@@ -14,7 +14,7 @@ export function parse(source: string, options?: any) {
     allowHashBang: true,
     allowImportExportEverywhere: true,
     allowReturnOutsideFunction: true,
-    ecmaVersion: getOption(options, "ecmaVersion", 8),
+    ecmaVersion: getOption(options, "ecmaVersion", 2020),
     sourceType: getOption(options, "sourceType", "module"),
     locations: true,
     onComment: comments,

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -302,3 +302,53 @@ describe("token ranges", function () {
     checkTokenRanges("`before${x}middle${y}after`;\n");
   });
 });
+
+describe("ecmaVersion option", function () {
+  const acorn = "../parsers/acorn";
+
+  // recast passed a hardcoded ecmaVersion: 6 to every parser, which overrode
+  // the value ../parsers/acorn asks for and made the acorn parser documented
+  // in the README reject anything newer than ES6 (#620).
+  const newerThanEs6 = [
+    ["object spread", "var x = {...y};\n"],
+    ["object rest", "const { ...props } = obj;\n"],
+    ["exponentiation", "a ** b;\n"],
+    ["async and await", "async function f() {\n  await 1;\n}\n"],
+    ["optional catch binding", "try {} catch {}\n"],
+  ];
+
+  newerThanEs6.forEach(function ([label, code]) {
+    it(`parses and reprints ${label} with acorn`, function () {
+      const ast = parse(code, { parser: require(acorn) });
+      assert.strictEqual(new Printer().print(ast).code, code);
+    });
+  });
+
+  it("passes an explicit ecmaVersion through to the parser", function () {
+    // A lower version must still be honoured, otherwise the option is being
+    // ignored rather than threaded.
+    assert.throws(function () {
+      parse("var x = {...y};\n", {
+        parser: require(acorn),
+        ecmaVersion: 6,
+      } as any);
+    });
+
+    const ast = parse("a ** b;\n", {
+      parser: require(acorn),
+      ecmaVersion: 2016,
+    } as any);
+    assert.strictEqual(new Printer().print(ast).code, "a ** b;\n");
+  });
+
+  it("reprints untouched newer syntax when a sibling changes", function () {
+    const code = ["var a = {...x};", "var b = 1;", ""].join("\n");
+    const ast = parse(code, { parser: require(acorn) });
+    ast.program.body[1].declarations[0].init.value = 2;
+
+    assert.strictEqual(
+      new Printer().print(ast).code,
+      ["var a = {...x};", "var b = 2;", ""].join("\n"),
+    );
+  });
+});


### PR DESCRIPTION
Fixes the acorn half of #620.

### The problem

`lib/parser.ts` passes a hardcoded `ecmaVersion: 6` into whatever parser it is given:

```js
const ast = options.parser.parse(sourceWithoutTabs, {
  ...
  tolerant: util.getOption(options, "tolerant", true),
  ecmaVersion: 6,
  sourceType: util.getOption(options, "sourceType", "module"),
});
```

Every neighbouring value is read from the user's options. This one is a literal, and it silently overrides `parsers/acorn.ts`, which asks for `getOption(options, "ecmaVersion", 8)`. Because recast always puts `6` in the bag, that default can never apply.

The result is that the acorn parser shown in the README rejects anything newer than ES6:

```js
recast.parse("var x = {...y};", { parser: require("recast/parsers/acorn") });
// Unexpected token (1:9)
```

Same for `const { ...props } = obj`, `a ** b`, `async`/`await`, and optional catch binding. Only the ES6 subset works.

### The change

Read `ecmaVersion` from the options like the values either side of it, defaulting to 2020, and add it to `Options` so it is a documented, typed option rather than an undocumented one that happens to reach some parsers. `parsers/acorn.ts` gets the same default so the two layers agree.

Parsers that do not take an `ecmaVersion` ignore it. I checked esprima explicitly, since it is the default parser: it accepts the option and ignores it, at 6 and at 2020 alike.

### Tests

Seven cases in `test/parser.ts` under `describe("ecmaVersion option")`. All seven fail on `main` and pass with this change.

Five cover syntax newer than ES6 parsing and reprinting byte-identically through acorn. One asserts the option is genuinely threaded in both directions, which is the part that pins the actual defect rather than the symptom: passing `ecmaVersion: 6` must still reject object spread, and passing `2016` must accept `**`. If the fix were just a raised constant, the first of those would fail. The last one parses a file containing a spread, edits an unrelated sibling, and checks the spread is reprinted verbatim, so the printer is exercised and not only the parser.

Full suite is 784 passing, 1 pending, up from 777 with no failures introduced. Lint is clean.

### Out of scope

The issue also reports `recast.parse("var x={...{xx:1}}")` throwing with no parser option. That is the default esprima parser, and esprima 4.0.1 does not support object spread at any setting, so it is not fixable here. Changing recast's default parser is a policy decision rather than a bug fix, and you have already pointed people to `parsers/babel` for that in the thread, so I have left it alone.

I picked 2020 because that is what acorn 6.4.2, the version that currently resolves, supports. Going higher would need a dependency bump, which felt like a separate decision. Happy to change the number if you would rather it were something else.

One thing I noticed but did not touch: `acorn` is not in `devDependencies`, so `parsers/acorn.ts` and the existing acorn tests rely on it resolving transitively. That is pre-existing rather than something this change introduces, but it is worth knowing about.
