### PR TITLE
fix: parenthesize `??` when it is combined with `||` or `&&`

### DIFF
--- a/lib/fast-path.ts
+++ b/lib/fast-path.ts
@@ -463,6 +463,20 @@ FPp.needsParens = function (assumeExpressionContext) {
           const no = node.operator;
           const np = PRECEDENCE[no];
 
+          // `??` cannot be combined with `||` or `&&` without parentheses.
+          // The `CoalesceExpression` production only admits
+          // `BitwiseORExpression` operands, plus a nested
+          // `CoalesceExpression` on the left, so both `a || b ?? c` and
+          // `a ?? b || c` are SyntaxErrors. Comparing precedence only
+          // parenthesizes a `??` nested inside `||` or `&&`, never a `||`
+          // or `&&` nested inside `??`.
+          if (
+            (po === "??" && (no === "||" || no === "&&")) ||
+            (no === "??" && (po === "||" || po === "&&"))
+          ) {
+            return true;
+          }
+
           if (pp > np) {
             return true;
           }

--- a/test/printer.ts
+++ b/test/printer.ts
@@ -1219,6 +1219,92 @@ describe("printer", function () {
     assert.strictEqual(pretty, code);
   });
 
+  it("adds parentheses when `??` is combined with `||` or `&&`", function () {
+    const cases: [string, any][] = [
+      [
+        "(a || b) ?? c;",
+        b.logicalExpression(
+          "??",
+          b.logicalExpression("||", b.identifier("a"), b.identifier("b")),
+          b.identifier("c"),
+        ),
+      ],
+      [
+        "a ?? (b || c);",
+        b.logicalExpression(
+          "??",
+          b.identifier("a"),
+          b.logicalExpression("||", b.identifier("b"), b.identifier("c")),
+        ),
+      ],
+      [
+        "(a && b) ?? c;",
+        b.logicalExpression(
+          "??",
+          b.logicalExpression("&&", b.identifier("a"), b.identifier("b")),
+          b.identifier("c"),
+        ),
+      ],
+      [
+        "a ?? (b && c);",
+        b.logicalExpression(
+          "??",
+          b.identifier("a"),
+          b.logicalExpression("&&", b.identifier("b"), b.identifier("c")),
+        ),
+      ],
+      [
+        "(a ?? b) || c;",
+        b.logicalExpression(
+          "||",
+          b.logicalExpression("??", b.identifier("a"), b.identifier("b")),
+          b.identifier("c"),
+        ),
+      ],
+    ];
+
+    cases.forEach(function ([code, expression]) {
+      const ast = b.program([b.expressionStatement(expression)]);
+      const printer = new Printer();
+      assert.strictEqual(printer.printGenerically(ast).code, code);
+    });
+  });
+
+  it("leaves `??` unparenthesized when it is not combined with `||` or `&&`", function () {
+    const cases: [string, any][] = [
+      [
+        "a ?? b ?? c;",
+        b.logicalExpression(
+          "??",
+          b.logicalExpression("??", b.identifier("a"), b.identifier("b")),
+          b.identifier("c"),
+        ),
+      ],
+      [
+        "a + b ?? c;",
+        b.logicalExpression(
+          "??",
+          b.binaryExpression("+", b.identifier("a"), b.identifier("b")),
+          b.identifier("c"),
+        ),
+      ],
+      [
+        "a ?? b + c;",
+        b.logicalExpression(
+          "??",
+          b.identifier("a"),
+          b.binaryExpression("+", b.identifier("b"), b.identifier("c")),
+        ),
+      ],
+    ];
+
+    cases.forEach(function ([code, expression]) {
+      const ast = b.program([b.expressionStatement(expression)]);
+      const printer = new Printer();
+      assert.strictEqual(printer.printGenerically(ast).code, code);
+    });
+  });
+
   it("prints class property initializers with type annotations correctly", function () {
     const code = ["class A {", "  foo = (a: b): void => {};", "}"].join(eol);
 


### PR DESCRIPTION
Fixes #1422.

`??` cannot be combined with `||` or `&&` without parentheses. The `CoalesceExpression` production only admits `BitwiseORExpression` operands, plus a nested `CoalesceExpression` on the left, so `a || b ?? c` and `a ?? b || c` are both SyntaxErrors.

`needsParens` decides this by comparing operator precedence, and `??` sits at the bottom of the table since #1095. That covers a `??` nested inside `||` or `&&`, which is why `(a ?? b) || c` prints correctly today. It does not cover the other direction: with `??` as the parent, `pp > np` is false and nothing is emitted.

So printing a `??` whose operand is a `||` or `&&` produces output that does not parse:

```
LogicalExpression("??", LogicalExpression("||", a, b), c)   ->  a || b ?? c;
LogicalExpression("??", a, LogicalExpression("||", b, c))   ->  a ?? b || c;
LogicalExpression("??", LogicalExpression("&&", a, b), c)   ->  a && b ?? c;
LogicalExpression("??", a, LogicalExpression("&&", b, c))   ->  a ?? b && c;
```

All four throw when parsed:

```
"a || b ?? c" -> SyntaxError: Unexpected token '??'
"a ?? b || c" -> SyntaxError: Unexpected token '||'
"a && b ?? c" -> SyntaxError: Unexpected token '??'
"a ?? b && c" -> SyntaxError: Unexpected token '&&'
```

With this change they print as `(a || b) ?? c`, `a ?? (b || c)`, `(a && b) ?? c` and `a ?? (b && c)`.

The check is on the operator pair rather than on precedence, because this restriction is a grammar production rather than an ordering. `??` alongside a non-logical operator is unaffected: `a ?? b + c`, `a + b ?? c` and `a ?? b ?? c` still print without parentheses.

Verified by feeding every printed form through `new Function` to confirm it parses, and by checking the opposite direction is not over-parenthesized. Round-tripping unmodified source containing each shape comes back byte-identical.

Two tests are added. The first covers the four broken shapes and fails on `main`. The second locks in that `??` is left alone when it is not combined with `||` or `&&`, and passes on `main`, so it guards against over-correction rather than restating the fix.

`npm test` is clean: 779 passing, lint and build included.
